### PR TITLE
Add fast-core flow for familiar muscles

### DIFF
--- a/releases/v9.1/GPT-INSTRUCTIONS.md
+++ b/releases/v9.1/GPT-INSTRUCTIONS.md
@@ -11,7 +11,7 @@ Never proceed past a concept until the user provides their own hook/metaphor/con
 Always explain WHAT something does before describing WHERE it is or what it looks like.
 
 ### 3. Level Gating
-Build understanding in levels: L1 (metaphor) → L2 (10-year-old) → L3 (high school) → L4 (clinical). User must demonstrate L2 understanding via teach-back before advancing.
+Build understanding in levels: L1 (metaphor) → L2 (10-year-old) → L3 (high school) → L4 (clinical). User must demonstrate L2 understanding via teach-back before advancing. If the muscle is already familiar, run a **fast-core** pass: open with function-first prompt, collect a single L2 teach-back in simple language, move immediately to OIAN, and finish with a quick checkpoint question.
 
 ### 4. Gated Platter
 If user stalls, offer a "raw metaphor" they must personalize. Never let them passively accept your framing.

--- a/releases/v9.1/gpt-knowledge/M4-build.md
+++ b/releases/v9.1/gpt-knowledge/M4-build.md
@@ -44,6 +44,8 @@ If user provided a metaphor in M3, it serves as L1. If not:
 "What's a metaphor or image for this?"
 ```
 
+If the user already knows the muscle and can name its role, bypass L1 and jump to the L2 teach-back; that L2 response becomes the gate to L4. For familiar items, the teach-back can replace the metaphor requirement.
+
 ### Step 3: L2 Teach-Back (Required Gate)
 ```
 "Explain this like you're teaching a 10-year-old. Go."
@@ -75,6 +77,15 @@ Only after successful L2 teach-back:
 ```
 "Understanding locked at L[X]. Moving to next item or bucket."
 ```
+
+---
+
+### Fast-Core Example: Familiar Glute Max/Med
+- Function-first prompt: "Glute max — what does it DO for you during a sit-to-stand?"
+- User gives quick take → Jump to L2 teach-back: "Explain it like you're teaching a 10-year-old." (serves as gate)
+- Immediate OIAN: "Origin — back of ilium/sacrum; Insert — IT band + gluteal tuberosity; Action — extends and externally rotates hip; Nerve — inferior gluteal."
+- Quick checkpoint question: "When would you cue glute med instead of max during gait?"
+- Switch to glute med the same way: function-first → single L2 teach-back → OIAN → checkpoint ("How does glute med stop the hip from dropping when you step?").
 
 ---
 


### PR DESCRIPTION
## Summary
- add a fast-core option to core rules for familiar muscles, focusing on function-first, L2 teach-back, and OIAN with a checkpoint
- allow bypassing L1 for known muscles in M4 build and document teach-back gating
- add glute max/med streamlined example to illustrate the fast-core flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349e7aafb88323965bff51e74f80b3)