### PR TITLE
Restore studio panel layout from project shell on mount

### DIFF
--- a/dashboard_rebuild/client/src/pages/tutor.tsx
+++ b/dashboard_rebuild/client/src/pages/tutor.tsx
@@ -45,6 +45,7 @@ import {
 import { normalizeStudioPolishPromotedNotes } from "@/lib/studioPacketSections";
 import {
   normalizeStudioDocumentTabs,
+  normalizeStudioPanelLayout,
 } from "@/lib/studioPanelLayout";
 import {
   normalizeStudioRunRuntimeState,
@@ -366,6 +367,15 @@ function useTutorPageController() {
         setActiveBoardId(nextProjectShell.workspace_state.active_board_id);
       }
       setViewerState(nextProjectShell.workspace_state.viewer_state || null);
+      // Restore the floating panel layout (positions, sizes, collapsed state,
+      // groupings) from the server. Without this, every navigation to /tutor
+      // wiped the canvas because the persisted panel_layout was never read
+      // back even though it was being saved on every change.
+      setPanelLayout(
+        normalizeStudioPanelLayout(
+          nextProjectShell.workspace_state.panel_layout,
+        ),
+      );
       setDocumentTabs(
         normalizeStudioDocumentTabs(
           nextProjectShell.workspace_state.document_tabs,
@@ -417,13 +427,21 @@ function useTutorPageController() {
     },
     [
       activeBoardScope,
+      hub,
       initialRouteQuery,
-      setPromotedPolishPacketNotes,
+      setActiveBoardId,
+      setActiveBoardScope,
       setActiveDocumentTabId,
       setDocumentTabs,
+      setPanelLayout,
+      setPromotedPolishPacketNotes,
+      setPromotedPrimePacketObjects,
       setRuntimeState,
+      setShellHydratedCourseId,
+      setShellRevision,
       setTutorChainId,
       setTutorCustomBlockIds,
+      setViewerState,
     ],
   );
 


### PR DESCRIPTION
## Summary
Fixes "the canvas was reset, none of the windows were on the canvas when I flipped back" — every time the user navigated away from /tutor and came back, the floating panel layout was wiped because `hydrateProjectShellState` never read the persisted `panel_layout` back from the server, even though `persistProjectShellState` was saving it on every change.

## Why
`hydrateProjectShellState` was hydrating almost every part of the project shell (board scope, board id, viewer state, document tabs, runtime state, tutor chain, packet promoted objects, selected materials) — but had no `setPanelLayout` call. So `panelLayout` always came up as `[]` on mount and stayed empty until the user manually re-opened panels. The save side was working; only the restore side was missing.

## What changed
- `hydrateProjectShellState` now calls `setPanelLayout(normalizeStudioPanelLayout(nextProjectShell.workspace_state.panel_layout))` so panel positions, sizes, collapsed state, and groupings restore from the server.
- Imported `normalizeStudioPanelLayout` from `@/lib/studioPanelLayout`.
- Tightened the callback's dep array to include the setters it already touches (`setActiveBoardId`, `setActiveBoardScope`, `setPanelLayout`, `setPromotedPrimePacketObjects`, `setShellHydratedCourseId`, `setShellRevision`, `setViewerState`, `hub`).

## Verified live
Used dev-browser headless against the integration build:
1. Saved a `source_shelf` panel via the API directly.
2. Loaded `/tutor` in headless Chromium.
3. Confirmed the panel rendered after the load.
4. Reloaded the tab.
5. Confirmed the panel **still rendered** — not wiped.

The save path (existing `persistProjectShellState` debounce → PUT `/tutor/project-shell/state`) is unchanged.

## Test plan
- [ ] `vitest run` — should still pass (no API/contract changes).
- [ ] Open the dashboard, open a few panels, drag one around.
- [ ] Click any other nav link, then come back to /tutor.
- [ ] Panels should be back exactly where you left them, not gone.
- [ ] Hard reload the tab. Same panels should reappear.

## Notes for reviewer
- This is independent of the dismissal-persistence fix in [#146](https://github.com/Treytucker05/pt-study-sop/pull/146); together they make a navigation-and-back round-trip leave both the entry-card state and the panel layout exactly as the user left them.
- No changes to the persistence side. If the server `panel_layout` is `[]`, hydration sets `[]` (correct).
- `panel_layout` is typed loosely as `Record<string, unknown>[]` on the server-response side; `normalizeStudioPanelLayout` filters it through the existing `isStudioPanelLayoutItem` guard so we never push malformed entries into state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)