### PR TITLE
Clarify PEIRRO cycle definitions and boundaries

### DIFF
--- a/sop/gpt-knowledge/PEIRRO.md
+++ b/sop/gpt-knowledge/PEIRRO.md
@@ -8,10 +8,10 @@ PEIRRO provides structure for deep learning architecture through its Prepare, En
 # Steps
 1. Prepare – Orient attention by clarifying scope, relevance, and expectations before learning begins.
 2. Encode – Actively construct durable, cued schemas by linking new material to prior maps and meaning before drilling details. Combine function-first context (e.g., how a structure works) with names later, especially in anatomy. Use multimodal cues (imagery + meaning; KWIK fits here) to create retrievable anchors. Encode precedes retrieval practice and is more than passive exposure.
-3. Interrogate – Unspecified in source.
-4. Retrieve – Unspecified in source.
-5. Refine – Unspecified in source.
-6. Overlearn – Unspecified in source.
+3. Interrogate – Actively question and explain “why/how” while learning to force meaning-making and connect to prior knowledge. It is not passive review or delayed recall testing; it happens during encoding to deepen understanding.
+4. Retrieve – Effortful recall without cues to strengthen memory access. It does not introduce new information and is distinct from re-reading or recognition.
+5. Refine – Targeted correction of errors and misconceptions using feedback from retrieval attempts. It does not involve learning new material or extended practice; it only repairs known gaps.
+6. Overlearn – Continued spaced recall beyond initial mastery to stabilize and automate knowledge. It does not introduce new content or correct errors; it reinforces already-correct knowledge over time.
 
 # Constraints (Must / Never)
 - Must act as a PEIRRO method guide when running study sessions.


### PR DESCRIPTION
## Summary
- Clarify PEIRRO Interrogate, Retrieve, Refine, and Overlearn steps with concise definitions and explicit boundaries.

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d4e01d440832385f2761bcece1efc)