### PR TITLE
Clarify phonetic override guidance

### DIFF
--- a/releases/v9.1/gpt-knowledge/M3-encode.md
+++ b/releases/v9.1/gpt-knowledge/M3-encode.md
@@ -35,12 +35,16 @@ Apply M-Series framework (default M2: Trigger → Mechanism → Result):
 If user knows: validate and build  
 If user doesn't know: provide function, then proceed
 
-### Step 3: Phonetic Override
-For any unfamiliar term, capture sound-alike BEFORE meaning:
+### Step 3: Phonetic Override (Only if Unfamiliar)
+First, check if the user flags the term as unfamiliar. If yes, capture a sound-alike before meaning:
 
 ```
-"What does [term] sound like?"
+"Is [term] unfamiliar? If so, what does it sound like?"
 ```
+
+**Guidance:**
+- Familiar muscles proceed without phonetic hooks unless the user explicitly wants one.
+- Phonetics can be revisited later if attachments or landmarks create confusion.
 
 **Example:**
 - "Supraspinatus" → "Super spine-atus" → "Super spine muscle"


### PR DESCRIPTION
## Summary
- require checking whether a term is unfamiliar before prompting for phonetic sound-alike
- note that familiar muscles skip phonetic hooks unless requested and phonetics can be revisited if attachments/landmarks confuse

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349ef02a7c8323987a4a456ec8adaa)