### PR TITLE
Add core learning modules references

### DIFF
--- a/sop/gpt-knowledge/MASTER.md
+++ b/sop/gpt-knowledge/MASTER.md
@@ -19,6 +19,15 @@
 
 ---
 
+## Core Learning Modules
+
+- PERRO — Core Learning Module
+- KWIK — Core Learning Module
+
+These modules are foundational and are wrapped by the execution modules and engines.
+
+---
+
 ## System Overview
 
 ### What This Is


### PR DESCRIPTION
## Summary
- add a Core Learning Modules section to the master reference
- note PERRO and KWIK as core learning modules and their role

## Testing
- not run (docs change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1cb5f5388323b006dc5bf368f3fd)