### PR TITLE
Show pipeline stage chip on each Material sidebar item

### DIFF
--- a/dashboard_rebuild/client/src/components/studio/StudioWorkspaceMaterialSidebar.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioWorkspaceMaterialSidebar.tsx
@@ -453,8 +453,18 @@ export function StudioWorkspaceMaterialSidebar({
                             className="group flex flex-col gap-1 rounded-md border border-primary/10 bg-black/30 px-2 py-1.5 transition-colors hover:border-primary/25 hover:bg-primary/8"
                           >
                             <div className="flex items-start justify-between gap-2">
-                              <span className="font-mono text-[11px] leading-snug text-foreground/88">
-                                {item.title}
+                              <span className="flex min-w-0 items-start gap-1.5">
+                                <span
+                                  className={cn(
+                                    "mt-0.5 shrink-0 rounded-full border px-1.5 py-px font-mono text-[8px] uppercase tracking-[0.16em]",
+                                    STAGE_BADGE_CLASS[section.stage],
+                                  )}
+                                >
+                                  {section.stage.toUpperCase()}
+                                </span>
+                                <span className="font-mono text-[11px] leading-snug text-foreground/88">
+                                  {item.title}
+                                </span>
                               </span>
                               <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
                                 {canAddToCanvas && onAddToCanvas ? (

--- a/dashboard_rebuild/client/src/components/studio/__tests__/StudioWorkspaceMaterialSidebar.test.tsx
+++ b/dashboard_rebuild/client/src/components/studio/__tests__/StudioWorkspaceMaterialSidebar.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StudioWorkspaceMaterialSidebar } from "@/components/studio/StudioWorkspaceMaterialSidebar";
+import type { SessionMaterialBundle } from "@/lib/sessionMaterialBundle";
+
+function buildBundle(
+  overrides: Partial<SessionMaterialBundle> = {},
+): SessionMaterialBundle {
+  return {
+    isReady: true,
+    sessionKey: "test-session",
+    topic: null,
+    studyUnit: null,
+    courseId: 1,
+    courseName: null,
+    learningObjectives: [],
+    concepts: [],
+    terms: [],
+    summaries: [],
+    rootExplanations: [],
+    gaps: [],
+    artifacts: [],
+    turnCount: 0,
+    primePacket: [],
+    polishPacket: [],
+    notes: [],
+    ...overrides,
+  };
+}
+
+describe("StudioWorkspaceMaterialSidebar", () => {
+  it("renders a stage chip on each material item showing which pipeline stage it belongs to", () => {
+    const bundle = buildBundle({
+      primePacket: [
+        {
+          id: "promoted-excerpt-1",
+          kind: "excerpt",
+          title: "Stroke volume modifiers",
+          detail: "Pre-load, after-load, contractility, and heart rate.",
+          badge: "EXCERPT",
+          provenance: {
+            materialId: 101,
+            sourcePath: "/tmp/cardio.pdf",
+            fileType: "pdf",
+            sourceTitle: "Cardiac Output",
+            selectionLabel: null,
+          },
+        },
+      ],
+      concepts: [
+        {
+          concept: "Stroke volume",
+          materialId: null,
+          sourceTitle: null,
+        },
+      ],
+    });
+
+    render(<StudioWorkspaceMaterialSidebar bundle={bundle} />);
+
+    const primeItem = screen.getByTestId(
+      "studio-workspace-material-item-prime-excerpt-promoted-excerpt-1",
+    );
+    expect(primeItem).toHaveTextContent(/PRIME/);
+
+    const conceptItem = screen.getByTestId(
+      "studio-workspace-material-item-concept-0",
+    );
+    expect(conceptItem).toHaveTextContent(/TUTOR/);
+  });
+});


### PR DESCRIPTION
## Summary
- Each item in the Workspace Material sidebar now renders a small inline stage badge ("LOAD", "PRIME", "TUTOR", "POLISH", "WORKBENCH"), so synthesis chunks visibly signal which workflow stage they came from.
- Reuses the existing stage palette (`STAGE_BADGE_CLASS`) for consistent color coding with the toolbar zones.
- This is step 4 of the post-priming-redesign plan, picked as the low-risk option (a) — no schema/state changes, no Prime/Polish Packet refactor yet.

## Test plan
- [x] New tracer test in `StudioWorkspaceMaterialSidebar.test.tsx` confirms a `primePacket` item renders "PRIME" and a concept item renders "TUTOR".
- [x] Studio + Priming suites: 55 passing locally; the 3 failures (`SourceShelf`, `StudioShell` zoom slider) reproduce on `origin/main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)