### PR TITLE
Add core learning module references

### DIFF
--- a/sop/gpt-knowledge/M2-prime.md
+++ b/sop/gpt-knowledge/M2-prime.md
@@ -1,6 +1,6 @@
 ﻿# M2: Prime (v9.2 dev)
 
-Purpose: Map the territory before encoding. Build buckets; don’t memorize yet.
+ Purpose: Map the territory before encoding. Build buckets; don’t memorize yet. The session’s learning cycle follows the PERRO Core Learning Module (Prepare → Encode → Retrieve → Reflect → Optimize) as the conceptual backbone.
 
 ---
 ## Protocol (fast)

--- a/sop/gpt-knowledge/M3-encode.md
+++ b/sop/gpt-knowledge/M3-encode.md
@@ -27,7 +27,7 @@ Purpose: Turn mapped buckets into understanding using function-first framing and
 
 ## Process Corrections (v9.2)
 - Word + Meaning together before imagery to trigger accurate hooks.
-- When creating memory hooks, runtime may invoke the KWIK Core Learning Module (Sound → Function → Image → Resonance → Lock) as the canonical flow.
+- When creating memory hooks, runtime may invoke the KWIK Core Learning Module (Sound → Function → Image → Resonance → Lock) as the canonical encoding flow.
 - Jim Kwik flow enforced: Sound → Function → Image → Lock (matches M3 dual code).
 - One-step gating: do not advance without user approval on Sound, Function, Image, Resonance, Lock.
 - Function-first ordering: image creation only after true action is stated.

--- a/sop/gpt-knowledge/M6-wrap.md
+++ b/sop/gpt-knowledge/M6-wrap.md
@@ -1,6 +1,6 @@
 ﻿# M6: Wrap (v9.2 dev)
 
-Purpose: End-of-session consolidation in 2–10 minutes: recall, error capture, cards, and next-review plan.
+ Purpose: End-of-session consolidation in 2–10 minutes: recall, error capture, cards, and next-review plan. Reflection and optimization align with the PERRO Core Learning Module’s Reflect and Optimize phases.
 
 ---
 ## Wrap Toolkit (pick 2–3 actions)


### PR DESCRIPTION
## Summary
- note that M2 and M6 stages align with PERRO Core Learning Module phases
- clarify M3 encoding can invoke the KWIK Core Learning Module as the canonical flow

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1e0988f083239c4873de11eef889)