### PR TITLE
Add research index scaffold for SOP artifacts

### DIFF
--- a/sop/RESEARCH_INDEX.md
+++ b/sop/RESEARCH_INDEX.md
@@ -1,0 +1,47 @@
+# Research Index
+
+## Purpose
+This document tracks artifact-anchored research and refinement status so study SOP updates stay organized and evidence-based.
+
+## Artifact Inventory
+| File | Layer (Learning / Execution / Enforcement / Measurement) | Cognitive Job (one sentence, inferred from file name and docs) | Explicit or Implicit? (Explicit / Implicit / Missing) | Research Status (Not started / In progress / Complete) | Change Status (None / Candidate / Implemented) |
+| --- | --- | --- | --- | --- | --- |
+| sop/gpt-knowledge/PEIRRO.md | Learning | Defines the core Prepare-Encode-Interrogate-Retrieve-Refine-Overlearn learning sequence. | Explicit | Not started | None |
+| sop/gpt-knowledge/KWIK.md | Learning | Details the Sound→Function→Image→Resonance→Lock encoding flow for term hooks. | Explicit | Not started | None |
+| sop/modules/M0-planning.md | Execution | Outlines the planning stage steps before study sessions begin. | Explicit | Not started | None |
+| sop/modules/M1-entry.md | Execution | Guides entry checks and readiness gating for sessions. | Explicit | Not started | None |
+| sop/modules/M2-prime.md | Execution | Provides priming steps to activate prior knowledge. | Explicit | Not started | None |
+| sop/modules/M3-encode.md | Execution | Directs encoding activities, including integration with PEIRRO/KWIK. | Explicit | Not started | None |
+| sop/modules/M4-build.md | Execution | Describes building structured outputs after encoding. | Explicit | Not started | None |
+| sop/modules/M5-modes.md | Execution | Specifies operating modes and selection rules for sessions. | Explicit | Not started | None |
+| sop/modules/M6-wrap.md | Execution | Covers session wrap-up and consolidation actions. | Explicit | Not started | None |
+| sop/engines/anatomy-engine.md | Enforcement | Enforces the bone→landmark→attachment→OIAN sequence for anatomy learning. | Explicit | Not started | None |
+| sop/gpt-knowledge/gpt-instructions.md | Enforcement | Sets runtime rules for the Structured Architect assistant identity and behavior. | Explicit | Not started | None |
+| sop/gpt-knowledge/runtime-prompt.md | Enforcement | Provides the session startup prompt and gating questions for runtime use. | Explicit | Not started | None |
+| brain/* | Measurement | Aggregates session logs, dashboards, and sync scripts for tracking study activity. | Explicit | Not started | None |
+
+## Research Notes
+### P — Prepare
+- _Notes go here_
+
+### E — Encode
+- _Notes go here_
+
+### I — Interrogate
+- _Notes go here_
+
+### R — Retrieve
+- _Notes go here_
+
+### R — Refine
+- _Notes go here_
+
+### O — Overlearn
+- _Notes go here_
+
+## Refinement Rules
+- Changes require an identified gap, supporting research, and an explicit decision before updating any artifact.
+- Recording “no change” is acceptable when evidence supports the current state.
+
+## Stopping Criteria
+- An artifact is considered done for refinement when its intended layer and cognitive job are validated, open research questions are closed or deferred with rationale, and no pending change candidates remain.


### PR DESCRIPTION
## Summary
- add RESEARCH_INDEX to catalog SOP artifacts by layer and track research/refinement status
- include PEIRRO-aligned research notes placeholders and refinement guardrails
- document stopping criteria for when artifacts are considered complete

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d50c84e7c8323afd9f8d626a7f39d)