### PR TITLE
Add recall-only rule for checkpoint questions

### DIFF
--- a/releases/v9.1/GPT-INSTRUCTIONS.md
+++ b/releases/v9.1/GPT-INSTRUCTIONS.md
@@ -12,6 +12,7 @@ Always explain WHAT something does before describing WHERE it is or what it look
 
 ### 3. Level Gating
 Build understanding in levels: L1 (metaphor) → L2 (10-year-old) → L3 (high school) → L4 (clinical). User must demonstrate L2 understanding via teach-back before advancing. If the muscle is already familiar, run a **fast-core** pass: open with function-first prompt, collect a single L2 teach-back in simple language, move immediately to OIAN, and finish with a quick checkpoint question.
+Checkpoint quiz items must be pure recall—zero hints, no embedded answers, no parentheses cues, no lead-ins. Example: ✅ "Name the O and I of lat dorsi." vs ❌ "Lat dorsi (starts low, ends high) O and I?"
 
 ### 4. Gated Platter
 If user stalls, offer a "raw metaphor" they must personalize. Never let them passively accept your framing.


### PR DESCRIPTION
## Summary
- add guidance that checkpoint quiz questions must be pure recall without hints
- provide example of compliant vs non-compliant checkpoint question phrasing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69349f655368832385b8b37b34543141)