### PR TITLE
Fix trends tests for Python 3.10 timezone compatibility

### DIFF
--- a/brain/tests/test_trends.py
+++ b/brain/tests/test_trends.py
@@ -1,5 +1,5 @@
 import sys
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -32,9 +32,9 @@ def sample_sessions(temp_db):
     conn = db_setup.get_connection()
     cursor = conn.cursor()
     rows = [
-            ("2024-02-15", "10:00", "Topic B", "Sprint", 50, "", "No", "No", 3, 4, 4, 4, "", "", "", datetime.now(UTC).isoformat()),
-            ("2024-01-01", "09:00", "Topic C", "Drill", 30, "", "No", "No", 1, 2, 2, 2, "", "", "", datetime.now(UTC).isoformat()),
-            ("2023-12-31", "20:00", "Topic A", "Core", 40, "", "No", "No", 2, 5, 5, 5, "", "", "", datetime.now(UTC).isoformat()),
+            ("2024-02-15", "10:00", "Topic B", "Sprint", 50, "", "No", "No", 3, 4, 4, 4, "", "", "", datetime.now(timezone.utc).isoformat()),
+            ("2024-01-01", "09:00", "Topic C", "Drill", 30, "", "No", "No", 1, 2, 2, 2, "", "", "", datetime.now(timezone.utc).isoformat()),
+            ("2023-12-31", "20:00", "Topic A", "Core", 40, "", "No", "No", 2, 5, 5, 5, "", "", "", datetime.now(timezone.utc).isoformat()),
     ]
     cursor.executemany(
         """


### PR DESCRIPTION
### Motivation
- Restore test compatibility with Python 3.10 by avoiding the unavailable `datetime.UTC` attribute and ensuring timezone-aware timestamps.

### Description
- Replace `from datetime import datetime, UTC` with `from datetime import datetime, timezone` and update `datetime.now(UTC)` to `datetime.now(timezone.utc)` in `brain/tests/test_trends.py`.

### Testing
- Ran `pytest brain/tests/test_trends.py -q` which passed, and `pytest brain/tests -q` which passed all tests (77 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa867ba508323b92a46b4b6641806)