### PR TITLE
Drop Send to Workspace from text-only priming result blocks

### DIFF
--- a/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
+++ b/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
@@ -1446,14 +1446,21 @@ export function TutorWorkflowPrimingPanel({
                       <Sparkles className="mr-2 h-3.5 w-3.5" />
                       Send to Prime Packet
                     </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => handleSendToWorkspace(block)}
-                      className="rounded-full border-[rgba(255,118,144,0.18)] bg-black/20 px-4 font-mono text-[10px] uppercase tracking-[0.18em] text-[#ffd9e1]"
-                    >
-                      Send to Workspace
-                    </Button>
+                    {/* "Send to Workspace" only renders for visual / graph-buildable
+                        result kinds. Text-only blocks (objectives, summaries,
+                        terms, generic) flow into the Prime Packet only — the
+                        Workspace canvas is reserved for things the user
+                        constructs visually (concept maps, sketches, mind maps). */}
+                    {block.kind === "concept_map" ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleSendToWorkspace(block)}
+                        className="rounded-full border-[rgba(255,118,144,0.18)] bg-black/20 px-4 font-mono text-[10px] uppercase tracking-[0.18em] text-[#ffd9e1]"
+                      >
+                        Send to Workspace
+                      </Button>
+                    ) : null}
                   </div>
                 </article>
               ))}

--- a/dashboard_rebuild/client/src/components/__tests__/TutorWorkflowPrimingPanel.test.tsx
+++ b/dashboard_rebuild/client/src/components/__tests__/TutorWorkflowPrimingPanel.test.tsx
@@ -199,6 +199,75 @@ describe("TutorWorkflowPrimingPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides Send to Workspace on text-only result blocks", async () => {
+    setPrimingPanelSessionState("workflow:wf-123", (current) => ({
+      ...current,
+      displayedRun: {
+        key: "method:M-PRE-010:1",
+        label: "Learning Objectives Primer",
+        kind: "method",
+        methodId: "M-PRE-010",
+        blocks: [
+          {
+            id: "block-1",
+            title: "Learning Objectives",
+            badge: "OBJECTIVES",
+            kind: "objectives",
+            sourceLabel: "Cardiac Output Lecture",
+            content: "Differentiate stroke volume modifiers",
+            materialId: 101,
+            objectives: [
+              { lo_code: "LO-1", title: "Differentiate stroke volume modifiers" },
+            ],
+          },
+        ],
+      },
+    }));
+    renderPanel();
+
+    await waitFor(() => expect(getPrimeMethodsMock).toHaveBeenCalledWith("PRIME"));
+
+    expect(
+      screen.getByRole("button", { name: /send to prime packet/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /send to workspace/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps both Send to Prime Packet and Send to Workspace on concept_map blocks", async () => {
+    setPrimingPanelSessionState("workflow:wf-123", (current) => ({
+      ...current,
+      displayedRun: {
+        key: "method:M-PRE-013:1",
+        label: "Concept Map",
+        kind: "method",
+        methodId: "M-PRE-013",
+        blocks: [
+          {
+            id: "block-graph-1",
+            title: "Cardiac Concept Map",
+            badge: "CONCEPT MAP",
+            kind: "concept_map",
+            sourceLabel: "Cardiac Output Lecture",
+            content: "graph TD\n  A[Heart] --> B[Stroke Volume]",
+            materialId: 101,
+          },
+        ],
+      },
+    }));
+    renderPanel();
+
+    await waitFor(() => expect(getPrimeMethodsMock).toHaveBeenCalledWith("PRIME"));
+
+    expect(
+      screen.getByRole("button", { name: /send to prime packet/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /send to workspace/i }),
+    ).toBeInTheDocument();
+  });
+
   it("auto-checks the chain's methods when a chain is selected", async () => {
     const setPrimingMethodsMock = vi.fn();
     renderPanel({
@@ -668,17 +737,13 @@ describe("TutorWorkflowPrimingPanel", () => {
       }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /send to workspace/i }));
-    expect(onSendResultToWorkspace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: "text_note",
-        title: expect.stringContaining("Learning Objectives"),
-        badge: "OBJECTIVES",
-        provenance: expect.objectContaining({
-          sourceType: "priming_result",
-        }),
-      }),
-    );
+    // Text-only result blocks (objectives) don't expose a Send to Workspace
+    // button — Workspace canvas is reserved for visual constructs. The
+    // onSendResultToWorkspace callback should remain unfired for this flow.
+    expect(
+      screen.queryByRole("button", { name: /send to workspace/i }),
+    ).not.toBeInTheDocument();
+    expect(onSendResultToWorkspace).not.toHaveBeenCalled();
   });
 
   it("enables Priming chat after RUN, sends a follow-up, and applies revised results", async () => {


### PR DESCRIPTION
## Summary
Step 3 of the Priming/Workspace overhaul. Hides the "Send to Workspace" button on priming result blocks where it doesn't make sense (text content), keeping it only on `concept_map` blocks where it actually places a graph on the tldraw canvas.

## Why
From the architectural pass with the user: Workspace canvas is for visual constructs (concept maps, sketches, mind maps). Today's priming result cards expose **both** "Send to Prime Packet" and "Send to Workspace" on every block. For text content (objectives, summaries, terms, generic), the second button is noise — it places raw text where it doesn't belong and confuses the staging-vs-synthesis distinction.

User's words: "I think the workspace button was really originally for things that were built into graphs and things like that."

## What changed
| Block kind | Before | After |
|---|---|---|
| `objectives` | both buttons | Send to Prime Packet only |
| `summary` | both buttons | Send to Prime Packet only |
| `terms` | both buttons | Send to Prime Packet only |
| `generic` | both buttons | Send to Prime Packet only |
| `concept_map` | both buttons | both buttons (unchanged) |

`onSendResultToWorkspace` callback contract is unchanged — it just doesn't get a button to fire it from text-only blocks.

## Tests (TDD, vertical slices)
- New: text-only `objectives` block exposes only Send to Prime Packet, not Send to Workspace.
- New: `concept_map` block keeps both buttons.
- Existing test that clicked Send to Workspace on an objectives result was updated to assert the button is absent and the callback is never invoked.

`TutorWorkflowPrimingPanel.test.tsx` 14/14 (was 12/12; +2 new, 1 updated).

## Test plan
- [x] `vitest run TutorWorkflowPrimingPanel.test.tsx` — 14/14.
- [ ] Open the dashboard, run a priming method that produces text content (e.g. learning objectives).
- [ ] Confirm only "Send to Prime Packet" is shown on the result card.
- [ ] Run a method that produces a concept map.
- [ ] Confirm both buttons are present on that result card.

## Notes
Part of the multi-PR overhaul. Already merged: #150 (priming first-run fix), #151 (priming layout). Next planned:
- Step 4: Workspace stage badges + sidebar drag-to-canvas.
- (Pause for re-plan with user)
- Steps 5/6: Prime Packet / Polish Packet → read-only filtered views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)