### PR TITLE
Persist FLOATING STUDIO entry card dismissal across navigations

### DIFF
--- a/dashboard_rebuild/client/src/hooks/useStudioRun.ts
+++ b/dashboard_rebuild/client/src/hooks/useStudioRun.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   TutorAccuracyProfile,
@@ -7,7 +7,9 @@ import type {
 } from "@/lib/api";
 import type { TutorBrainLaunchContext } from "@/lib/tutorClientState";
 import {
+  readTutorEntryCardDismissed,
   writeTutorAccuracyProfile,
+  writeTutorEntryCardDismissed,
   writeTutorObjectiveScope,
   writeTutorSelectedMaterialIds,
   writeTutorStoredStartState,
@@ -118,7 +120,15 @@ export function useStudioRun({
   const [tutorCustomBlockIds, setTutorCustomBlockIds] = useState<number[]>(
     customBlockIds,
   );
-  const [showSetup, setShowSetup] = useState<boolean>(() => !Boolean(initialSessionId));
+  // Initial showSetup is `false` if (a) we already have a session id to resume,
+  // (b) the user has previously dismissed the entry card on this device — so
+  // navigating away and back doesn't pop the FLOATING STUDIO modal again.
+  const [showSetup, setShowSetup] = useState<boolean>(
+    () =>
+      !Boolean(initialSessionId) &&
+      !readTutorEntryCardDismissed() &&
+      !shouldSuppressStoredSessionResume,
+  );
   const [brainLaunchContext, setBrainLaunchContext] =
     useState<TutorBrainLaunchContext | null>(
       pendingLaunchHandoff.brainLaunchContext,
@@ -137,6 +147,21 @@ export function useStudioRun({
   const entryKind: StudioRunEntryKind = activeSessionId
     ? "exact_resume"
     : "workspace_home";
+
+  // Persist the dismissal of the FLOATING STUDIO entry card. Once the user
+  // closes it (or a session gets resumed), don't pop it again on the next
+  // mount until they explicitly open a new session via the hero button.
+  const showSetupRef = useRef<boolean>(showSetup);
+  useEffect(() => {
+    const prev = showSetupRef.current;
+    showSetupRef.current = showSetup;
+    if (prev === showSetup) return;
+    if (prev === true && showSetup === false) {
+      writeTutorEntryCardDismissed(true);
+    } else if (prev === false && showSetup === true) {
+      writeTutorEntryCardDismissed(false);
+    }
+  }, [showSetup]);
 
   useEffect(() => {
     if (!persistStartState) return;

--- a/dashboard_rebuild/client/src/lib/tutorClientState.ts
+++ b/dashboard_rebuild/client/src/lib/tutorClientState.ts
@@ -8,6 +8,7 @@ export const TUTOR_START_STATE_LEGACY_KEY = "tutor.wizard.state.v1";
 export const TUTOR_ACCURACY_PROFILE_KEY = "tutor.accuracy_profile.v1";
 export const TUTOR_OBJECTIVE_SCOPE_KEY = "tutor.objective_scope.v1";
 export const TUTOR_ACTIVE_SESSION_KEY = "tutor.active_session.v1";
+export const TUTOR_ENTRY_CARD_DISMISSED_KEY = "tutor.entry_card_dismissed.v1";
 export const TUTOR_LIBRARY_HANDOFF_KEY = "tutor.open_from_library.v1";
 export const TUTOR_BRAIN_HANDOFF_KEY = "tutor.open_from_brain.v1";
 export const TUTOR_VAULT_FOLDER_KEY = "tutor.vault_folder.v1";
@@ -356,6 +357,31 @@ export function clearTutorActiveSessionId(
 ) {
   try {
     storage.removeItem(TUTOR_ACTIVE_SESSION_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function readTutorEntryCardDismissed(
+  storage: Pick<Storage, "getItem"> = window.localStorage,
+): boolean {
+  try {
+    return storage.getItem(TUTOR_ENTRY_CARD_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeTutorEntryCardDismissed(
+  dismissed: boolean,
+  storage: Pick<Storage, "setItem" | "removeItem"> = window.localStorage,
+): void {
+  try {
+    if (dismissed) {
+      storage.setItem(TUTOR_ENTRY_CARD_DISMISSED_KEY, "1");
+    } else {
+      storage.removeItem(TUTOR_ENTRY_CARD_DISMISSED_KEY);
+    }
   } catch {
     // Ignore storage failures.
   }

--- a/dashboard_rebuild/client/src/pages/tutor.tsx
+++ b/dashboard_rebuild/client/src/pages/tutor.tsx
@@ -30,6 +30,7 @@ import {
   consumeTutorLaunchHandoff,
   peekTutorLaunchHandoff,
   readTutorActiveSessionId,
+  readTutorEntryCardDismissed,
   readTutorSelectedMaterialIds,
   readTutorStoredStartState,
   writeTutorObjectiveScope,
@@ -835,7 +836,14 @@ function useTutorPageController() {
       }
     }
 
-    setShowSetup(true);
+    // Respect a prior dismissal of the FLOATING STUDIO entry card. If the
+    // user previously closed it on this device and there's nothing to resume,
+    // leave the entry card hidden so navigating away and back doesn't pop it
+    // again. They can re-open it any time via the hero NEW SESSION button,
+    // which clears the dismissal flag.
+    if (!readTutorEntryCardDismissed()) {
+      setShowSetup(true);
+    }
     const canonicalMaterialSelection = readTutorSelectedMaterialIds();
     if (canonicalMaterialSelection.length > 0) {
       hub.setSelectedMaterials(canonicalMaterialSelection);


### PR DESCRIPTION
## Summary
Fixes issue #3 from the user's three-issue list: navigating away from the Tutor page and coming back used to re-open the FLOATING STUDIO entry card every time, even right after the user clicked X to dismiss it. Now the dismissal is persisted to localStorage so the card stays hidden until the user explicitly asks for it via the hero **NEW SESSION** button.

## Why
The card is meant to be an opt-in "start a fresh session" launcher, not something that auto-pops on every mount. The user explicitly asked: "If I go to another page and come back to the tutor it should pick up where I left off, not pop up with the floating studio screen."

## What changed
- New `tutor.entry_card_dismissed.v1` localStorage key, plus `read/writeTutorEntryCardDismissed` helpers in `lib/tutorClientState.ts`.
- `useStudioRun` initializes `showSetup` to `false` when the user has previously dismissed and there's nothing to resume. A `useEffect` watches `showSetup` transitions to keep the flag in sync — `true → false` writes `dismissed=true`, `false → true` clears it. Hitting the hero **NEW SESSION** button (which goes through `resetTutorWorkspaceHome` → `setShowSetup(true)`) therefore re-opens the card cleanly.
- `tutor.tsx`'s mount-time `restoreTutorShellState` no longer unconditionally calls `setShowSetup(true)` when no session is resumable. It now skips that call if the dismissal flag is set.

## Verified live (dev-browser headless)
| Step | FLOATING STUDIO visible | Dismissed flag |
|---|---|---|
| Fresh visit, flag cleared | ✅ visible | `null` |
| Click X to dismiss | ❌ hidden | `"1"` |
| **Reload** | ❌ **still hidden** | `"1"` |
| Click hero NEW SESSION | ✅ visible | `null` (cleared) |

Pipeline zones still render correctly after reload (8/8). No regressions in the toolbar or workspace sidebar.

## Test plan
- [ ] `vitest run` — no behavior changes outside the new helpers; existing useStudioRun and tutor tests should still pass.
- [ ] Reload the dashboard with a clean cache. Expect the FLOATING STUDIO modal.
- [ ] Click the X. Modal goes away.
- [ ] Click any other nav link, then come back to /tutor. Modal should stay closed; you land on the Studio Canvas with the toolbar visible.
- [ ] Click the hero **NEW SESSION** button. Modal re-opens.
- [ ] Start a session from the modal, then navigate away and back. Session resumes (no modal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)