### PR TITLE
Clarify Brain setup location

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ A structured study system for Doctor of Physical Therapy coursework, powered by 
 **Everything you need is in:** `releases/v9.1/`
 
 1. Open `releases/v9.1/README.md` for setup instructions
-2. Copy `GPT-INSTRUCTIONS.md` into your CustomGPT
-3. Upload all files from `gpt-knowledge/` to GPT Knowledge
-4. Run `python brain/db_setup.py` to initialize tracking
+2. From the repo root, run `python brain/db_setup.py` (Brain lives in the root repo; it is **not packaged** inside releases)
+3. Copy `GPT-INSTRUCTIONS.md` into your CustomGPT
+4. Upload all files from `gpt-knowledge/` to GPT Knowledge
 5. Start studying
 
 **One-click launcher:** Run `Run_Brain_All.bat` (repo root) to sync logs, regenerate resume, start the dashboard server, and open http://127.0.0.1:5000 automatically. Keep the new "PT Study Brain Dashboard" window open while using the site.
@@ -30,8 +30,7 @@ pt-study-sop/
 │   └── v9.1/                    ← CURRENT RELEASE (start here)
 │       ├── README.md            ← Setup instructions
 │       ├── GPT-INSTRUCTIONS.md  ← Copy to GPT Instructions field
-│       ├── gpt-knowledge/       ← Upload to GPT Knowledge (14 files)
-│       └── brain/               ← Session tracking system
+│       └── gpt-knowledge/       ← Upload to GPT Knowledge (14 files)
 ├── sop/                         ← Source files (development)
 │   ├── MASTER.md
 │   ├── gpt-instructions.md      ← Full version (reference)

--- a/releases/v9.1/README.md
+++ b/releases/v9.1/README.md
@@ -11,7 +11,7 @@ Everything you need to set up and run the PT Study Tutor system (general-first; 
 **Knowledge files:** Upload ALL 14 files from the `gpt-knowledge/` folder.
 
 ### 2. Set Up Brain (Session Tracking)
-Use the root-level `brain/` (authoritative copy) for ingesting session logs and running the dashboard.
+Use the root-level `brain/` (authoritative copy) for ingesting session logs and running the dashboard (the dashboard lives there; the release package does not include its own copy).
 
 ```powershell
 cd brain
@@ -50,6 +50,8 @@ v9.1/
     drawing-for-anatomy.md
 README.md (this file)
 ```
+
+> The release package includes GPT instructions and knowledge files only; the live `brain/` system remains at the repo root.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify Quick Start instructions to run the Brain setup from the repo root and note it is not packaged with releases
- update the v9.1 release guide to highlight the root-level Brain/dashboard location and that the release packages only GPT instructions and knowledge files

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b1140b8c832398e3302b8e9ec1a6)