### PR TITLE
Reorder Priming panel: chain at top, methods middle, run at bottom

### DIFF
--- a/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
+++ b/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
@@ -837,12 +837,12 @@ export function TutorWorkflowPrimingPanel({
     setCustomBlockIds([]);
   }, [chainId, customBlockIds.length, setCustomBlockIds]);
 
-  useEffect(() => {
-    if (typeof chainId !== "number" || primingMethods.length === 0) {
-      return;
-    }
-    setPrimingMethods([]);
-  }, [chainId, primingMethods, setPrimingMethods]);
+  // Previously a useEffect cleared `primingMethods` whenever a chain was
+  // selected to keep "chain mode" and "method mode" mutually exclusive. The
+  // new flow inverts that: picking a chain *populates* method checkboxes from
+  // the chain's blocks (see handleChainSelectionChange). The user can then
+  // tweak which methods to actually run. Manual method toggling clears the
+  // chain selection (see handleToggleMethod). No clearing effect needed.
 
   useEffect(() => {
     const wasRunning = previousAssistRunningRef.current;
@@ -921,7 +921,22 @@ export function TutorWorkflowPrimingPanel({
     if (!Number.isFinite(parsedChainId)) {
       return;
     }
-    setPrimingMethods([]);
+    // Resolve the chain's blocks back to PRIME method_ids so picking a chain
+    // auto-checks the matching method cards. The chain block carries a numeric
+    // `id` matching `primeMethod.id`; we look up the string `method_id` so the
+    // checkbox UI (keyed by method_id) reflects the chain.
+    const selectedChainDefinition = templateChains.find(
+      (chain) => chain.id === parsedChainId,
+    );
+    const chainMethodIds = (selectedChainDefinition?.blocks ?? [])
+      .map((block) => {
+        const primeMethod = primeMethods.find(
+          (method) => method.id === block.id,
+        );
+        return primeMethod?.method_id ?? null;
+      })
+      .filter((value): value is string => Boolean(value));
+    setPrimingMethods(chainMethodIds);
     setChainId(parsedChainId);
     setCustomBlockIds([]);
   };
@@ -1154,6 +1169,29 @@ export function TutorWorkflowPrimingPanel({
             )}
           </div>
 
+          <label className="block">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[#ffb9c7]/76">
+              Optional Chain Mode
+            </div>
+            <select
+              aria-label="Priming chain"
+              data-testid="priming-chain-selector"
+              value={typeof chainId === "number" ? String(chainId) : ""}
+              onChange={(event) => handleChainSelectionChange(event.target.value)}
+              disabled={templateChainsLoading}
+              className="mt-2 h-11 w-full rounded-[0.85rem] border border-[rgba(255,118,144,0.18)] bg-black/30 px-3 text-sm text-white outline-none"
+            >
+              <option value="">
+                {templateChainsLoading ? "Loading chains..." : "Select a chain instead of method cards"}
+              </option>
+              {templateChains.map((chain) => (
+                <option key={chain.id} value={chain.id}>
+                  {chain.name || `Chain #${chain.id}`}
+                </option>
+              ))}
+            </select>
+          </label>
+
           <div className="space-y-3">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
@@ -1300,30 +1338,7 @@ export function TutorWorkflowPrimingPanel({
             </div>
           </div>
 
-          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-            <label className="block">
-              <div className="text-[10px] uppercase tracking-[0.18em] text-[#ffb9c7]/76">
-                Optional Chain Mode
-              </div>
-              <select
-                aria-label="Priming chain"
-                data-testid="priming-chain-selector"
-                value={typeof chainId === "number" ? String(chainId) : ""}
-                onChange={(event) => handleChainSelectionChange(event.target.value)}
-                disabled={templateChainsLoading}
-                className="mt-2 h-11 w-full rounded-[0.85rem] border border-[rgba(255,118,144,0.18)] bg-black/30 px-3 text-sm text-white outline-none"
-              >
-                <option value="">
-                  {templateChainsLoading ? "Loading chains..." : "Select a chain instead of method cards"}
-                </option>
-                {templateChains.map((chain) => (
-                  <option key={chain.id} value={chain.id}>
-                    {chain.name || `Chain #${chain.id}`}
-                  </option>
-                ))}
-              </select>
-            </label>
-
+          <div className="flex justify-end">
             <Button
               type="button"
               data-testid="priming-run-button"

--- a/dashboard_rebuild/client/src/components/__tests__/TutorWorkflowPrimingPanel.test.tsx
+++ b/dashboard_rebuild/client/src/components/__tests__/TutorWorkflowPrimingPanel.test.tsx
@@ -199,6 +199,98 @@ describe("TutorWorkflowPrimingPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("auto-checks the chain's methods when a chain is selected", async () => {
+    const setPrimingMethodsMock = vi.fn();
+    renderPanel({
+      setPrimingMethods: setPrimingMethodsMock,
+      templateChains: [
+        {
+          id: 7,
+          name: "Quick prime",
+          description: "",
+          context_tags: "",
+          blocks: [
+            {
+              id: 201,
+              name: "Learning Objectives Primer",
+              category: "prepare",
+              duration: 8,
+            },
+            {
+              id: 202,
+              name: "Structural Extraction",
+              category: "prepare",
+              duration: 12,
+            },
+          ],
+        },
+      ],
+    });
+
+    await waitFor(() => expect(getPrimeMethodsMock).toHaveBeenCalledWith("PRIME"));
+
+    fireEvent.change(
+      screen.getByRole("combobox", { name: /priming chain/i }),
+      { target: { value: "7" } },
+    );
+
+    expect(setPrimingMethodsMock).toHaveBeenLastCalledWith([
+      "M-PRE-010",
+      "M-PRE-013",
+    ]);
+  });
+
+  it("clears the chain selection when the user manually toggles a method", async () => {
+    const setChainIdMock = vi.fn();
+    renderPanel({
+      chainId: 7,
+      setChainId: setChainIdMock,
+      templateChains: [
+        {
+          id: 7,
+          name: "Quick prime",
+          description: "",
+          context_tags: "",
+          blocks: [
+            {
+              id: 201,
+              name: "Learning Objectives Primer",
+              category: "prepare",
+              duration: 8,
+            },
+          ],
+        },
+      ],
+    });
+
+    await waitFor(() => expect(getPrimeMethodsMock).toHaveBeenCalledWith("PRIME"));
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /structural extraction/i }),
+    );
+
+    expect(setChainIdMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("renders the chain selector above the method cards and the run button below them", async () => {
+    renderPanel();
+
+    await waitFor(() => expect(getPrimeMethodsMock).toHaveBeenCalledWith("PRIME"));
+
+    const chainSelect = screen.getByRole("combobox", { name: /priming chain/i });
+    const methodGrid = screen.getByTestId("priming-method-card-grid");
+    const runButton = screen.getByTestId("priming-run-button");
+
+    expect(
+      chainSelect.compareDocumentPosition(methodGrid) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      methodGrid.compareDocumentPosition(runButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("shows selected state for more than one method card", async () => {
     renderPanel({
       primingMethods: ["M-PRE-010", "M-PRE-013"],


### PR DESCRIPTION
## Summary
Step 2 of the Priming/Workspace overhaul. Re-orders the Priming panel so chain selection drives method selection top-to-bottom, matching the user's mental model: pick a chain → see what methods it activates → hit Run.

Three behavior changes, each test-driven (RED → GREEN, vertical slice).

## What changed

| Behavior | Before | After |
|---|---|---|
| Chain selector position | tucked under the method grid, sharing a row with Run | sits above the method grid as the first input the user sees |
| Picking a chain | cleared `primingMethods` to `[]` (chain mode and method mode mutually exclusive) | auto-checks the chain's methods by resolving `chain.blocks[].id` → `primeMethod.method_id` |
| Toggling a method while a chain is active | (already did this via `handleToggleMethod`) but had no test to pin it | now pinned by a regression test |

Also removed the now-stale `useEffect` that cleared `primingMethods` when `chainId` was set — under the new flow that effect would erase the chain's auto-checked methods immediately.

## Tests
- `TutorWorkflowPrimingPanel.test.tsx` was 9/9 → 12/12. Three new tests:
  1. **Tracer:** chain selector DOM-precedes method card grid which DOM-precedes run button.
  2. Picking a chain calls `setPrimingMethods` with the chain's resolved method IDs.
  3. Manually toggling a method while a chain is active clears `chainId`.

Each test was written first, watched fail, then minimum code to pass.

## Test plan
- [ ] `vitest run TutorWorkflowPrimingPanel.test.tsx` — 12/12.
- [ ] `tsc --noEmit -p tsconfig.json` — same pre-existing errors as `main`, no new ones.
- [ ] Open the dashboard, navigate to /tutor, open the Priming panel.
- [ ] Confirm the chain dropdown sits above the PRIME Methods card grid.
- [ ] Confirm the Run button sits below all method cards (own row, right-aligned).
- [ ] Pick a chain from the dropdown — its method cards should auto-check.
- [ ] Manually uncheck one of those methods — the chain dropdown should drop back to "Select a chain".

## Notes
- This is part of a multi-PR effort (#150 priming first-run fix already merged). Next planned PRs in this stream:
  - Step 3: Stage-for-Run button consolidation on Source Shelf + Document Dock.
  - Step 4: Workspace stage badges + sidebar drag-to-canvas.
  - Steps 5/6: Prime Packet / Polish Packet → read-only filtered views over existing state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)