### PR TITLE
Add core learning modules to build order

### DIFF
--- a/sop/gpt-knowledge/BUILD_ORDER.md
+++ b/sop/gpt-knowledge/BUILD_ORDER.md
@@ -1,0 +1,17 @@
+# BUILD ORDER
+
+## Recommended Upload/Paste Order
+1. Rules/Mechanisms
+2. Core Learning Modules (PERRO, KWIK)
+3. Engines
+
+## Rules/Mechanisms
+- runtime-prompt.md
+- gpt-instructions.md
+
+## Core Learning Modules
+- PERRO.md
+- KWIK.md
+
+## Engines
+- anatomy-engine.md


### PR DESCRIPTION
## Summary
- add a BUILD_ORDER document for gpt-knowledge
- include Core Learning Modules section with PERRO and KWIK between Rules/Mechanisms and Engines

## Testing
- not run (not needed for docs)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1c2d5aec8323b0caa88bc1697278)