### PR TITLE
Clarify runtime canon docs and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f brain/requirements.txt ]; then
+            pip install -r brain/requirements.txt
+          else
+            pip install pytest
+          fi
+
+      - name: Run tests
+        run: pytest brain/tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+This repository centers on the Runtime Canon in `sop/gpt-knowledge/`. Keep changes minimal and explicit so the canon stays trustworthy.
+
+## Safe Changes
+- Documentation and CI configuration updates are safe by default.
+- Runtime Canon (`sop/gpt-knowledge/`) changes should stay isolated and clearly documented; avoid altering SOP behavior unless explicitly requested.
+- Brain code, prompts, and database logic should not be modified for routine documentation updates.
+
+## How to Validate Changes
+Run these commands from the repository root:
+- Unit tests: `python -m pytest brain/tests`
+- Brain smoke check (creates/updates local SQLite): `python brain/db_setup.py`
+
+If you add dependencies, document how to install them alongside these commands.
+
+## Pull Request Expectations
+- Keep Runtime Canon edits in their own commits or PR sections so reviewers can audit them separately.
+- Update documentation when terminology or version messaging changes.
+- Include before/after notes for any SOP-facing text so reviewers can spot intent quickly.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
-> Runtime Canon is sop/gpt-knowledge/
-> If this document conflicts with Runtime Canon, Runtime Canon wins.
-> This README mirrors the Runtime Canon stored in `sop/gpt-knowledge/`.
-
-## Repository Authority Chain
-
-- Runtime Canon = `sop/gpt-knowledge/`.
-- Release snapshots are frozen copies when present.
-- If conflict: Runtime Canon wins.
-
 # PT Study SOP
 
 A structured study system for Doctor of Physical Therapy coursework, powered by the PEIRRO protocol.
 
-## Current Version: 9.1 "Structured Architect + Anatomy Engine" (development tag)
+## Source of Truth
 
-Version numbers track the development state of the SOP. Packaged release bundles may lag behind, and when in doubt the Runtime Canon in `sop/gpt-knowledge/` is the source of truth.
+- Runtime Canon: `sop/gpt-knowledge/`.
+- If any document conflicts with the Runtime Canon, the Runtime Canon wins.
+- Packaged bundle present in this repo: `v9.2/` (development snapshot). Runtime Canon remains authoritative when versions diverge.
+
+## Repository Authority Chain
+
+- Runtime Canon = `sop/gpt-knowledge/`.
+- Release snapshots (for example, `v9.2/`) are frozen copies when present.
+- If conflict: Runtime Canon wins.
 
 **Master Plan (North Star):** See `sop/MASTER_PLAN_PT_STUDY.md` for the stable vision, invariants, and contracts every release must honor.
 
@@ -26,8 +24,8 @@ Version numbers track the development state of the SOP. Packaged release bundles
 
 1. Open `sop/gpt-knowledge/README.md` for setup instructions
 2. From the repo root, run `python brain/db_setup.py` (Brain lives in the root repo; it is **not packaged** inside releases)
-3. Copy `GPT-INSTRUCTIONS.md` into your CustomGPT
-4. Upload all files from `sop/gpt-knowledge/` to GPT Knowledge (or upload the combined bundle in the same directory)
+3. Copy `sop/gpt-knowledge/gpt-instructions.md` into your CustomGPT system instructions
+4. Upload `sop/gpt-knowledge/` following `BUILD_ORDER.md`, and paste `runtime-prompt.md` at session start
 5. Start studying
 
 **One-click launcher:** Run `Run_Brain_All.bat` (repo root) to sync logs, regenerate resume, start the dashboard server, and open http://127.0.0.1:5000 automatically. Keep the new "PT Study Brain Dashboard" window open while using the site.
@@ -83,7 +81,7 @@ pt-study-sop/
 
 ---
 
-## What's New in v9.1
+## Highlights from v9.1 snapshot
 
 - **Planning Phase (M0):** Mandatory target/sources/plan before teaching
 - **Anatomy Engine:** Bone-first protocol with visual landmark recognition

--- a/sop/gpt-knowledge/README.md
+++ b/sop/gpt-knowledge/README.md
@@ -1,0 +1,27 @@
+# Runtime Canon (sop/gpt-knowledge/)
+
+This folder is the authoritative Runtime Canon for the PT Study SOP. If other documentation differs, use this directory as the source of truth.
+
+## Quick Start
+- Paste `gpt-instructions.md` into your Custom GPT system instructions.
+- Paste `runtime-prompt.md` at the start of each session.
+- Upload files following the order in `BUILD_ORDER.md`.
+
+## Key Files
+
+| File | Purpose |
+| ---- | ------- |
+| `PEIRRO.md` | Core PEIRRO protocol overview. |
+| `KWIK.md` | Rapid recall strategy and coaching cues. |
+| `M0-planning.md` | PEIRRO M0: planning gates and checks. |
+| `M1-entry.md` | PEIRRO M1: entry questions and readiness checks. |
+| `M2-prime.md` | PEIRRO M2: priming and target locking. |
+| `M3-encode.md` | PEIRRO M3: encoding flows and note patterns. |
+| `M4-build.md` | PEIRRO M4: build/testing steps. |
+| `M5-modes.md` | PEIRRO M5: mode selection and switches. |
+| `M6-wrap.md` | PEIRRO M6: WRAP/retention routines. |
+| `anatomy-engine.md` | Bone-first anatomy engine protocol. |
+| `BUILD_ORDER.md` | Upload sequencing for GPT Knowledge. |
+| `DEPLOYMENT_CHECKLIST.md` | Final checks before deploying or sharing bundles. |
+| `runtime-prompt.md` | Session-starter prompt to keep GPT aligned. |
+| `gpt-instructions.md` | System instructions to load into Custom GPT. |


### PR DESCRIPTION
## Summary
- clarify source-of-truth messaging and version context in the root README
- add runtime canon onboarding README plus contribution guidance and validation steps
- add CI workflow to install dependencies and run pytest on pushes and pull requests

## Testing
- python -m pytest brain/tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e247c0c0c83238d01a3c6abb04f88)