### PR TITLE
fix: use gpt-5.3-codex default for ChatGPT backend calls

### DIFF
--- a/brain/llm_provider.py
+++ b/brain/llm_provider.py
@@ -553,7 +553,7 @@ def call_chatgpt_responses(
     system_prompt: str,
     user_prompt: str,
     *,
-    model: str = "gpt-5.1",
+    model: str = "gpt-5.3-codex",
     timeout: int = 120,
     web_search: bool = False,
 ) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

- Fix Tutor Priming RUN silently producing no output.
- Root cause: `call_chatgpt_responses` defaulted to `model="gpt-5.1"`, which ChatGPT-account Codex auth rejects with `400 {"detail":"The 'gpt-5.1' model is not supported when using Codex with a ChatGPT account."}`.
- `/tutor/workflows/<id>/priming-assist` swallowed the per-material error into a `failures` list the frontend does not surface, so the panel rendered empty blocks and a success toast.
- Default now matches `stream_chatgpt_responses` and scholar: `gpt-5.3-codex`.

## Verification

- Seeded a test material + course, POSTed `/api/tutor/workflows/.../priming-assist` with `M-PRE-010` and `M-PRE-008` before and after the change.
- Before: `failures=[{...gpt-5.1 not supported...}]`, all method runs empty, aggregate empty.
- After: full `priming_method_runs` with learning objectives, concepts, follow-up targets, and a map outline; aggregate populated.
- Pre-push gate (fast backend test suite) passed.

## Reviewer notes

- One-line default change in `brain/llm_provider.py`; no other call sites rely on the old default (this function is the only caller that passed through without specifying a model, via `_call_codex`).
- Separate UX gap — the frontend ignores the response's `failures` array — is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)