### PR TITLE
Clarify legacy references and deduplicate v8 notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,11 @@
 - `releases/v8/PT_Study_SOP_v8/`: complete v8 package with Runtime Prompt, Master Index, and Modules 1-6.
 - `USAGE.md`: step-by-step instructions for loading v8 into a Custom GPT.
 - `changelog.md`: version history.
-- `legacy/`: v7.4 single-session prompt ([legacy/V7.4/](./legacy/V7.4/)), v7.3 package ([legacy/v7.3/](./legacy/v7.3/)), and v7.2 core SOP/methods ([legacy/sop_v7_core.md](./legacy/sop_v7_core.md), [legacy/methods_index.md](./legacy/methods_index.md)).
-- `legacy/`: v7.4 single-session prompt (`V7.4.md`), v7.3 (`v7.3.md`), and v7.2 core SOP/methods (historical reference).
+- `legacy/`: archival v7.x docs—v7.4 prompt ([legacy/V7.4/](./legacy/V7.4/)), v7.3 package ([legacy/v7.3/](./legacy/v7.3/)), and v7.2 core SOP/methods ([legacy/sop_v7_core.md](./legacy/sop_v7_core.md), [legacy/methods_index.md](./legacy/methods_index.md)). Use v8 in `releases/v8/` as the current source.
 
 ## What's here
 
 - `releases/v8/PT_Study_SOP_v8/`: latest v8 modules.
-- `legacy/`: historical files ([legacy/V7.4/](./legacy/V7.4/)), [legacy/v7.3/](./legacy/v7.3/), [legacy/sop_v7_core.md](./legacy/sop_v7_core.md), [legacy/methods_index.md](./legacy/methods_index.md).
-- `legacy/`: historical files (`V7.4.md`, `v7.3.md`, v7.2 core SOP, methods index).
 
 The sections below summarize the older v7.x documentation. For current usage, start with `releases/v8/` and read `USAGE.md`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,10 +15,7 @@
 - Includes Module_1_Core_Protocol.md, Module_2_Triage_Rules.md, Module_3_Framework_Selector.md, Module_4_Session_Recap_Template.md, Module_5_Troubleshooting.md, Module_6_Framework_Library.md, Master_Index.md, and Runtime_Prompt.md.
 
 ### Notes
-- v7.x documentation is archived under `legacy/` (V7.4 prompt, sop_v7_core.md, methods_index.md).
-- Use the v8 package in `releases/v8/` for the latest materials; keep `legacy/` for historical reference.
-- v7.x documentation remains in the root (V7.4.md prompt, sop_v7_core.md, methods_index.md).
-- Use the v8 package for the latest materials; keep v7.x for historical reference.
+- v7.x documentation lives in `legacy/` (including V7.4 prompt, sop_v7_core.md, methods_index.md); v8 in `releases/v8/` is the latest source.
 
 ---
 


### PR DESCRIPTION
## Summary
- streamline README to give one clear pointer to legacy v7.x docs while emphasizing v8 as the current source
- remove repeated legacy bullets from the v8 changelog notes, keeping a single concise statement

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69267f1357bc8323b90df06d821205c2)