### PR TITLE
Add stage filter pills to Material sidebar

### DIFF
--- a/dashboard_rebuild/client/src/components/studio/StudioWorkspaceMaterialSidebar.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioWorkspaceMaterialSidebar.tsx
@@ -55,6 +55,26 @@ const STAGE_BADGE_CLASS: Record<MaterialSection["stage"], string> = {
   workbench: "border-pink-400/30 bg-pink-400/10 text-pink-200",
 };
 
+type StageFilter = "all" | MaterialSection["stage"];
+
+const STAGE_FILTER_ORDER: StageFilter[] = [
+  "all",
+  "load",
+  "prime",
+  "tutor",
+  "polish",
+  "workbench",
+];
+
+const STAGE_FILTER_LABEL: Record<StageFilter, string> = {
+  all: "All",
+  load: "Load",
+  prime: "Prime",
+  tutor: "Tutor",
+  polish: "Polish",
+  workbench: "Workbench",
+};
+
 // ── Section builders ─────────────────────────────────────────────────
 
 function snippet(text: string | null | undefined, limit = 140): string | null {
@@ -293,13 +313,18 @@ export function StudioWorkspaceMaterialSidebar({
     activeTabId === "mind-map" || activeTabId === "concept-map";
   const sections = useMemo(() => buildSections(bundle), [bundle]);
   const [query, setQuery] = useState("");
+  const [stageFilter, setStageFilter] = useState<StageFilter>("all");
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const filteredSections = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return sections;
-    return sections
+    const stageMatched =
+      stageFilter === "all"
+        ? sections
+        : sections.filter((section) => section.stage === stageFilter);
+    if (!q) return stageMatched;
+    return stageMatched
       .map((section) => ({
         ...section,
         items: section.items.filter((item) => {
@@ -308,7 +333,7 @@ export function StudioWorkspaceMaterialSidebar({
         }),
       }))
       .filter((section) => section.items.length > 0);
-  }, [query, sections]);
+  }, [query, sections, stageFilter]);
 
   const totalItems = useMemo(
     () => sections.reduce((sum, section) => sum + section.items.length, 0),
@@ -379,7 +404,7 @@ export function StudioWorkspaceMaterialSidebar({
         </div>
       </div>
 
-      <div className="shrink-0 border-b border-primary/10 px-3 py-2">
+      <div className="flex shrink-0 flex-col gap-2 border-b border-primary/10 px-3 py-2">
         <Input
           data-testid="studio-workspace-material-search"
           value={query}
@@ -388,6 +413,37 @@ export function StudioWorkspaceMaterialSidebar({
           aria-label="Search workspace material"
           className="h-8 border-primary/15 bg-black/40 font-mono text-xs"
         />
+        <div
+          role="tablist"
+          aria-label="Filter material by pipeline stage"
+          className="flex flex-wrap gap-1"
+        >
+          {STAGE_FILTER_ORDER.map((stage) => {
+            const isActive = stageFilter === stage;
+            const accent =
+              stage === "all"
+                ? "border-primary/30 bg-primary/10 text-primary"
+                : STAGE_BADGE_CLASS[stage];
+            return (
+              <button
+                key={stage}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                data-testid={`studio-workspace-material-stage-filter-${stage}`}
+                onClick={() => setStageFilter(stage)}
+                className={cn(
+                  "rounded-full border px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] transition-colors",
+                  isActive
+                    ? accent
+                    : "border-primary/15 bg-transparent text-foreground/52 hover:border-primary/25 hover:text-foreground/72",
+                )}
+              >
+                {STAGE_FILTER_LABEL[stage]}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       <ScrollArea className="flex-1 min-h-0">

--- a/dashboard_rebuild/client/src/components/studio/__tests__/StudioWorkspaceMaterialSidebar.test.tsx
+++ b/dashboard_rebuild/client/src/components/studio/__tests__/StudioWorkspaceMaterialSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { StudioWorkspaceMaterialSidebar } from "@/components/studio/StudioWorkspaceMaterialSidebar";
@@ -68,5 +68,67 @@ describe("StudioWorkspaceMaterialSidebar", () => {
       "studio-workspace-material-item-concept-0",
     );
     expect(conceptItem).toHaveTextContent(/TUTOR/);
+  });
+
+  it("filters items to a single pipeline stage when a stage pill is selected", () => {
+    const bundle = buildBundle({
+      primePacket: [
+        {
+          id: "promoted-excerpt-1",
+          kind: "excerpt",
+          title: "Stroke volume modifiers",
+          detail: "Pre-load, after-load, contractility, and heart rate.",
+          badge: "EXCERPT",
+          provenance: {
+            materialId: 101,
+            sourcePath: "/tmp/cardio.pdf",
+            fileType: "pdf",
+            sourceTitle: "Cardiac Output",
+            selectionLabel: null,
+          },
+        },
+      ],
+      concepts: [
+        {
+          concept: "Stroke volume",
+          materialId: null,
+          sourceTitle: null,
+        },
+      ],
+    });
+
+    render(<StudioWorkspaceMaterialSidebar bundle={bundle} />);
+
+    expect(
+      screen.getByTestId(
+        "studio-workspace-material-item-prime-excerpt-promoted-excerpt-1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("studio-workspace-material-item-concept-0"),
+    ).toBeInTheDocument();
+
+    const primePill = screen.getByTestId(
+      "studio-workspace-material-stage-filter-prime",
+    );
+    fireEvent.click(primePill);
+
+    expect(
+      screen.getByTestId(
+        "studio-workspace-material-item-prime-excerpt-promoted-excerpt-1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("studio-workspace-material-item-concept-0"),
+    ).not.toBeInTheDocument();
+
+    const allPill = screen.getByTestId(
+      "studio-workspace-material-stage-filter-all",
+    );
+    fireEvent.click(allPill);
+
+    expect(
+      screen.getByTestId("studio-workspace-material-item-concept-0"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a pill row to the Workspace Material sidebar (`All / Load / Prime / Tutor / Polish / Workbench`) so the user can narrow the list to a single pipeline stage.
- Picking `Prime` shows just the Prime Packet items, picking `Polish` shows just promoted polish notes — gives the same focused view that the standalone packet panels gave, without a second surface to manage.
- Reuses `STAGE_BADGE_CLASS` for consistent color cues; the active pill takes the stage's accent, the others sit muted.

## Scope
- This is half 1 of the Prime/Polish Packet → filtered-views plan.
- The standalone Prime Packet / Polish Packet floating panels are still wired in this PR — half 2 will remove them after the TutorShell test surface is migrated.

## Test plan
- [x] New RED→GREEN test in `StudioWorkspaceMaterialSidebar.test.tsx` covers: pill renders → click `Prime` → only Prime items remain → click `All` → everything returns.
- [x] Both stage-chip tests still pass.

## Base
- Stacked on top of [#153](https://github.com/Treytucker05/pt-study-sop/pull/153). Will retarget to `main` after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)