### PR TITLE
Clarify PEIRRO terminology and runtime canon docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 > Runtime Canon is sop/gpt-knowledge/
 > If this document conflicts with Runtime Canon, Runtime Canon wins.
-> This README points to releases; runtime canon is in sop/gpt-knowledge/
+> This README mirrors the Runtime Canon stored in `sop/gpt-knowledge/`.
 
 ## Repository Authority Chain
 
 - Runtime Canon = `sop/gpt-knowledge/`.
-- Release snapshots are frozen copies.
+- Release snapshots are frozen copies when present.
 - If conflict: Runtime Canon wins.
 
 # PT Study SOP
 
-A structured study system for Doctor of Physical Therapy coursework, powered by the PERRIO protocol.
+A structured study system for Doctor of Physical Therapy coursework, powered by the PEIRRO protocol.
 
-## Current Version: 9.1 "Structured Architect + Anatomy Engine"
+## Current Version: 9.1 "Structured Architect + Anatomy Engine" (development tag)
+
+Version numbers track the development state of the SOP. Packaged release bundles may lag behind, and when in doubt the Runtime Canon in `sop/gpt-knowledge/` is the source of truth.
 
 **Master Plan (North Star):** See `sop/MASTER_PLAN_PT_STUDY.md` for the stable vision, invariants, and contracts every release must honor.
 
@@ -20,12 +22,12 @@ A structured study system for Doctor of Physical Therapy coursework, powered by 
 
 ## Quick Start
 
-**Everything you need is in:** `releases/v9.1/`
+**Runtime canon lives in:** `sop/gpt-knowledge/`
 
-1. Open `releases/v9.1/README.md` for setup instructions
+1. Open `sop/gpt-knowledge/README.md` for setup instructions
 2. From the repo root, run `python brain/db_setup.py` (Brain lives in the root repo; it is **not packaged** inside releases)
 3. Copy `GPT-INSTRUCTIONS.md` into your CustomGPT
-4. Upload all files from `gpt-knowledge/` to GPT Knowledge (or just upload the combined `PT_Study_SOP_v9.1_ALL.md` bundle)
+4. Upload all files from `sop/gpt-knowledge/` to GPT Knowledge (or upload the combined bundle in the same directory)
 5. Start studying
 
 **One-click launcher:** Run `Run_Brain_All.bat` (repo root) to sync logs, regenerate resume, start the dashboard server, and open http://127.0.0.1:5000 automatically. Keep the new "PT Study Brain Dashboard" window open while using the site.
@@ -37,8 +39,8 @@ A structured study system for Doctor of Physical Therapy coursework, powered by 
 ## Repository Structure
 
 pt-study-sop/
-- v9.1/ (current release bundle)
-- sop/ (source / development)
+- v9.2/ (current development bundle)
+- sop/ (source / development; Runtime Canon in `sop/gpt-knowledge/`)
   - MASTER_PLAN_PT_STUDY.md
   - RESEARCH_TOPICS.md
   - modules/
@@ -88,7 +90,7 @@ pt-study-sop/
 - **Rollback Rule:** Return to landmarks if OIAN struggles
 - **Drawing Protocol:** AI-generated drawing instructions for anatomy
 - **Condensed GPT Instructions:** Under 8k character limit
-- **Packaged Release:** All files in `releases/v9.1/`
+- **Packaged Release:** Bundled copies are produced when available; Runtime Canon stays authoritative.
 
 ---
 
@@ -96,7 +98,7 @@ pt-study-sop/
 
 | Document | Purpose |
 |----------|---------|
-| `releases/v9.1/README.md` | Setup and usage guide |
+| `sop/gpt-knowledge/README.md` | Setup and usage guide (Runtime Canon) |
 | `sop/MASTER.md` | Complete system reference |
 | `sop/MASTER_PLAN_PT_STUDY.md` | Stable North Star vision/invariants/contracts |
 | `sop/CHANGELOG.md` | Version history |
@@ -111,7 +113,7 @@ pt-study-sop/
 
 ## Links
 - GitHub: https://github.com/Treytucker05/pt-study-sop
-- Current Release: releases/v9.1/
+- Current Development Bundle: v9.2/
 
 
 

--- a/brain/README.md
+++ b/brain/README.md
@@ -2,6 +2,8 @@
 
 Session tracking and analytics system for the PT Study SOP.
 
+Brain logs and WRAP activities map to the PEIRRO learning cycle (Prepare, Encode, Refine, Overlearn) for documentation clarity only.
+
 ---
 
 ## Quick Start

--- a/sop/MASTER_PLAN_PT_STUDY.md
+++ b/sop/MASTER_PLAN_PT_STUDY.md
@@ -32,6 +32,12 @@ Build a personal AI study OS that:
 - Observability: tool calls and gating decisions are recorded (log/resume/dashboard).
 - Security/Privacy: local-first; external APIs are opt-in per tool.
 
+### MAP/PEIRRO alignment (documentation note)
+- MAP → LOOP → WRAP is the execution lifecycle; PEIRRO is the learning cycle backbone.
+- MAP aligns primarily with Prepare.
+- LOOP spans Encode, Interrogate, Retrieve.
+- WRAP covers Refine and Overlearn.
+
 ---
 
 ## 3) System architecture (stable components)

--- a/v9.2/CHANGELOG.md
+++ b/v9.2/CHANGELOG.md
@@ -96,7 +96,7 @@
 - v8.5.1 Spotter Prime
 - v8.4 Tutor Edition
 - v8.1 Archive
-- Progressive development of PERRIO protocol
+- Progressive development of PEIRRO learning cycle
 
 ---
 


### PR DESCRIPTION
## Summary
- Update the root README to emphasize `sop/gpt-knowledge/` as the Runtime Canon, clarify development-version numbering, and align terminology with the PEIRRO learning cycle.
- Add concise mapping between MAP → LOOP → WRAP and PEIRRO stages in the master plan and note PEIRRO alignment for brain logs.
- Correct changelog language to reference the PEIRRO learning cycle.

## Testing
- Not run (documentation-only changes).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d4fcea0ec8323a27d47c7ce6b3539)