### PR TITLE
Address PR #143 Copilot review — preset hints + explicit zone order

### DIFF
--- a/dashboard_rebuild/client/src/components/studio/StudioShell.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioShell.tsx
@@ -118,13 +118,41 @@ const PANEL_STAGE_MAP: Record<string, PipelineStage> = {
   memory: "settings",
 };
 
+// Explicit display order within each pipeline stage. Action chips come before
+// their packet artifacts (e.g. Priming before Prime Packet) so the toolbar
+// reads "do X, then look at the packet X produced". Without this, ordering
+// would silently follow whatever order panels happen to appear in
+// `panelDefinitions`, which is fragile.
+const STAGE_PANEL_ORDER: Record<PipelineStage, readonly string[]> = {
+  load: ["source_shelf"],
+  read: ["document_dock"],
+  prime: ["priming_chat", "prime_packet"],
+  tutor: ["tutor_chat", "polish_packet"],
+  polish: ["polish_chat"],
+  export: ["obsidian", "anki"],
+  workbench: ["workspace", "notes"],
+  settings: ["run_config", "memory"],
+};
+
 const LAYOUT_PRESETS: { key: StudioShellPreset; label: string; hint: string }[] =
   [
-    { key: "priming", label: "Prime", hint: "Sources + Workspace + Prime Packet" },
-    { key: "study", label: "Study", hint: "Live tutoring set" },
-    { key: "polish", label: "Polish", hint: "Polish + outputs" },
+    {
+      key: "priming",
+      label: "Prime",
+      hint: "Sources + Doc + Priming + Prime Packet + Run Config",
+    },
+    {
+      key: "study",
+      label: "Study",
+      hint: "Doc + Workspace + Tutor + Memory",
+    },
+    {
+      key: "polish",
+      label: "Polish",
+      hint: "Polish + Polish Packet + Workspace",
+    },
     { key: "full_studio", label: "Full Studio", hint: "Every panel" },
-    { key: "minimal", label: "Minimal", hint: "Bare canvas" },
+    { key: "minimal", label: "Minimal", hint: "Tutor only" },
   ];
 
 const PRESET_PANEL_KEYS: Record<StudioShellPreset, string[]> = {
@@ -1623,10 +1651,16 @@ export function StudioShell({
               className="flex flex-wrap items-stretch gap-0"
             >
               {PIPELINE_STAGES.map((stage, stageIndex) => {
-                const stagePanels = panelDefinitions.filter(
-                  (definition) =>
-                    PANEL_STAGE_MAP[definition.panel] === stage.key,
-                );
+                const stagePanels = STAGE_PANEL_ORDER[stage.key]
+                  .map((panelKey) =>
+                    panelDefinitions.find(
+                      (definition) => definition.panel === panelKey,
+                    ),
+                  )
+                  .filter(
+                    (definition): definition is StudioPanelDefinition =>
+                      Boolean(definition),
+                  );
                 if (stagePanels.length === 0) return null;
                 return (
                   <Fragment key={stage.key}>
@@ -1687,20 +1721,24 @@ export function StudioShell({
                 );
               })}
 
-              {SIDE_CLUSTERS.map((cluster, clusterIndex) => {
-                const clusterPanels = panelDefinitions.filter(
-                  (definition) =>
-                    PANEL_STAGE_MAP[definition.panel] === cluster.key,
-                );
+              <div className="ml-auto" aria-hidden="true" />
+              {SIDE_CLUSTERS.map((cluster) => {
+                const clusterPanels = STAGE_PANEL_ORDER[cluster.key]
+                  .map((panelKey) =>
+                    panelDefinitions.find(
+                      (definition) => definition.panel === panelKey,
+                    ),
+                  )
+                  .filter(
+                    (definition): definition is StudioPanelDefinition =>
+                      Boolean(definition),
+                  );
                 if (clusterPanels.length === 0) return null;
                 return (
                   <div
                     key={cluster.key}
                     data-testid={`studio-toolbar-zone-${cluster.key}`}
-                    className={cn(
-                      "flex flex-col gap-1.5 border-l border-dashed border-[rgba(255,118,144,0.16)] pl-3 px-2.5 py-1",
-                      clusterIndex === 0 && "ml-auto",
-                    )}
+                    className="flex flex-col gap-1.5 border-l border-dashed border-[rgba(255,118,144,0.16)] pl-3 px-2.5 py-1"
                   >
                     <span className="font-mono text-[9px] uppercase tracking-[0.24em] text-[rgba(255,201,213,0.44)]">
                       {cluster.label}


### PR DESCRIPTION
## Summary
Follow-up to [#143](https://github.com/Treytucker05/pt-study-sop/pull/143) addressing Copilot's review notes that didn't make it into the squash merge.

## Why
1. The Layout dropdown hint copy didn't match what `PRESET_PANEL_KEYS` actually opens — "Prime" claimed it opened "Sources + Workspace + Prime Packet" but the preset opens Document Dock, Priming, and Run Config and doesn't open Workspace. "Minimal" claimed "Bare canvas" but the preset opens Tutor.
2. Within-zone panel order was inferred from declaration order in `panelDefinitions`, which is fragile. Producer chips need to come before their packet artifacts (Priming before Prime Packet, Tutor before Polish Packet) and that should be explicit.

## What changed
- **Layout preset hints** now mirror `PRESET_PANEL_KEYS` exactly (`"Doc + Workspace + Tutor + Memory"` for Study, `"Tutor only"` for Minimal, etc.).
- **`STAGE_PANEL_ORDER` map** added; both pipeline-row and side-cluster renders now look up panels by this map instead of filtering `panelDefinitions`. Order is intentional and a future re-shuffle of `panelDefinitions` cannot accidentally swap producer/packet chips.
- Replaced the `clusterIndex === 0 && "ml-auto"` rule with a dedicated spacer `<div className="ml-auto" />` before the side-clusters loop, so layout doesn't break if the first cluster filters to zero panels.

## Test plan
- [ ] `vitest run client/src/components/studio` — unchanged from `main` (same single pre-existing zoom-slider failure).
- [ ] `tsc --noEmit -p tsconfig.json` introduces no new errors.
- [ ] Open the toolbar's Layout dropdown; confirm hints match what each preset actually opens.
- [ ] Close the workbench cluster (e.g. by removing both Workspace and Notes from `panelDefinitions` or `PANEL_STAGE_MAP`); confirm the settings cluster still aligns to the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)