### PR TITLE
Update documentation paths to v8.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # PT Study SOP - releases and docs
 
-**Latest package:** v8.1 (`releases/v8/PT_Study_SOP_v8.zip`)
-**Included docs:** v8.1 module folder (`releases/v8/PT_Study_SOP_v8/`), legacy prompts/docs (`legacy/`)
+**Latest package:** v8.1 (`releases/v8/PT_Study_SOP_v8.1/`)
+**Included docs:** v8.1 module folder (`releases/v8/PT_Study_SOP_v8.1/`), legacy prompts/docs (`legacy/`)
 **Last Updated:** December 5, 2025
 
 ---
 
 ## Repo map
 
-- `releases/v8/PT_Study_SOP_v8/`: complete v8 package with Runtime Prompt, Master Index, Modules 1-7 (Core Protocol, Triage Rules, Framework Selector, Session Recap Template, Troubleshooting, Framework Library, Meta Revision Log), and optional Module_7_Storyframe_Protocol.
+- `releases/v8/PT_Study_SOP_v8.1/`: complete v8.1 package with Runtime Prompt, Master Index, Modules 1-7 (Core Protocol, Triage Rules, Framework Selector, Session Recap Template, Troubleshooting, Framework Library, Meta Revision Log), and optional Module_7_Storyframe_Protocol.
 - `USAGE.md`: step-by-step instructions for loading v8 into a Custom GPT.
 - `changelog.md`: version history.
 - `legacy/`: archival v7.x docs—v7.4 prompt ([legacy/V7.4/](./legacy/V7.4/)), v7.3 package ([legacy/v7.3/](./legacy/v7.3/)), and v7.2 core SOP/methods ([legacy/sop_v7_core.md](./legacy/sop_v7_core.md), [legacy/methods_index.md](./legacy/methods_index.md)). Use v8.1 in `releases/v8/` as the current source.
 
 ## What's here
 
-- `releases/v8/PT_Study_SOP_v8/`: latest v8 modules — Runtime Prompt, Master Index, Modules 1-7, and optional Module_7_Storyframe_Protocol.
+- `releases/v8/PT_Study_SOP_v8.1/`: latest v8.1 modules — Runtime Prompt, Master Index, Modules 1-7, and optional Module_7_Storyframe_Protocol.
 
 The sections below summarize the older v7.x documentation. For current usage, start with `releases/v8/` and read `USAGE.md`.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -3,7 +3,7 @@
 This repo is organized so you can drop the v8 package into a Custom GPT and keep it source-locked. Use the files below and follow the instructions to ensure the agent reads only what you provide and runs the correct flow.
 
 ## Files to upload to your Custom GPT
-**Required v8.1.1 files (upload all 9 from `releases/v8/PT_Study_SOP_v8/`):**
+**Required v8.1.1 files (upload all 9 from `releases/v8/PT_Study_SOP_v8.1/`):**
 1. `Module_1_Core_Protocol.md`
 2. `Module_2_Triage_Rules.md`
 3. `Module_3_Framework_Selector.md`
@@ -87,7 +87,7 @@ When configuring the Custom GPT:
 ## Tips
 - Keep only v8 files in the knowledge base to avoid mixing old versions.
 - If you update the repo, replace the uploaded files with the new versions and restate Source-Lock.
-- For portability, you can also upload the zip (`releases/v8/PT_Study_SOP_v8.zip`) to another tool, but for Custom GPTs, use the extracted 9 required files above.
+- For portability, you can also zip the `releases/v8/PT_Study_SOP_v8.1/` folder for other tools, but for Custom GPTs, use the extracted 9 required files above.
 
 ## When to write (light notes)
 - MAP: jot the chosen framework(s) and 3-5 anchors (one line each).


### PR DESCRIPTION
## Summary
- correct README references to the v8.1 release folder
- update USAGE instructions to point to the existing v8.1 files and zip guidance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a6efe115c8323830401a86c43ecd3)