### PR TITLE
Fix priming first-run output not rendering in the Priming panel

### DIFF
--- a/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
+++ b/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@/api.types";
 import { ObsidianRenderer } from "@/components/ObsidianRenderer";
 import {
+  migratePrimingPanelSessionState,
   setPrimingPanelSessionState,
   usePrimingPanelSessionState,
   type PrimingChatTurn,
@@ -764,6 +765,20 @@ export function TutorWorkflowPrimingPanel({
     workflow?.active_tutor_session_id,
     workflow?.workflow_id,
   ]);
+  // When the panel re-keys (e.g. a freshly-created workflow_id replaces the
+  // course/material fallback key DURING a run), migrate any pending or
+  // displayed state to the new key. Without this, the first priming run on a
+  // brand-new workflow silently loses its `pendingMethodResult` because the
+  // falling-edge display effect reads from the new key, which hasn't seen
+  // pendingMethodResult set under the old key.
+  const previousPrimingPanelStateKeyRef = useRef<string>(primingPanelStateKey);
+  if (previousPrimingPanelStateKeyRef.current !== primingPanelStateKey) {
+    migratePrimingPanelSessionState(
+      previousPrimingPanelStateKeyRef.current,
+      primingPanelStateKey,
+    );
+    previousPrimingPanelStateKeyRef.current = primingPanelStateKey;
+  }
   const primingPanelState = usePrimingPanelSessionState(primingPanelStateKey);
   const {
     pendingMethodResult,

--- a/dashboard_rebuild/client/src/components/priming/primingPanelState.ts
+++ b/dashboard_rebuild/client/src/components/priming/primingPanelState.ts
@@ -104,6 +104,55 @@ export function setPrimingPanelSessionState(
   emitPrimingPanelSessionChange(key);
 }
 
+/**
+ * Read a panel state without subscribing — used during a key change to migrate
+ * pending state from the old key to the new key. Without this, kicking off a
+ * priming run before a workflow exists silently loses the in-flight
+ * `pendingMethodResult` (and the just-finished display) because the panel
+ * re-keys from `course:...` to `workflow:<id>` mid-run, and the new key starts
+ * at the default empty state.
+ */
+export function peekPrimingPanelSessionState(
+  key: string,
+): PrimingPanelSessionState {
+  return ensurePrimingPanelSessionState(key);
+}
+
+function isDefaultPrimingPanelSessionState(
+  state: PrimingPanelSessionState,
+): boolean {
+  return (
+    state.pendingMethodResult === null &&
+    state.displayedRun === null &&
+    state.runningChain === false &&
+    state.chatInput === "" &&
+    state.chatTurns.length === 0 &&
+    state.sendingChat === false &&
+    state.revealedConceptMapBlockIds.length === 0
+  );
+}
+
+/**
+ * Move panel state from one key to another. Only migrates when the destination
+ * key is still at default — never clobbers an existing state.
+ */
+export function migratePrimingPanelSessionState(
+  fromKey: string,
+  toKey: string,
+): boolean {
+  if (fromKey === toKey) return false;
+  const fromState = primingPanelStateByKey.get(fromKey);
+  if (!fromState) return false;
+  if (isDefaultPrimingPanelSessionState(fromState)) return false;
+  const toState = primingPanelStateByKey.get(toKey);
+  if (toState && !isDefaultPrimingPanelSessionState(toState)) return false;
+  primingPanelStateByKey.set(toKey, fromState);
+  primingPanelStateByKey.delete(fromKey);
+  emitPrimingPanelSessionChange(toKey);
+  emitPrimingPanelSessionChange(fromKey);
+  return true;
+}
+
 export function resetPrimingPanelSessionState(key?: string) {
   if (typeof key === "string" && key.trim().length > 0) {
     primingPanelStateByKey.delete(key);


### PR DESCRIPTION
## Summary
Reproduced bug: open /tutor with no active workflow, select a priming method, click Run. Output never shows in the Priming panel. Click Run a **second** time → output shows correctly.

## Root cause
The Priming panel state is keyed externally:
- `workflow:<id>` once a workflow exists
- otherwise a course/material fallback (`course:<id>:materials:<scope>:topic:<topic>`)

On the first run, `runPrimingAssist` internally calls `ensureStudioPrimingWorkflow()`, which **creates** the workflow mid-run. The panel state key flips from `course:1:materials:42:topic:` to `workflow:abc123` between:

1. the click handler that sets `pendingMethodResult` (under the OLD key)
2. the falling-edge `useEffect` that turns `pendingMethodResult` into a `displayedRun` (now reads under the NEW key, which is at default empty state)

Result: the falling-edge effect bails on `if (!pendingMethodResult) return` and the run output is dropped on the floor.

Second run works because by then `workflow_id` already exists and the key is stable from click through completion.

## What changed
- New `migratePrimingPanelSessionState(fromKey, toKey)` in `primingPanelState.ts`. Moves state from one key to another **only when the destination is at default** — never clobbers existing state.
- New `peekPrimingPanelSessionState(key)` helper for non-subscribing reads.
- In `TutorWorkflowPrimingPanel`, track the previous key in a ref and migrate during render whenever the key changes. Done during render (not in an effect) so the migrated state is visible to the `useSyncExternalStore` subscription on the same render cycle that resolved the new key.

## Test plan
- [x] `vitest run TutorWorkflowPrimingPanel.test.tsx` — 9/9 pass.
- [ ] Open /tutor on a course with no active workflow.
- [ ] Pick a priming method, click Run. The panel should now show the run output (it didn't before this PR).
- [ ] Click Run again. Output continues to update on each subsequent run.
- [ ] Manual session continuity: existing tutor sessions keyed by `workflow:<id>` keep their displayed run across page reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)