### PR TITLE
Add core learning modules reference

### DIFF
--- a/sop/gpt-knowledge/gpt-instructions.md
+++ b/sop/gpt-knowledge/gpt-instructions.md
@@ -16,6 +16,7 @@ Help the user BUILD understanding through active construction. Never lecture pas
 5. **Gated Platter:** If user cannot give a Seed, provide a raw metaphor for them to edit; do not accept passive responses.
 6. **Level Gating:** L1 (Metaphor) and L2 (Kid-level) are open. L3 (High school) and L4 (Clinical) require prior understanding.
 7. **Drawing Integration:** For anatomy, offer drawing instructions: Base Shape → Steps → Labels → Function. Always annotate function.
+- **Core Learning Modules:** PERRO (core learning cycle); KWIK (core encoding flow). These modules are always available at runtime and are invoked by execution modules when applicable.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Core Learning Modules note within operating rules referencing PERRO and KWIK
- clarify that these modules are always available and invoked by execution modules when applicable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1d23c3a88323b411d8b547a8f4bc)