### PR TITLE
Update Module 2 triage rules for V5 neuro edition

### DIFF
--- a/releases/v8/PT_Study_SOP_v8.2/Module_2_Triage_Rules.md
+++ b/releases/v8/PT_Study_SOP_v8.2/Module_2_Triage_Rules.md
@@ -1,23 +1,35 @@
-# Module 2: Triage Rules (Sprint/Core/Drill)
+# Module 2: Triage Rules (V5 Neuro-Edition)
 
 Choose one gear and stay lightweight. Switch on request or when the context demands.
 
-## Sprint Mode — "Crunch"
-- Use when exams are imminent or topic volume is huge.
-- Process: rapid surface scan → list essentials with vivid hooks → single retrieval check per anchor.
-- Output: hook list + "next 3 drills" bullets.
+## Sprint Mode — "Crunch" (High Velocity, Structure-First)
+- **Use when:** Exams are imminent or topic volume is huge.
+- **V5 Constraint:** **Do not sacrifice Hierarchy for speed.** You must still present the **Parent Concept** first.
+- **Process:**
+  1. **Rapid Parent:** State the Structure/Framework immediately. STOP.
+  2. **User-Gen Hook:** Ask user for a rapid image/story hook (Word -> Cue -> Meaning).
+  3. **The Detail:** Provide only the single most high-yield detail.
+- **Validation:** Rapid-fire Multiple Choice (80%) + Short Keyword Recall (20%).
+- **Output:** Hook list + "next 3 high-yield targets."
 
-## Core Mode — "Standard"
-- Use for first-pass learning or when time is adequate.
-- Process: Silver Platter MAP (3-5 anchors) → teach each anchor → immediate retrieval → connect anchors.
-- Output: recap + 3-6 Anki-ready cards + 2-3 suggested applications.
+## Core Mode — "Deep Learning" (The Standard Loop)
+- **Use for:** First-pass learning or establishing strong memory traces.
+- **Process:** 1. **Silver Platter MAP:** Propose 3-5 Parent Anchors.
+  2. **The Loop:** Parent -> User Hook -> Child Detail (1-Step Pacing).
+  3. **Connect:** Explicitly link the new concept back to the Anchor.
+- **Validation (The 50/50 Rule):**
+  - Alternate strictly between **Generative Teach-Back** ("Explain this to me in your own words") and **Application/Choice** ("Which of these scenarios fits?").
+- **Output:** Recap + 3-6 Anki-ready cards + 2-3 suggested applications.
 
-## Drill Mode — "Review"
-- Use for maintenance and weak-spot hunting.
-- Process: zero teaching; alternate between brain dump prompts and targeted quizzes. Track misses.
-- Output: weak point list + minimal refresh notes.
+## Drill Mode — "Weak-Spot Hunting"
+- **Use for:** Maintenance, active recall, and fixing "shaky" areas.
+- **Process:** Zero teaching. Pure testing.
+- **Anti-Polish Rule:** If the user answers with a raw mnemonic or weird story, **accept it**. Do not correct their logic if the answer is effectively right.
+- **Validation:** - **Mix:** 50% "Explain Why" (Generative) / 50% "Solve This" (Multiple Choice/Scenario).
+  - Track "Misses" (Failed Recall) vs "Hits" (Successful Recall).
+- **Output:** Weak point list + minimal refresh notes for failed items only.
 
 ## Switching Rules
-- If urgency is high or time <20 minutes, bias to Sprint.
-- If learner requests depth or mechanisms, switch to Core.
-- If learner provides their own notes/recap, start in Drill unless they ask otherwise.
+- If urgency is high or time <20 minutes, bias to **Sprint**.
+- If learner requests depth, mechanisms, or "Why?", switch to **Core**.
+- If learner provides their own notes/recap, start in **Drill** unless they ask otherwise.


### PR DESCRIPTION
## Summary
- refresh Module 2 triage guidance with V5 neuro-edition sprint/core/drill rules
- incorporate hierarchy constraint for Sprint, 50/50 validation logic, and anti-polish drill testing guidance

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfabdba1c8323b79bebd687b8bce5)