### PR TITLE
Add missing v8.3 files to root directory

### DIFF
--- a/Master_Index.md
+++ b/Master_Index.md
@@ -1,0 +1,22 @@
+# Master Index — PT Study SOP v8.3 Package
+
+Use this index to load the right files for a session or to rebuild the Custom GPT package.
+
+## Files
+- **Custom_GPT_Instructions.md** — safety override, prime directives, startup line.
+- **Runtime_Prompt.md** — one-paste runtime script for ChatGPT sessions.
+- **Module_1_Core_Protocol.md** — identity, Silver Platter MAP, LOOP workflow, commands.
+- **Module_2_Triage_Rules.md** — Sprint/Core/Drill definitions and switching rules.
+- **Module_3_Framework_Selector.md** — ready-to-offer frameworks.
+- **Module_4_Session_Recap_Template.md** — recap and resume structure.
+- **Module_6_Framework_Library.md** — quick skeletons for common PT tasks.
+
+## How to Deploy
+1. Paste **Custom_GPT_Instructions.md** into Custom GPT instructions or the system prompt.
+2. Paste **Runtime_Prompt.md** as the session prompt (per chat).
+3. Keep the modules handy for reference when adjusting the flow.
+
+## Version Notes
+- v8.3 removes Modules 5 and 7; triage is now Sprint/Core/Drill only.
+- Silver Platter MAP: propose anchors immediately—no waiting for outlines.
+- Safety Override: when in doubt, choose the fastest safe help path and explain briefly.

--- a/Module_4_Session_Recap_Template.md
+++ b/Module_4_Session_Recap_Template.md
@@ -1,0 +1,11 @@
+# Module 4: Session Recap Template
+
+Keep recaps short and actionable. Use after any MAP/LOOP cycle or when the learner asks to pause.
+
+1) **Anchors Learned**: 3-5 bullets, numbered.
+2) **Hooks/Analogies**: 2-3 highlights tied to the learner's chosen style.
+3) **Weak Points**: list misses or low-confidence spots.
+4) **Next Drills**: 3 prompts for self-testing or flashcards.
+5) **Cards**: 3-6 Anki-ready cloze or Q/A items (label sources).
+
+If the learner supplies a prior recap, import it and prepend "Resume" bullets before adding new items.


### PR DESCRIPTION
## Summary
- copy the v8.3 Module 4 session recap template and master index into the root production folder to complete the active package

## Testing
- not run (not required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c1fbda4648323b253131b29d1beba)