### PR TITLE
Add runtime canon banners to non-canonical docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-﻿# PT Study SOP
+> Runtime Canon is sop/gpt-knowledge/
+> If this document conflicts with Runtime Canon, Runtime Canon wins.
+> This README points to releases; runtime canon is in sop/gpt-knowledge/
+
+# PT Study SOP
 
 A structured study system for Doctor of Physical Therapy coursework, powered by the PERRIO protocol.
 

--- a/sop/MASTER_PLAN_PT_STUDY.md
+++ b/sop/MASTER_PLAN_PT_STUDY.md
@@ -1,4 +1,8 @@
-﻿# PT Study SOP - Master Plan (Stable North Star)
+> Runtime Canon is sop/gpt-knowledge/
+> If this document conflicts with Runtime Canon, Runtime Canon wins.
+> This is a blueprint/design doc.
+
+# PT Study SOP - Master Plan (Stable North Star)
 **Owner:** Trey Tucker  
 **Purpose:** Version-agnostic blueprint; only change when invariants or contracts change.
 

--- a/sop/engines/anatomy-engine.md
+++ b/sop/engines/anatomy-engine.md
@@ -1,3 +1,7 @@
+> Runtime Canon is sop/gpt-knowledge/
+> If this document conflicts with Runtime Canon, Runtime Canon wins.
+> This is a non-canonical reference; canonical engine lives in sop/gpt-knowledge/
+
 # Anatomy Learning Engine
 
 ## Purpose

--- a/sop/engines/concept-engine.md
+++ b/sop/engines/concept-engine.md
@@ -1,4 +1,8 @@
-﻿# Concept Engine (universal, non-anatomy)
+> Runtime Canon is sop/gpt-knowledge/
+> If this document conflicts with Runtime Canon, Runtime Canon wins.
+> This is a non-canonical reference; canonical engine lives in sop/gpt-knowledge/
+
+# Concept Engine (universal, non-anatomy)
 
 Purpose: Default flow for abstract/non-spatial topics (law, coding, history, etc.). Aligns with Gagné/Merrill to move from identity → context → mechanism → boundary → application.
 

--- a/v9.2/PT_Study_SOP_v9.2_DEV.md
+++ b/v9.2/PT_Study_SOP_v9.2_DEV.md
@@ -1,4 +1,8 @@
-﻿# CustomGPT Instructions — PT Study SOP v9.2 (dev)
+> Runtime Canon is sop/gpt-knowledge/
+> If this document conflicts with Runtime Canon, Runtime Canon wins.
+> This is a development/reference doc.
+
+# CustomGPT Instructions — PT Study SOP v9.2 (dev)
 
 ## Identity
 You are the **Structured Architect** — a study partner who guides active learning for PT (Physical Therapy) students. You enforce structured protocols while adapting to the user's current knowledge state.


### PR DESCRIPTION
## Summary
- add runtime canon warning banners to root README and master plan
- mark v9.2 development doc and engine references as non-canonical relative to sop/gpt-knowledge

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d28f2c0388323b353955a6b45de64)