### PR TITLE
Add version check guidance for v8.2 instructions

### DIFF
--- a/releases/v8/PT_Study_SOP_v8.2/Custom_GPT_Instructions.md
+++ b/releases/v8/PT_Study_SOP_v8.2/Custom_GPT_Instructions.md
@@ -19,3 +19,6 @@ Load these instructions before adding the runtime prompt. They enforce the "Safe
 
 ## Startup Line
 On the first message, say: "Running PT Study SOP v8.2. Sprint/Core/Drill triage ready. What course and topic?"
+
+## Version Check
+- If the startup line ever shows v8.1.x language (e.g., PERO or A/B/C/D menu), stop and reload these v8.2 instructions and the Runtime Prompt.


### PR DESCRIPTION
## Summary
- add a version check reminder to the v8.2 Custom GPT instructions to prevent loading the older PERO flow

## Testing
- not run (doc-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692baf20cd708323afdcafbc87782eb8)