### PR TITLE
Clarify Prepare step in PEIRRO guide

### DIFF
--- a/sop/gpt-knowledge/PEIRRO.md
+++ b/sop/gpt-knowledge/PEIRRO.md
@@ -6,7 +6,7 @@ Status: Canonical
 PEIRRO provides structure for deep learning architecture through its Prepare, Encode, Interrogate, Retrieve, Refine, Overlearn sequence.
 
 # Steps
-1. Prepare – Unspecified in source.
+1. Prepare – Orient attention by clarifying scope, relevance, and expectations before learning begins.
 2. Encode – PEIRRO method encodes knowledge.
 3. Interrogate – Unspecified in source.
 4. Retrieve – Unspecified in source.


### PR DESCRIPTION
## Summary
- describe the Prepare step as orienting attention by clarifying scope, relevance, and expectations before learning begins

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d40b8279883238331b2e19d9268e6)