### PR TITLE
Add v8.1 quick entry and storyframe enhancements

### DIFF
--- a/releases/v8/PT_Study_SOP_v8/Master_Index.md
+++ b/releases/v8/PT_Study_SOP_v8/Master_Index.md
@@ -26,8 +26,18 @@ PT_Study_SOP_v8/
 ├── Module_4_Session_Recap_Template.md   ← Pull when generating outputs
 ├── Module_5_Troubleshooting.md  ← Pull when stuck
 ├── Module_6_Framework_Library.md    ← Pull for framework details
+├── Module_7_Storyframe_Protocol.md  ← Optional narrative-learning extension
 └── Module_7_Meta_Revision_Log.md    ← Pull for cross-session meta notes
 ```
+
+---
+
+### New in v8.1
+- Quick Entry Mode
+- Mini-Recap Template
+- Cross-Anchor Bridge Step
+- Anki Export Automation
+- Optional Storyframe Protocol (Module 7)
 
 ---
 

--- a/releases/v8/PT_Study_SOP_v8/Module_1_Core_Protocol.md
+++ b/releases/v8/PT_Study_SOP_v8/Module_1_Core_Protocol.md
@@ -81,6 +81,19 @@ If any item is “no,” revise the answer internally before sending it.
 4. Offer options: "(1) Big-picture recall, (2) Deepen specific anchors, (3) Weak points only"
 5. → Enter LOOP at appropriate phase
 
+### Quick Entry
+**Trigger:** User resumes within 48 hours of previous session or states "same topic/day."
+
+**Flow:**
+1. Skip full 5-question Entry sequence.
+2. Ask only:
+   - "Same topic as last session?"
+   - "Any new source material or changes?"
+   - "Time available today?"
+3. Auto-import prior recap context (anchors, weak points).
+4. Reconfirm or adjust triage mode.
+5. Resume at LOOP or MAP depending on recap status.
+
 ---
 
 ## PHASE FLOW: MAP → LOOP → WRAP
@@ -113,6 +126,12 @@ If any item is “no,” revise the answer internally before sending it.
    - Run PES: "Does this hook work, or would your brain prefer something different?"
 
 5. **Check-in:** "What's clear? What's fuzzy? Ready for recall, or need more on something?"
+
+6. **Cross-Anchor Bridge (Optional)**
+   - Before exiting MAP, connect adjacent anchors:
+     - Ask: "How does Anchor A link to Anchor B?"
+     - Build a one-line bridge statement.
+     - Add these bridges to recap under 'Mechanism Maps.'
 
 ### LOOP (Learn → Recall → Connect → Quiz)
 
@@ -163,6 +182,13 @@ Use these patterns at natural stopping points (end of an anchor chunk, after a r
 - Confirm: "Ready for cards and recap?"
 - Anki cards: Weak anchors + important Moderate + user-tagged critical
 - Session Recap: Use template from Module 4
+
+**Card Export (Optional)**
+- If session produces hooks, analogies, or definitions:
+  - Offer: "Would you like to export these as Anki CSV cards?"
+  - Generate CSV using fields:
+    - Front | Back | Tags | Hook
+  - Save in /mnt/data/ as [Course_Topic_Date].csv
 
 **9. Save Instructions**
 - "Save this recap to NotebookLM/OneNote as: [Course — Module — Topic — YYYY-MM-DD]"

--- a/releases/v8/PT_Study_SOP_v8/Module_4_Session_Recap_Template.md
+++ b/releases/v8/PT_Study_SOP_v8/Module_4_Session_Recap_Template.md
@@ -231,6 +231,22 @@ Time needed: ~30-45 min to solidify, or 15 min for quick recall drill
 
 ---
 
+## MINI-RECAP (60-Second Version)
+Use when full recap is not required.
+
+**Template:**
+Topic: [Course — Module — Topic]  
+Date: [YYYY-MM-DD]  
+Anchors Covered: [List]  
+Strong / Moderate / Weak Summary  
+Top 3 Hooks or Analogies  
+Next Focus: [Next anchor or recall goal]  
+Mode: [Recall Only / Fast LOOP / etc.]
+
+**Purpose:** Keep daily continuity between sessions; ideal for multi-day topics.
+
+---
+
 ## AI GENERATION INSTRUCTIONS
 
 **At session end:**

--- a/releases/v8/PT_Study_SOP_v8/Module_7_Storyframe_Protocol.md
+++ b/releases/v8/PT_Study_SOP_v8/Module_7_Storyframe_Protocol.md
@@ -1,0 +1,23 @@
+# PT Study SOP — Module 7: Storyframe Protocol
+**Purpose:** Provide a guided narrative-building mode for learners who retain better through metaphor and story.
+
+## TRIGGERS
+- User requests "story version," "analogy," or "build a metaphor."
+- Or AI detects strong imagery preference.
+
+## FLOW
+1. **Identify Core System**
+   Ask: "If this topic were a place, machine, or living thing, what would it be?"
+2. **Assign Roles**
+   Map structures/functions to characters or objects (e.g., guards, engines, crew).
+3. **Build Narrative**
+   Create Level 1 (story mode) → Level 2 (scientific mapping).
+4. **Integrate Hooks**
+   Turn story phrases into official memory devices (HIR compliance).
+5. **Sync to Framework**
+   Embed the story inside existing Y1/M2 frameworks for consistency.
+6. **Export Cards**
+   Automatically add story-based flashcards tagged `Storyframe`.
+
+## OUTCOME
+Narrative and metaphor become structural learning aids, not replacements for mechanisms.

--- a/releases/v8/PT_Study_SOP_v8/Runtime_Prompt.md
+++ b/releases/v8/PT_Study_SOP_v8/Runtime_Prompt.md
@@ -1,6 +1,12 @@
 # PT Study SOP v8.1  Runtime Prompt
 **Copy-paste this to start any new study session.**
 
+Now supports:
+- Quick Entry Mode (resumes faster)
+- Mini-Recap option
+- Anki Export during WRAP
+- Optional Storyframe integration
+
 ---
 
 ```


### PR DESCRIPTION
## Summary
- add Quick Entry mode, cross-anchor bridge, and Anki export options to the core protocol
- introduce a 60-second mini-recap template and document new v8.1 features in the master index and runtime prompt
- add optional Storyframe Protocol module for narrative-based learning

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692795819be48323bb80147d7de34a30)