### PR TITLE
Update research backlog for v9.2 architecture

### DIFF
--- a/sop/research/RESEARCH_TOPICS.md
+++ b/sop/research/RESEARCH_TOPICS.md
@@ -1,56 +1,61 @@
-﻿# Research Priorities (lean list)
+# Research Backlog: System Architecture Audit (v9.2)
 
-## Tier 1 (work through first)
-1) Testing Effect / Retrieval Practice (Roediger, Karpicke) — fuel Sprint/Drill design.
-2) Cognitive Load Theory (Sweller) — chunking, Gated Platter limits, extraneous load trim.
-3) Dual Coding / Multimedia Learning (Paivio, Mayer) — drawing protocol, landmarks-first.
-4) Levels of Processing / Elaborative Interrogation (Craik & Lockhart) — Seed-Lock depth.
-5) Spacing & Interleaving (Cepeda, Kornell) — dashboard spacing alerts, content scheduling.
+## PART 1: BROAD EXPLORATION (The "Wide Lens")
+*Goal: Find new structures to handle topics where current Engines might struggle.*
 
-## Tier 2 (next pass)
-6) Metacognition & Calibration (Dunlosky, Bjork) — confidence vs performance charts.
-7) Desirable Difficulties (Bjork) — generation, varied practice, reduced cues.
-8) Feedback Timing & Specificity (Hattie/Timperley) — gate design, prompt timing.
-9) Schema Theory / Prior Knowledge Activation — priming/bucketing refinements.
-10) Transfer & Analogical Learning — build better hooks/seed prompts and cross-topic bridges.
+### 1. New Engine Research
+*   [ ] **The Procedure Engine:** Current "Concept Engine" is declarative. Research "Cognitive Apprenticeship" (Collins/Brown) for teaching physical skills (e.g., goniometry, transfers) via text.
+*   [ ] **The Case Engine:** Research "Case-Based Reasoning" (Kolodner). Should we add a mode for solving complex patient vignettes (SOAP note logic) distinct from M8 Diagnosis?
+*   [ ] **The Debate Engine:** Research "Dialectical Learning." Should we add a "Devil's Advocate" mode to force defense of clinical choices?
+*   [ ] **The Math/Physics Engine:** Research "Polya’s Problem Solving Principles." Does Biomechanics need a distinct flow (Given -> Find -> Formula -> Solve) different from Anatomy?
 
-## How to use
-- Pick 1 topic/week; read 2–3 papers or solid summaries.
-- Update the relevant methods/framework file and test in one session.
-- Log impact notes in `sop/working/PLAN_v9.2_dev.md`.
+### 2. Alternative Hierarchies
+*   [ ] **Network vs. Tree:** Research "Rhizomatic Learning." When is the strict H1 (System -> Subsystem) too rigid? Should we introduce "Concept Maps" (cross-linking) alongside "Tree Maps"?
+*   [ ] **Chronological Structures:** Research "Narrative Structuring." Is "Time-Course" (Onset -> Acute -> Chronic) a better default for Pathology than M2 (Trigger -> Mechanism)?
 
+---
 
-## Status / Completed Research
-# SOP Research Status (v9.1)
+## PART 2: DEEP VALIDATION (The "Zoom Lens")
+*Goal: Validate the specific v9.2 components against learning science.*
 
-## Completed Research Notes
-- Modules:  
-  - M0-planning (`modules/M0-planning-research.md`)  
-  - M2-prime (`modules/M2-prime-research.md`)  
-  - M3-encode (`modules/M3-encode-research.md`)  
-  - M4-build (`modules/M4-build-research.md`)  
-  - M5-modes (`modules/M5-modes-research.md`)  
-  - M6-wrap (`modules/M6-wrap-research.md`)
+### 3. The Engines (Content Architecture)
+*   [ ] **Anatomy Engine (OIANA+):**
+    *   **Target:** "Visual-First" & Bruner Enforcement (Iconic -> Symbolic).
+    *   **Question:** Does showing the image *before* the name reliably improve retrieval speed for adults, or is it just for novices?
+    *   **Target:** "Bone-First" sequence.
+    *   **Question:** Does anchoring muscles to bones first actually facilitate faster learning than "Region-First" (learning all tissues in a slice)?
+*   [ ] **Concept Engine (Gagné/Merrill):**
+    *   **Target:** The "Identity -> Context -> Mechanism -> Boundary" flow.
+    *   **Question:** Is this flow superior to "Inquiry-Based" (Problem -> Solution) for abstract topics like Law or Code?
 
-## Recommended Next Research Targets
-- Frameworks: H-series, M-series, Levels â€” evidence on mapping/hierarchical org, when to choose which framework for novice vs. intermediate learners.
-- Methods (deep dives/quick refs):
-  - Drawing for anatomy (labeled vs unlabeled, guided drawing, spatial memory).
-  - Desirable difficulties (spacing/interleaving/variability) in health-sci contexts.
-  - Elaborative interrogation & self-explanation (health-sci examples, effect sizes).
-  - Metacognition/calibration (JOLs, confidence-based scoring).
-  - Retrieval practice quick-reference (for easy reuse in methods).
-- Engines/Content:
-  - Anatomy Engine: visual landmark training, discrimination of similar structures, image-based/AR/VR anatomy learning.
-  - Recap Engine: structured recap/exam wrappers/post-lesson quiz evidence for a recap workflow.
+### 4. The Frameworks (H/M/Y)
+*   [ ] **H1 System (Hierarchy):**
+    *   **Target:** `System -> Subsystem -> Component`.
+    *   **Question:** Does this break down for "Systemic" diseases (e.g., Lupus) that affect multiple subsystems simultaneously?
+*   [ ] **M2 Trigger (Mechanism):**
+    *   **Target:** `Trigger -> Mechanism -> Result`.
+    *   **Question:** Is this linear flow sufficient for "Feedback Loops" (Homeostasis)? Should we default to M6 for all Physiology?
+*   [ ] **Y-Series (Context):**
+    *   **Target:** `Y1 Generalist` (What is it -> What does it do -> Fail state).
+    *   **Question:** Is this the scientifically optimal "minimum viable context" for new terms?
 
-## Integration To-Do (after research)
-- Pull key â€œToolkit / Evidence / Risksâ€ sections from each module research file into the live module docs (M0, M2â€“M6).
-- Add crosswalks and decision rules (e.g., mode switching thresholds, framework selection) into `MASTER.md`.
-- Update runtime prompt with prime (pre-test) reminder and wrap (mark unverified) note.
-- Add spacing/next-step templates to M6; add fading/ramp templates to M4; add mode rules to M5.
+### 5. The Core Loop Mechanisms
+*   [ ] **Seed-Lock:**
+    *   **Target:** User *must* supply the hook; AI cannot lecture.
+    *   **Question:** At what point does "Generation Fatigue" set in? Should we auto-suggest hooks after 45 mins?
+*   [ ] **Stop Rule (Wait-for-Retrieval):**
+    *   **Target:** No answers in the same message as questions.
+    *   **Question:** Does this friction cause drop-off? Compare "Errorful Retrieval" vs. "Worked Examples" for initial acquisition.
+*   [ ] **Level Gating (L2 -> L4):**
+    *   **Target:** The "10-year-old explanation" requirement.
+    *   **Question:** Does "simplification" (L2) actually correlate with clinical competence (L4), or are they separate skills?
 
-## Notes
-- Research files are meant as scratch pads. When integrating, keep module files concise and keep citations handy.  
-- Prioritize short wrap formats (2â€“10 min) and micro/standard session timing guidance as already captured in module research.
+---
 
+## PART 3: ARCHIVE (Completed in v9.1)
+*   M0-planning (modules/M0-planning-research.md)
+*   M2-prime (modules/M2-prime-research.md)
+*   M3-encode (modules/M3-encode-research.md)
+*   M4-build (modules/M4-build-research.md)
+*   M5-modes (modules/M5-modes-research.md)
+*   M6-wrap (modules/M6-wrap-research.md)


### PR DESCRIPTION
## Summary
- replace RESEARCH_TOPICS.md with v9.2-aligned research backlog
- organize topics into broad exploration and deep validation for current engines and frameworks
- archive completed v9.1 research references

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b46a7bf648323824e33552b0a3bb1)