### PR TITLE
Land Document Dock clips on the Workspace canvas + persist them

### DIFF
--- a/dashboard_rebuild/client/src/components/TutorShell.tsx
+++ b/dashboard_rebuild/client/src/components/TutorShell.tsx
@@ -29,8 +29,13 @@ import type {
 import type { StudioRunRuntimeState } from "@/lib/studioRunRuntimeState";
 import {
   buildStudioWorkspaceObjects,
+  normalizeStudioWorkspaceObjects,
   type StudioWorkspaceObject,
 } from "@/lib/studioWorkspaceObjects";
+import {
+  readTutorWorkspaceDraftObjects,
+  writeTutorWorkspaceDraftObjects,
+} from "@/lib/tutorClientState";
 import {
   buildPolishPacketSections,
   buildPrimePacketSections,
@@ -427,6 +432,15 @@ export function TutorShell({
   const [workspaceDraftObjects, setWorkspaceDraftObjects] = useState<
     StudioWorkspaceObject[]
   >([]);
+  const [hydratedDraftCourseId, setHydratedDraftCourseId] = useState<number | null>(
+    null,
+  );
+  const lastWorkspaceResetVersionRef = useRef<number>(0);
+  const [workspaceTabRequest, setWorkspaceTabRequest] = useState<{
+    tab: "canvas" | "mind-map" | "concept-map";
+    requestKey: number;
+  } | null>(null);
+  const workspaceTabRequestCounterRef = useRef<number>(3_000_000);
   const [localDocumentTabs, setLocalDocumentTabs] = useState<StudioDocumentTab[]>(
     controlledDocumentTabs ?? [],
   );
@@ -773,13 +787,83 @@ export function TutorShell({
       setViewerState,
     ],
   );
-  const handleClipExcerpt = useCallback((workspaceObject: StudioWorkspaceObject) => {
-    setWorkspaceDraftObjects((prev) =>
-      prev.some((existingObject) => existingObject.id === workspaceObject.id)
-        ? prev
-        : [...prev, workspaceObject],
+  const handleClipExcerpt = useCallback(
+    (workspaceObject: StudioWorkspaceObject) => {
+      setWorkspaceDraftObjects((prev) =>
+        prev.some((existingObject) => existingObject.id === workspaceObject.id)
+          ? prev
+          : [...prev, workspaceObject],
+      );
+      // Make sure the user actually sees the clip land. Spawn the Workspace
+      // panel if it isn't open yet, and switch its inner tab to the tldraw
+      // Canvas (where clipped objects render). Without this, clips disappeared
+      // into a closed panel or a non-Canvas tab.
+      setPanelLayout((current) => {
+        if (current.some((item) => item.panel === "workspace")) {
+          return current;
+        }
+        const nextZIndex =
+          current.reduce(
+            (highest, item) => Math.max(highest, item.zIndex || 0),
+            0,
+          ) + 1;
+        return [
+          ...current,
+          {
+            id: "panel-workspace",
+            panel: "workspace",
+            position: { x: 1090, y: 120 },
+            size: { width: 940, height: 760 },
+            zIndex: nextZIndex,
+            collapsed: false,
+          },
+        ];
+      });
+      workspaceTabRequestCounterRef.current += 1;
+      setWorkspaceTabRequest({
+        tab: "canvas",
+        requestKey: workspaceTabRequestCounterRef.current,
+      });
+    },
+    [setPanelLayout],
+  );
+
+  // Hydrate workspaceDraftObjects from localStorage when courseId resolves.
+  // Prevents clips from disappearing when the user navigates away and back.
+  // Uses state (not a ref) for the hydration sentinel so that the persist
+  // effect below sees the hydrated workspaceDraftObjects on the same render
+  // it sees `hydratedDraftCourseId === hub.courseId` — otherwise the persist
+  // effect would fire with the stale empty state and clobber localStorage.
+  useEffect(() => {
+    const courseId = hub.courseId;
+    if (typeof courseId !== "number") return;
+    if (hydratedDraftCourseId === courseId) return;
+    const stored = normalizeStudioWorkspaceObjects(
+      readTutorWorkspaceDraftObjects(courseId),
     );
-  }, []);
+    setWorkspaceDraftObjects((current) => {
+      if (stored.length === 0) return current;
+      if (current.length === 0) return stored;
+      const merged = [...current];
+      const seen = new Set(current.map((item) => item.id));
+      for (const obj of stored) {
+        if (!seen.has(obj.id)) {
+          merged.push(obj);
+          seen.add(obj.id);
+        }
+      }
+      return merged;
+    });
+    setHydratedDraftCourseId(courseId);
+  }, [hub.courseId, hydratedDraftCourseId]);
+
+  // Persist workspaceDraftObjects on every change so a reload restores them.
+  // Gated on hydration completion so the initial empty state from React's
+  // useState default doesn't blow away whatever is in localStorage.
+  useEffect(() => {
+    if (hydratedDraftCourseId !== hub.courseId) return;
+    writeTutorWorkspaceDraftObjects(hub.courseId, workspaceDraftObjects);
+  }, [hub.courseId, hydratedDraftCourseId, workspaceDraftObjects]);
   useEffect(() => {
     if (!activeDocumentTabId) return;
     const activeTab = documentTabs.find((tab) => tab.id === activeDocumentTabId);
@@ -1253,11 +1337,21 @@ export function TutorShell({
     setShowSetup(false);
   }, [setShowSetup]);
 
+  // Reset workspace state when an explicit reset is requested (workspaceResetVersion
+  // increments). Tracking the version itself instead of also depending on
+  // `setNotesDraft` — which is recreated on every parent render — prevents
+  // the effect from re-firing and wiping fresh hydrated state (e.g. clipped
+  // workspace objects pulled from localStorage).
   useEffect(() => {
     if (!hasAppliedInitialWorkspaceResetRef.current) {
       hasAppliedInitialWorkspaceResetRef.current = true;
+      lastWorkspaceResetVersionRef.current = workspaceResetVersion;
       return;
     }
+    if (lastWorkspaceResetVersionRef.current === workspaceResetVersion) {
+      return;
+    }
+    lastWorkspaceResetVersionRef.current = workspaceResetVersion;
     setCanvasObjectIds([]);
     setWorkspaceDraftObjects([]);
     setLocalDocumentTabs([]);
@@ -1371,6 +1465,7 @@ export function TutorShell({
         courseId={hub.courseId ?? null}
         courseName={sourceShelfCourseName || null}
         conceptMapImportRequest={conceptMapImportRequest}
+        workspaceTabRequest={workspaceTabRequest}
         currentRunObjects={currentRunWorkspaceObjects}
         promotedPrimeObjectIds={promotedPrimeObjectIds}
         selectedMaterialCount={hub.selectedMaterials.length}

--- a/dashboard_rebuild/client/src/components/studio/StudioWorkspaceUnified.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioWorkspaceUnified.tsx
@@ -20,6 +20,10 @@ type StudioWorkspaceUnifiedProps = StudioTldrawWorkspaceProps & {
     mermaid: string;
     requestKey: number;
   } | null;
+  workspaceTabRequest?: {
+    tab: WorkspaceTabId;
+    requestKey: number;
+  } | null;
   sessionMaterialBundle?: SessionMaterialBundle;
 };
 
@@ -51,6 +55,7 @@ export function StudioWorkspaceUnified({
   courseId,
   vaultFolder,
   conceptMapImportRequest,
+  workspaceTabRequest,
   sessionMaterialBundle,
   ...canvasProps
 }: StudioWorkspaceUnifiedProps) {
@@ -67,6 +72,7 @@ export function StudioWorkspaceUnified({
   const conceptMapCommandCounterRef = useRef<number>(1_000_000);
   const conceptMapSessionSeedKeyRef = useRef<string | null>(null);
   const addItemCommandCounterRef = useRef<number>(2_000_000);
+  const lastWorkspaceTabRequestKeyRef = useRef<number | null>(null);
 
   const handleSelectTab = (nextTab: WorkspaceTabId) => {
     setActiveTab(nextTab);
@@ -93,6 +99,26 @@ export function StudioWorkspaceUnified({
       payload: conceptMapImportRequest?.mermaid || "",
     });
   }, [conceptMapImportRequest]);
+
+  // External tab-switch request — used by the Document Dock clip flow so a
+  // freshly clipped excerpt actually shows up on the tldraw Canvas tab where
+  // it renders, instead of staying invisible on Mind Map / Concept Map.
+  useEffect(() => {
+    const requestKey = workspaceTabRequest?.requestKey;
+    const tab = workspaceTabRequest?.tab;
+    if (
+      typeof requestKey !== "number" ||
+      lastWorkspaceTabRequestKeyRef.current === requestKey ||
+      !tab
+    ) {
+      return;
+    }
+    lastWorkspaceTabRequestKeyRef.current = requestKey;
+    setActiveTab(tab);
+    setVisitedTabs((current) =>
+      current[tab] ? current : { ...current, [tab]: true },
+    );
+  }, [workspaceTabRequest]);
 
   const sessionConceptMapMermaid = useMemo(() => {
     if (!sessionMaterialBundle?.isReady) return "";

--- a/dashboard_rebuild/client/src/lib/tutorClientState.ts
+++ b/dashboard_rebuild/client/src/lib/tutorClientState.ts
@@ -9,6 +9,7 @@ export const TUTOR_ACCURACY_PROFILE_KEY = "tutor.accuracy_profile.v1";
 export const TUTOR_OBJECTIVE_SCOPE_KEY = "tutor.objective_scope.v1";
 export const TUTOR_ACTIVE_SESSION_KEY = "tutor.active_session.v1";
 export const TUTOR_ENTRY_CARD_DISMISSED_KEY = "tutor.entry_card_dismissed.v1";
+export const TUTOR_WORKSPACE_DRAFT_OBJECTS_KEY = "tutor.workspace_draft_objects.v1";
 export const TUTOR_LIBRARY_HANDOFF_KEY = "tutor.open_from_library.v1";
 export const TUTOR_BRAIN_HANDOFF_KEY = "tutor.open_from_brain.v1";
 export const TUTOR_VAULT_FOLDER_KEY = "tutor.vault_folder.v1";
@@ -381,6 +382,43 @@ export function writeTutorEntryCardDismissed(
       storage.setItem(TUTOR_ENTRY_CARD_DISMISSED_KEY, "1");
     } else {
       storage.removeItem(TUTOR_ENTRY_CARD_DISMISSED_KEY);
+    }
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function workspaceDraftObjectsStorageKey(courseId: number): string {
+  return `${TUTOR_WORKSPACE_DRAFT_OBJECTS_KEY}:${courseId}`;
+}
+
+export function readTutorWorkspaceDraftObjects(
+  courseId: number | null | undefined,
+  storage: Pick<Storage, "getItem"> = window.localStorage,
+): unknown[] {
+  if (typeof courseId !== "number") return [];
+  try {
+    const raw = storage.getItem(workspaceDraftObjectsStorageKey(courseId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeTutorWorkspaceDraftObjects(
+  courseId: number | null | undefined,
+  objects: unknown[],
+  storage: Pick<Storage, "setItem" | "removeItem"> = window.localStorage,
+): void {
+  if (typeof courseId !== "number") return;
+  const key = workspaceDraftObjectsStorageKey(courseId);
+  try {
+    if (!Array.isArray(objects) || objects.length === 0) {
+      storage.removeItem(key);
+    } else {
+      storage.setItem(key, JSON.stringify(objects));
     }
   } catch {
     // Ignore storage failures.


### PR DESCRIPTION
## Summary
Fixes "When I clip from document doc it is not going to the workspace." Clips now reliably show up on the tldraw Canvas tab inside the Workspace panel — the panel auto-opens, the Canvas tab auto-activates, and the clipped objects survive navigation away and back.

## Why
The wiring from StudioDocumentDock through `handleClipExcerpt` into `workspaceDraftObjects` and on into tldraw shape sync was already correct. The actual gaps were three:

1. **Clips were invisible.** If the Workspace panel wasn't open, or the user was on Mind Map / Concept Map tab, the clip landed in state but rendered offscreen.
2. **Clips never survived navigation.** `workspaceDraftObjects` was pure local state with no save side, so navigating away wiped them.
3. **Latent reset bug.** The workspace-reset `useEffect` at line 1339 depended on `setNotesDraft`, an inline arrow recreated every parent render. After the initial mount-skip ref ran, every parent re-render re-fired the effect and cleared `workspaceDraftObjects`, masking any persistence work.

## What changed
- New `tutor.workspace_draft_objects.v1:<courseId>` localStorage helpers (`read/writeTutorWorkspaceDraftObjects`) in `lib/tutorClientState.ts`, keyed per course.
- `TutorShell` hydrates `workspaceDraftObjects` from localStorage when `hub.courseId` resolves, using a `hydratedDraftCourseId` state sentinel so the persist effect can't clobber the stored value before hydration's setState propagates.
- `TutorShell` persists `workspaceDraftObjects` on every change once hydration completes.
- On clip, `handleClipExcerpt` auto-spawns the Workspace panel into `panelLayout` (with the same default position/size as `StudioShell`'s panel definition) if it isn't already open, and emits a `workspaceTabRequest` switching `StudioWorkspaceUnified` to the Canvas tab.
- New `workspaceTabRequest` prop on `StudioWorkspaceUnified` mirroring the existing `conceptMapImportRequest` pattern (`{ tab, requestKey }`); the inner `useEffect` watches the ref-tracked key and switches `activeTab` once per request.
- Fixed the workspace-reset `useEffect` so it only runs when `workspaceResetVersion` actually increments — it now tracks the last applied version in `lastWorkspaceResetVersionRef`. Previously the dep on `setNotesDraft` made it fire on every parent render and silently wipe `workspaceDraftObjects` (and the other workspace state it resets).

## Test plan
- [ ] `vitest run client/src/components/studio` — same 3 pre-existing failures.
- [ ] `tsc --noEmit -p tsconfig.json` introduces no new errors (only the pre-existing TutorShell test typing + StudioShell type-predicate issues remain).
- [ ] Open the dashboard, navigate to /tutor.
- [ ] Open a document in Document Dock, select text, click Clip.
- [ ] Workspace panel should open if not already open; Canvas tab should activate; clip should appear as a tldraw shape.
- [ ] Navigate to /library, then back to /tutor.
- [ ] Workspace panel reopens (via PR #147 panel-layout hydrate) and the previously clipped objects are still on the tldraw canvas.
- [ ] Hard reload the tab. Same clips reappear.
- [ ] Click "Clear Canvas" — clips and panels are cleared and localStorage entry is wiped.

## Notes for reviewer
- The localStorage approach is intentionally client-side only for now; the project-shell server save path doesn't yet have a `workspace_draft_objects` field. Adding one is a future enhancement that would let clips sync across devices, but for the user's complaint (single-device navigation persistence) localStorage is enough.
- The reset-effect fix is small but pre-existing; if you want it isolated I can split it to its own PR. It was the root cause that made every other persistence attempt look broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)