### PR TITLE
Polish documentation and CI instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,8 @@ jobs:
             pip install -r requirements.txt
           elif [ -f brain/requirements.txt ]; then
             pip install -r brain/requirements.txt
-          else
-            pip install pytest
           fi
+          pip install pytest
 
       - name: Run tests
-        run: pytest brain/tests
+        run: python -m pytest brain/tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ This repository centers on the Runtime Canon in `sop/gpt-knowledge/`. Keep chang
 Run these commands from the repository root:
 - Unit tests: `python -m pytest brain/tests`
 - Brain smoke check (creates/updates local SQLite): `python brain/db_setup.py`
+- CI runs `python -m pytest brain/tests` on pushes and pull requests.
 
-If you add dependencies, document how to install them alongside these commands.
+If you add dependencies, document how to install them alongside these commands. When in doubt, align wording and behavior to the Runtime Canon in `sop/gpt-knowledge/`.
 
 ## Pull Request Expectations
 - Keep Runtime Canon edits in their own commits or PR sections so reviewers can audit them separately.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,11 @@
 
 A structured study system for Doctor of Physical Therapy coursework, powered by the PEIRRO protocol.
 
-## Source of Truth
+## Source of Truth / Authority Chain
 
-- Runtime Canon: `sop/gpt-knowledge/`.
-- If any document conflicts with the Runtime Canon, the Runtime Canon wins.
-- Packaged bundle present in this repo: `v9.2/` (development snapshot). Runtime Canon remains authoritative when versions diverge.
-
-## Repository Authority Chain
-
-- Runtime Canon = `sop/gpt-knowledge/`.
-- Release snapshots (for example, `v9.2/`) are frozen copies when present.
-- If conflict: Runtime Canon wins.
+- Runtime Canon: `sop/gpt-knowledge/` (authoritative for all instructions).
+- Packaged bundle present in this repo: `v9.2/` (development snapshot). If anything conflicts, the Runtime Canon wins.
+- Release snapshots are frozen copies when present; they remain subordinate to the Runtime Canon.
 
 **Master Plan (North Star):** See `sop/MASTER_PLAN_PT_STUDY.md` for the stable vision, invariants, and contracts every release must honor.
 
@@ -20,13 +14,11 @@ A structured study system for Doctor of Physical Therapy coursework, powered by 
 
 ## Quick Start
 
-**Runtime canon lives in:** `sop/gpt-knowledge/`
-
-1. Open `sop/gpt-knowledge/README.md` for setup instructions
-2. From the repo root, run `python brain/db_setup.py` (Brain lives in the root repo; it is **not packaged** inside releases)
-3. Copy `sop/gpt-knowledge/gpt-instructions.md` into your CustomGPT system instructions
-4. Upload `sop/gpt-knowledge/` following `BUILD_ORDER.md`, and paste `runtime-prompt.md` at session start
-5. Start studying
+1. Read `sop/gpt-knowledge/README.md`.
+2. Paste `sop/gpt-knowledge/gpt-instructions.md` into your Custom GPT system instructions.
+3. Upload `sop/gpt-knowledge/` files in the order listed in `BUILD_ORDER.md`.
+4. Paste `sop/gpt-knowledge/runtime-prompt.md` at the start of each session.
+5. Run `python brain/db_setup.py` (or `Run_Brain_All.bat`) from the repo root for Brain setup.
 
 **One-click launcher:** Run `Run_Brain_All.bat` (repo root) to sync logs, regenerate resume, start the dashboard server, and open http://127.0.0.1:5000 automatically. Keep the new "PT Study Brain Dashboard" window open while using the site.
 
@@ -39,10 +31,10 @@ A structured study system for Doctor of Physical Therapy coursework, powered by 
 ## Repository Structure
 
 pt-study-sop/
-- v9.2/ (current development bundle)
+- v9.2/ (development snapshot bundle)
 - sop/ (source / development; Runtime Canon in `sop/gpt-knowledge/`)
   - MASTER_PLAN_PT_STUDY.md
-  - RESEARCH_TOPICS.md
+  - RESEARCH_INDEX.md
   - modules/
   - frameworks/
   - methods/
@@ -83,7 +75,7 @@ pt-study-sop/
 
 ---
 
-## Highlights from v9.1 snapshot
+## Highlights from the current canon (v9.2 development snapshot)
 
 - **Planning Phase (M0):** Mandatory target/sources/plan before teaching
 - **Anatomy Engine:** Bone-first protocol with visual landmark recognition
@@ -99,10 +91,10 @@ pt-study-sop/
 | Document | Purpose |
 |----------|---------|
 | `sop/gpt-knowledge/README.md` | Setup and usage guide (Runtime Canon) |
-| `sop/MASTER.md` | Complete system reference |
+| `sop/gpt-knowledge/MASTER.md` | Complete system reference |
 | `sop/MASTER_PLAN_PT_STUDY.md` | Stable North Star vision/invariants/contracts |
-| `sop/CHANGELOG.md` | Version history |
-| `sop/RESEARCH_TOPICS.md` | Learning science research topics |
+| `sop/MASTER_REFERENCE_v9.2.md` | Detailed reference for the v9.2 development snapshot |
+| `sop/RESEARCH_INDEX.md` | Learning science research topics and sourcing |
 | `sop/working/ROADMAP.md` | Current gaps and next steps |
 
 ---
@@ -113,7 +105,7 @@ pt-study-sop/
 
 ## Links
 - GitHub: https://github.com/Treytucker05/pt-study-sop
-- Current Development Bundle: v9.2/
+- Development snapshot bundle: v9.2/
 
 
 

--- a/sop/gpt-knowledge/README.md
+++ b/sop/gpt-knowledge/README.md
@@ -3,23 +3,25 @@
 This folder is the authoritative Runtime Canon for the PT Study SOP. If other documentation differs, use this directory as the source of truth.
 
 ## Quick Start
-- Paste `gpt-instructions.md` into your Custom GPT system instructions.
-- Paste `runtime-prompt.md` at the start of each session.
-- Upload files following the order in `BUILD_ORDER.md`.
+1. Read this `README.md`.
+2. Paste `gpt-instructions.md` into your Custom GPT system instructions.
+3. Upload files following the order in `BUILD_ORDER.md`.
+4. Paste `runtime-prompt.md` at the start of each session.
+5. Run `python brain/db_setup.py` (or `Run_Brain_All.bat`) from the repo root for Brain setup.
 
 ## Key Files
 
 | File | Purpose |
 | ---- | ------- |
-| `PEIRRO.md` | Core PEIRRO protocol overview. |
-| `KWIK.md` | Rapid recall strategy and coaching cues. |
-| `M0-planning.md` | PEIRRO M0: planning gates and checks. |
-| `M1-entry.md` | PEIRRO M1: entry questions and readiness checks. |
-| `M2-prime.md` | PEIRRO M2: priming and target locking. |
-| `M3-encode.md` | PEIRRO M3: encoding flows and note patterns. |
-| `M4-build.md` | PEIRRO M4: build/testing steps. |
-| `M5-modes.md` | PEIRRO M5: mode selection and switches. |
-| `M6-wrap.md` | PEIRRO M6: WRAP/retention routines. |
+| `PEIRRO.md` | PEIRRO learning cycle overview. |
+| `KWIK.md` | Encoding flow: Sound → Function → Image → Resonance → Lock. |
+| `M0-planning.md` | Execution Module (M0): planning gates and checks. |
+| `M1-entry.md` | Execution Module (M1): entry questions and readiness checks. |
+| `M2-prime.md` | Execution Module (M2): priming and target locking. |
+| `M3-encode.md` | Execution Module (M3): encoding flows and note patterns. |
+| `M4-build.md` | Execution Module (M4): build/testing steps. |
+| `M5-modes.md` | Execution Module (M5): mode selection and switches. |
+| `M6-wrap.md` | Execution Module (M6): WRAP/retention routines. |
 | `anatomy-engine.md` | Bone-first anatomy engine protocol. |
 | `BUILD_ORDER.md` | Upload sequencing for GPT Knowledge. |
 | `DEPLOYMENT_CHECKLIST.md` | Final checks before deploying or sharing bundles. |


### PR DESCRIPTION
## Summary
- clarify runtime canon authority, quick start, and documentation references
- align runtime canon README descriptions with encoding and execution module terminology
- update contributing and CI workflow to use consistent pytest command and installation

## Testing
- Not run (documentation and CI configuration updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e2e46b7508323a851e1b4084184e3)