### PR TITLE
Align PERRO/KWIK naming and runtime reminders

### DIFF
--- a/sop/gpt-knowledge/BUILD_ORDER.md
+++ b/sop/gpt-knowledge/BUILD_ORDER.md
@@ -1,9 +1,15 @@
 # BUILD ORDER
 
 ## Recommended Upload/Paste Order
-1. Rules/Mechanisms
-2. Core Learning Modules (PERRO, KWIK)
-3. Engines
+1. Templates/Index
+2. Rules/Mechanisms
+3. Core Learning Modules (PERRO, KWIK)
+4. Frameworks
+5. Execution Modules (M0–M6)
+6. Engines
+
+## Templates/Index
+- MASTER.md
 
 ## Rules/Mechanisms
 - runtime-prompt.md
@@ -12,6 +18,21 @@
 ## Core Learning Modules
 - PERRO.md
 - KWIK.md
+
+## Frameworks
+- H-series.md
+- M-series.md
+- Y-series.md
+- levels.md
+
+## Execution Modules (M0–M6)
+- M0-planning.md
+- M1-entry.md
+- M2-prime.md
+- M3-encode.md
+- M4-build.md
+- M5-modes.md
+- M6-wrap.md
 
 ## Engines
 - anatomy-engine.md

--- a/sop/gpt-knowledge/M5-modes.md
+++ b/sop/gpt-knowledge/M5-modes.md
@@ -73,3 +73,4 @@ Purpose: Define how AI behavior changes by mode and give quick presets for short
 - Seed-Lock: user supplies hook/metaphor; AI rejects passive acceptance.
 - Function before structure; mark unverified if no source.
 - Insert breaks when accuracy drops/fatigue shows; Light/Quick Sprint are time-boxed by design.
+- Sprint and Drill still run inside the PERRO cycle and may call KWIK for encoding steps when hooks need reinforcement.

--- a/sop/gpt-knowledge/MASTER.md
+++ b/sop/gpt-knowledge/MASTER.md
@@ -9,10 +9,12 @@
 
 | File | Purpose |
 |------|---------|
+| `MASTER.md` | Template/index for the PT Study SOP set |
 | `gpt-instructions.md` | CustomGPT system prompt (paste into GPT settings) |
 | `runtime-prompt.md` | Session start script (paste at beginning of each session) |
-| `modules/M0-M6` | Protocol steps in sequence |
-| `modules/anatomy-engine.md` | Specialized anatomy learning protocol |
+| Core Learning Modules (`PERRO.md`, `KWIK.md`) | Learning cycle backbone and encoding flow |
+| Execution Modules (M0–M6 files) | Protocol steps in sequence |
+| `anatomy-engine.md` | Specialized anatomy learning protocol |
 | `frameworks/` | H-Series, M-Series, Y-Series reference |
 | `methods/` | Learning science foundations |
 | `examples/` | Dialogue examples and command reference |
@@ -177,7 +179,7 @@ M0 (Planning) → Anatomy Engine → M6 (Wrap)
 
 ## Anatomy Learning Engine
 
-> **See full documentation:** `modules/anatomy-engine.md`
+> **See full documentation:** `anatomy-engine.md`
 
 ### Primary Goal for Anatomy
 Build a **clean mental atlas** of every exam-relevant bone landmark, where each landmark sits in space, and what muscles attach to that landmark — BEFORE trying to memorize OIAN lists.
@@ -340,7 +342,9 @@ sop/
 ├── MASTER.md              ← You are here
 ├── gpt-instructions.md    ← CustomGPT system prompt
 ├── runtime-prompt.md      ← Session start script
-├── modules/
+├── PERRO.md               ← Core Learning Module: learning cycle
+├── KWIK.md                ← Core Learning Module: encoding flow
+├── Execution Modules/
 │   ├── M0-planning.md     ← NEW: Planning phase
 │   ├── M1-entry.md
 │   ├── M2-prime.md
@@ -352,6 +356,7 @@ sop/
 ├── frameworks/
 │   ├── H-series.md
 │   ├── M-series.md
+│   ├── Y-series.md
 │   └── levels.md
 ├── methods/
 │   ├── desirable-difficulties.md
@@ -366,6 +371,6 @@ sop/
 ```
 
 ## Versioning / Canonical Source
-- Canonical frameworks and modes now live in sop/ (H-series, M-series, levels, modules).
+- Canonical frameworks and modes now live in sop/ (H-series, M-series, Y-series, levels, execution modules M0–M6).
 - Releases/v9.1 gpt-knowledge and archive/v8.* files are kept only for historical reference; content has been merged forward.
 

--- a/sop/gpt-knowledge/gpt-instructions.md
+++ b/sop/gpt-knowledge/gpt-instructions.md
@@ -16,6 +16,7 @@ Help the user BUILD understanding through active construction. Never lecture pas
 5. **Gated Platter:** If user cannot give a Seed, provide a raw metaphor for them to edit; do not accept passive responses.
 6. **Level Gating:** L1 (Metaphor) and L2 (Kid-level) are open. L3 (High school) and L4 (Clinical) require prior understanding.
 7. **Drawing Integration:** For anatomy, offer drawing instructions: Base Shape → Steps → Labels → Function. Always annotate function.
+8. **Invocation Rule:** PERRO is the learning cycle backbone; KWIK is the default encoding flow when creating hooks/terms.
 - **Core Learning Modules:** PERRO (core learning cycle); KWIK (core encoding flow). These modules are always available at runtime and are invoked by execution modules when applicable.
 
 ---

--- a/sop/gpt-knowledge/runtime-prompt.md
+++ b/sop/gpt-knowledge/runtime-prompt.md
@@ -18,6 +18,8 @@ Role: Guide active construction. Enforce Seed-Lock. Adapt to your readiness leve
 
 Before any teaching:
 
+- Use PERRO as the learning cycle; default to KWIK for encoding hooks/terms when needed.
+
 **1. TARGET**
 - What exam or block is this for?
 - How much time do we have?


### PR DESCRIPTION
## Summary
- add explicit PERRO/KWIK invocation guidance to gpt-instructions and runtime prompt
- clarify mode behavior with PERRO/KWIK alignment and normalize module naming in MASTER
- update build order to group templates, frameworks, core learning modules, and execution modules correctly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1ec1073883239971c135a9aa7257)