### PR TITLE
Connect workspace study loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ scripts/_ai_config_backups/
 # Scratch directories
 /tmp/
 /.codex_tmp/
+/scratch/
 
 # Playwright MCP screenshots (local only)
 .playwright-mcp/*.png

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,85 @@
 # Design System: PT Study OS
 
+## Active Site Source Map
+
+This is the current source map for the React dashboard. Edit source files only; built files under `brain/static/dist/` are generated output.
+
+### App Shell
+
+* `dashboard_rebuild/client/src/main.tsx` — React entrypoint; imports `App` and the active global stylesheet.
+* `dashboard_rebuild/client/src/App.tsx` — route table; maps `/library` to `dashboard_rebuild/client/src/pages/library.tsx`.
+* `dashboard_rebuild/client/src/components/layout.tsx` — global cockpit shell, top navigation, support nav image placement, notes dock, and the `page-hero-portal` that page heroes render into.
+* `dashboard_rebuild/client/src/components/PageScaffold.tsx` — shared page hero, title/subtitle/stat rail, and content wrapper used by Library and the other support pages.
+
+### Active Styling
+
+* `dashboard_rebuild/client/src/index.css` — active global CSS, Tailwind theme tokens, base font scale, `page-shell` styling, `brain-workspace` frame styling, and responsive shell behavior.
+* `dashboard_rebuild/client/src/lib/theme.ts` — shared Tailwind class tokens for typography, inputs, buttons, panels, icons, and semantic status colors.
+* `dashboard_rebuild/client/src/lib/utils.ts` — `cn()` class merge helper used across the UI.
+* `dashboard_rebuild/client/src/components/ui/HudPanel.tsx` — shared HUD panel primitive; pulls border/panel classes from `theme.ts`.
+* `dashboard_rebuild/client/src/components/ui/HudButton.tsx` — shared HUD button primitive; pulls primary/outline button classes from `theme.ts`.
+* `dashboard_rebuild/client/src/components/ui/badge.tsx`, `dashboard_rebuild/client/src/components/ui/checkbox.tsx`, and `dashboard_rebuild/client/src/components/ui/dialog.tsx` — shared UI primitives used by Library rows, file selection, and modals.
+
+### Library Page
+
+* `dashboard_rebuild/client/src/pages/library.tsx` — main Library controller and page design. This file owns the visible `/library` layout: folder/course rail, Semester Intake preview/apply, upload, folder sync, material table, Tutor handoff queue, cleanup controls, add-course modal, and material preview modal.
+* `dashboard_rebuild/client/src/components/MaterialUploader.tsx` — direct file-upload dropzone embedded inside Library.
+* `dashboard_rebuild/client/src/lib/tutorClientState.ts` — local/session storage handoff state between Library and Tutor.
+* `dashboard_rebuild/client/src/api.ts` — frontend API client for courses, semester intake, Tutor material upload/list/update/delete/re-extract/content, folder sync preview/apply/status, embed status, and Tutor handoff data.
+* `dashboard_rebuild/client/src/lib/api.ts` — compatibility re-export of `src/api.ts`.
+* `dashboard_rebuild/client/src/api.types.ts` — generated/central frontend API type surface used by Tutor and Library contracts.
+* `shared/schema.ts` — shared course/material schema types consumed by the frontend.
+
+### Library Backend
+
+* `brain/dashboard/api_semester_intake.py` — `/api/semester-intake/preview` and `/api/semester-intake/apply`; classifies the PT School folder and applies selected course/material intake.
+* `brain/dashboard/api_tutor_materials.py` — `/api/tutor/materials/*`; upload, list, update, delete, content preview, folder sync preview/apply/status, extracted assets, video processing, and embed linkage.
+* `brain/dashboard/api_adapter.py` — `/api/courses/*`; course list/create/update/archive/unarchive/delete used by the Library course rail and forms.
+* `brain/dashboard/api_tutor.py` — Tutor blueprint registration hub that wires material routes into the app.
+* `brain/dashboard/app.py` and `brain/dashboard/routes.py` — Flask app/React catch-all wiring that serves `/library` from the built frontend.
+
+### Tests That Protect Library
+
+* `dashboard_rebuild/client/src/pages/__tests__/library.test.tsx` — primary Library UI/unit coverage.
+* `dashboard_rebuild/client/src/pages/__tests__/tutor.workspace.integration.test.tsx` and `dashboard_rebuild/client/src/pages/__tests__/tutor.test.tsx` — protect Library-to-Tutor handoff behavior.
+* `brain/tests/test_semester_intake.py` — backend Semester Intake classification/apply behavior.
+* `brain/tests/test_tutor_material_pipeline_certification.py` — backend material sync/embed pipeline behavior.
+
+### Reference / Not Active By Default
+
+* `dashboard_rebuild/client/src/styles/theme.css`, `dashboard_rebuild/client/src/styles/hud-theme.css`, `dashboard_rebuild/client/src/styles/hud-components.css`, `dashboard_rebuild/client/src/styles/hud-variants.css`, and `dashboard_rebuild/client/src/styles/hud-wrappers.css` are currently theme-lab/reference styles unless imported by the main app.
+* `dashboard_rebuild/client/theme-lab/*` is a design playground, not the live `/library` page.
+* `docs/stitch-designs/*`, `docs/design/*`, and `wireframe/*` are visual references and prototypes.
+
+## Library Design Direction
+
+Library is the study-material operations page. It should answer three questions in order:
+
+1. What course am I organizing?
+2. What files were found and what do they mean?
+3. What is selected and ready to send to Tutor?
+
+The Library page should be course-first and file-explicit. Folder scans are review/classification steps, not permission to load every file. Course names should be primary; PHYT/course codes are secondary metadata only.
+
+Preferred flow:
+
+1. Pick or scan a source.
+2. Review courses and file classifications.
+3. Select only the files to load.
+4. Apply selected files.
+5. Confirm material readiness.
+6. Hand selected material to Tutor.
+
+Visual direction for Library: keep the PT Study cockpit identity, but use calmer operations hierarchy than the live Tutor surface. Red is an accent and active-state signal, not the whole page. Use graphite/black surfaces, muted crimson structure, teal/green for ready, amber for missing/review, and blue/cyan for sync/information.
+
+Avoid:
+
+* Redundant panels that repeat the same readiness signal.
+* Hidden bulk actions that look like the normal next step.
+* Course-code-first labels when the learner needs course names.
+* Loading folder contents without an explicit file selection step.
+* Editing `brain/static/dist/` directly.
+
 ## Philosophy & Metadata
 *   **Project:** PT Study OS
 *   **Theme:** Premium Cyberpunk / High-Fidelity Sci-Fi Cockpit.

--- a/brain/dashboard/api_semester_intake.py
+++ b/brain/dashboard/api_semester_intake.py
@@ -326,6 +326,14 @@ def _clean_course_name(folder_name: str) -> str:
     return re.sub(r"\s+", " ", cleaned) or folder_name
 
 
+def _infer_course_code(*values: str) -> str | None:
+    for value in values:
+        match = re.search(r"\b(PHYT)\s*[_-]?\s*(\d{4})\b", value, flags=re.IGNORECASE)
+        if match:
+            return f"{match.group(1).upper()} {match.group(2)}"
+    return None
+
+
 def _is_global_schedule_folder(name: str) -> bool:
     lowered = name.lower()
     return "schedule" in lowered and (lowered.startswith("00") or "class" in lowered)
@@ -387,8 +395,40 @@ def _read_existing_course_summary() -> dict[str, int]:
     return summary
 
 
+def _read_existing_course_material_readiness() -> dict[int, dict[str, int]]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                d.course_id AS course_id,
+                COUNT(DISTINCT d.id) AS material_count,
+                COUNT(DISTINCT CASE WHEN e.rag_doc_id IS NOT NULL THEN d.id END) AS embedded_count
+            FROM rag_docs d
+            LEFT JOIN rag_embeddings e
+              ON e.rag_doc_id = d.id
+            WHERE d.course_id IS NOT NULL
+              AND COALESCE(d.corpus, 'materials') = 'materials'
+              AND COALESCE(d.enabled, 1) = 1
+            GROUP BY d.course_id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    readiness: dict[int, dict[str, int]] = {}
+    for row in rows:
+        course_id = int(row[0])
+        readiness[course_id] = {
+            "material_count": int(row[1] or 0),
+            "embedded_count": int(row[2] or 0),
+        }
+    return readiness
+
+
 def _classify_intake_folder(root: Path) -> dict[str, Any]:
     existing_courses = _read_existing_course_summary()
+    existing_material_readiness = _read_existing_course_material_readiness()
     course_map: dict[str, dict[str, Any]] = {}
     global_schedule_files: list[dict[str, Any]] = []
     ignored_files: list[dict[str, Any]] = []
@@ -423,12 +463,16 @@ def _classify_intake_folder(root: Path) -> dict[str, Any]:
                 top_folder,
                 {
                     "name": _clean_course_name(top_folder),
+                    "code": None,
                     "folder_path": top_folder,
                     "syllabus_files": [],
                     "schedule_files": [],
                     "material_files": [],
                 },
             )
+            course_code = _infer_course_code(rel_path, filename, top_folder)
+            if course_code and not course.get("code"):
+                course["code"] = course_code
             if "syllabus" in roles:
                 course["syllabus_files"].append(payload)
             if "schedule" in roles:
@@ -442,7 +486,16 @@ def _classify_intake_folder(root: Path) -> dict[str, Any]:
     material_count = len(unassigned_material_files)
     for course in sorted(course_map.values(), key=lambda item: item["folder_path"].lower()):
         course_name_key = str(course["name"]).lower()
-        course_id = existing_courses.get(course_name_key)
+        course_code_key = str(course.get("code") or "").lower()
+        course_id = (
+            existing_courses.get(course_code_key)
+            if course_code_key
+            else None
+        ) or existing_courses.get(course_name_key)
+        material_readiness = existing_material_readiness.get(course_id or -1, {})
+        existing_material_count = int(material_readiness.get("material_count") or 0)
+        embedded_count = int(material_readiness.get("embedded_count") or 0)
+        has_materials = bool(course["material_files"]) or existing_material_count > 0
         syllabus_count += len(course["syllabus_files"])
         schedule_count += len(course["schedule_files"])
         material_count += len(course["material_files"])
@@ -450,9 +503,11 @@ def _classify_intake_folder(root: Path) -> dict[str, Any]:
             "course": "exists" if course_id else "missing",
             "syllabus": "found" if course["syllabus_files"] else "missing",
             "schedule": "found" if course["schedule_files"] else "missing",
-            "materials": "found" if course["material_files"] else "missing",
-            "embeddings": "pending",
-            "readyForTutor": False,
+            "materials": "found" if has_materials else "missing",
+            "embeddings": (
+                "ready" if embedded_count > 0 else "pending" if has_materials else "missing"
+            ),
+            "readyForTutor": bool(course_id and embedded_count > 0),
         }
         if course_id:
             course["course_id"] = course_id
@@ -544,7 +599,16 @@ def _insert_modules_and_objectives(
             module_id = int(cur.lastrowid)
             modules_created += 1
 
-        for objective in module.get("objectives") or []:
+        objectives = list(module.get("objectives") or [])
+        if not objectives:
+            objectives = [
+                {
+                    "loCode": f"MOD-{order_index or index + 1}",
+                    "title": f"Study {name}",
+                }
+            ]
+
+        for objective in objectives:
             title = str(objective.get("title") or "").strip()
             if not title:
                 continue
@@ -559,15 +623,25 @@ def _insert_modules_and_objectives(
                 """,
                 (course_id, module_id, title),
             )
-            if cur.fetchone():
+            existing = cur.fetchone()
+            if existing:
+                cur.execute(
+                    """
+                    UPDATE learning_objectives
+                    SET group_name = COALESCE(NULLIF(group_name, ''), ?),
+                        updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (name, now, int(existing[0])),
+                )
                 continue
             cur.execute(
                 """
                 INSERT INTO learning_objectives (
-                    course_id, module_id, lo_code, title, status, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, 'not_started', ?, ?)
+                    course_id, module_id, lo_code, title, status, group_name, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, 'not_started', ?, ?, ?)
                 """,
-                (course_id, module_id, lo_code, title, now, now),
+                (course_id, module_id, lo_code, title, name, now, now),
             )
             objectives_created += 1
 

--- a/brain/dashboard/api_tutor_materials.py
+++ b/brain/dashboard/api_tutor_materials.py
@@ -1352,6 +1352,14 @@ def _launch_materials_sync_job(
                 progress_callback=_progress,
             )
             sync_errors = sync_result.get("errors") or []
+            synced_doc_ids: list[int] = []
+            for raw_doc_id in sync_result.get("doc_ids") or []:
+                try:
+                    doc_id = int(raw_doc_id)
+                except (TypeError, ValueError):
+                    continue
+                if doc_id > 0:
+                    synced_doc_ids.append(doc_id)
             _update_sync_job(
                 job_id,
                 phase="embedding",
@@ -1386,8 +1394,20 @@ def _launch_materials_sync_job(
                     )
 
                 def _run_embed() -> dict:
+                    if not synced_doc_ids:
+                        return {
+                            "embedded": 0,
+                            "skipped": 0,
+                            "timed_out": 0,
+                            "total_chunks": 0,
+                            "failures": [],
+                            "scope": "synced_doc_ids",
+                            "scoped_doc_count": 0,
+                        }
                     return embed_rag_docs(
-                        corpus="materials", progress_callback=_embed_progress
+                        corpus="materials",
+                        rag_doc_ids=synced_doc_ids,
+                        progress_callback=_embed_progress,
                     )
 
                 with _TPE(max_workers=1) as _phase_executor:

--- a/brain/dashboard/api_tutor_materials.py
+++ b/brain/dashboard/api_tutor_materials.py
@@ -2372,6 +2372,12 @@ def get_material_content(material_id: int):
 
     # Strip replacement characters so the viewer gets clean text
     content = raw_content.replace("\ufffd", "") if replacement_count else raw_content
+    try:
+        from text_extractor import normalize_extracted_text
+
+        content = normalize_extracted_text(content)
+    except Exception:
+        pass
     asset_dir = _find_extracted_asset_dir(row["source_path"], row["file_path"])
     content = _inject_extracted_images(
         content, material_id=row["id"], asset_dir=asset_dir

--- a/brain/dashboard/api_tutor_materials.py
+++ b/brain/dashboard/api_tutor_materials.py
@@ -705,17 +705,30 @@ def _normalize_selected_sync_files(
 
 def _parse_sync_folder_payload(
     data: dict[str, Any]
-) -> tuple[Path, Optional[set[str]], Optional[set[str]], Optional[int]]:
+) -> tuple[Path, Optional[set[str]], Optional[set[str]], Optional[set[str]], Optional[int]]:
     root, allowed_exts = _parse_sync_folder_root_and_exts(data)
     selected_files = _normalize_selected_sync_files(
         data.get("selected_files"),
         root=root,
         allowed_exts=allowed_exts,
     )
-    if data.get("selected_files") is not None and not selected_files:
+    setup_files = _normalize_selected_sync_files(
+        data.get("setup_files"),
+        root=root,
+        allowed_exts=allowed_exts,
+    )
+    if setup_files is not None and selected_files is None:
+        selected_files = set()
+    if selected_files is not None and setup_files:
+        selected_files = selected_files - setup_files
+    if (
+        (data.get("selected_files") is not None or data.get("setup_files") is not None)
+        and not selected_files
+        and not setup_files
+    ):
         raise ValueError("selected_files is empty. Choose at least one file.")
     course_id = _parse_sync_course_id(data.get("course_id"))
-    return root, allowed_exts, selected_files, course_id
+    return root, allowed_exts, selected_files, setup_files, course_id
 
 
 def _build_sync_folder_preview(
@@ -1245,7 +1258,7 @@ def _auto_link_materials_to_courses(conn: sqlite3.Connection) -> dict:
     cur.execute(
         """SELECT id, folder_path FROM rag_docs
            WHERE course_id IS NULL
-             AND COALESCE(corpus, 'materials') = 'materials'
+             AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')
              AND folder_path IS NOT NULL AND TRIM(folder_path) != ''"""
     )
     unlinked = cur.fetchall()
@@ -1303,15 +1316,22 @@ def _launch_materials_sync_job(
     allowed_exts: Optional[set[str]],
     *,
     selected_files: Optional[set[str]] = None,
+    setup_files: Optional[set[str]] = None,
     course_id: Optional[int] = None,
 ) -> str:
     job_id = uuid.uuid4().hex
+    selected_total = (
+        None
+        if selected_files is None and setup_files is None
+        else len(selected_files or set()) + len(setup_files or set())
+    )
     _update_sync_job(
         job_id,
         status="pending",
         phase="pending",
         folder=str(root),
-        selected_count=len(selected_files) if selected_files is not None else None,
+        selected_count=selected_total,
+        setup_count=len(setup_files or set()),
         course_id=course_id,
         processed=0,
         total=0,
@@ -1343,15 +1363,50 @@ def _launch_materials_sync_job(
                     errors=int(payload.get("errors") or 0),
                 )
 
-            sync_result = sync_folder_to_rag(
-                str(root),
-                corpus="materials",
-                allowed_exts=allowed_exts,
-                include_paths=selected_files,
-                course_id=course_id,
-                progress_callback=_progress,
+            if selected_files == set():
+                sync_result = {
+                    "ok": True,
+                    "root": str(root),
+                    "total": 0,
+                    "processed": 0,
+                    "failed": 0,
+                    "deleted": 0,
+                    "deleted_paths": [],
+                    "errors": [],
+                    "doc_ids": [],
+                }
+            else:
+                sync_result = sync_folder_to_rag(
+                    str(root),
+                    corpus="materials",
+                    allowed_exts=allowed_exts,
+                    include_paths=selected_files,
+                    course_id=course_id,
+                    progress_callback=_progress,
+                )
+            setup_result = {
+                "ok": True,
+                "root": str(root),
+                "total": 0,
+                "processed": 0,
+                "failed": 0,
+                "deleted": 0,
+                "deleted_paths": [],
+                "errors": [],
+                "doc_ids": [],
+            }
+            if setup_files:
+                setup_result = sync_folder_to_rag(
+                    str(root),
+                    corpus="course_setup",
+                    allowed_exts=allowed_exts,
+                    include_paths=setup_files,
+                    course_id=course_id,
+                    progress_callback=_progress,
+                )
+            sync_errors = (sync_result.get("errors") or []) + (
+                setup_result.get("errors") or []
             )
-            sync_errors = sync_result.get("errors") or []
             synced_doc_ids: list[int] = []
             for raw_doc_id in sync_result.get("doc_ids") or []:
                 try:
@@ -1360,14 +1415,43 @@ def _launch_materials_sync_job(
                     continue
                 if doc_id > 0:
                     synced_doc_ids.append(doc_id)
+            setup_doc_ids: list[int] = []
+            for raw_doc_id in setup_result.get("doc_ids") or []:
+                try:
+                    doc_id = int(raw_doc_id)
+                except (TypeError, ValueError):
+                    continue
+                if doc_id > 0:
+                    setup_doc_ids.append(doc_id)
+            combined_sync_result = {
+                "ok": bool(sync_result.get("ok", True))
+                and bool(setup_result.get("ok", True)),
+                "root": str(root),
+                "total": int(sync_result.get("total") or 0)
+                + int(setup_result.get("total") or 0),
+                "processed": int(sync_result.get("processed") or 0)
+                + int(setup_result.get("processed") or 0),
+                "failed": int(sync_result.get("failed") or 0)
+                + int(setup_result.get("failed") or 0),
+                "deleted": int(sync_result.get("deleted") or 0)
+                + int(setup_result.get("deleted") or 0),
+                "deleted_paths": list(sync_result.get("deleted_paths") or [])
+                + list(setup_result.get("deleted_paths") or []),
+                "errors": sync_errors,
+                "doc_ids": synced_doc_ids + setup_doc_ids,
+                "material_doc_ids": synced_doc_ids,
+                "setup_doc_ids": setup_doc_ids,
+                "material_result": sync_result,
+                "setup_result": setup_result,
+            }
             _update_sync_job(
                 job_id,
                 phase="embedding",
-                sync_result=sync_result,
-                processed=int(sync_result.get("processed") or 0),
-                total=int(sync_result.get("total") or 0),
-                index=int(sync_result.get("total") or 0),
-                errors=int(sync_result.get("failed") or len(sync_errors)),
+                sync_result=combined_sync_result,
+                processed=int(combined_sync_result.get("processed") or 0),
+                total=int(combined_sync_result.get("total") or 0),
+                index=int(combined_sync_result.get("total") or 0),
+                errors=int(combined_sync_result.get("failed") or len(sync_errors)),
                 current_file=None,
             )
 
@@ -1735,6 +1819,26 @@ def upload_material():
     title = request.form.get("title", Path(file.filename).stem)
     course_id = request.form.get("course_id", type=int)
     tags = request.form.get("tags", "")
+    library_role = str(request.form.get("library_role") or "study").strip().lower()
+    if library_role not in {"study", "setup"}:
+        return jsonify({"error": "library_role must be study or setup"}), 400
+    setup_kind = str(request.form.get("setup_kind") or "").strip().lower()
+    if library_role == "setup" and setup_kind not in {
+        "syllabus",
+        "schedule",
+        "syllabus_schedule",
+        "course_setup",
+        "",
+    }:
+        return jsonify({"error": "unsupported setup_kind"}), 400
+    if library_role == "setup" and not setup_kind:
+        setup_kind = "course_setup"
+    corpus = "course_setup" if library_role == "setup" else "materials"
+    doc_type = "course_setup" if library_role == "setup" else "upload"
+    metadata = {
+        "library_role": library_role,
+        "setup_kind": setup_kind or None,
+    }
 
     # Save to disk
     os.makedirs(UPLOADS_DIR, exist_ok=True)
@@ -1776,8 +1880,8 @@ def upload_material():
     duplicate_of = None
     if checksum:
         cur.execute(
-            "SELECT id, title FROM rag_docs WHERE checksum = ? AND COALESCE(corpus, 'materials') = 'materials'",
-            (checksum,),
+            "SELECT id, title FROM rag_docs WHERE checksum = ? AND COALESCE(corpus, 'materials') = ?",
+            (checksum, corpus),
         )
         existing = cur.fetchone()
         if existing:
@@ -1790,19 +1894,22 @@ def upload_material():
         """INSERT INTO rag_docs
            (source_path, content, checksum, corpus, title, file_path, file_size,
             file_type, doc_type, topic_tags, course_id, enabled,
-            extraction_error, created_at, updated_at)
-           VALUES (?, ?, ?, 'materials', ?, ?, ?, ?, 'upload', ?, ?, 1, ?, ?, ?)""",
+            extraction_error, metadata_json, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)""",
         (
             str(disk_path),
             content,
             checksum,
+            corpus,
             title,
             str(disk_path),
             file_size,
             file_type,
+            doc_type,
             tags,
             course_id,
             extraction_error,
+            json.dumps(metadata, sort_keys=True),
             now,
             now,
         ),
@@ -1813,11 +1920,11 @@ def upload_material():
     # Attempt embedding (non-blocking -- don't fail the upload if embedding fails)
     # Skip for mp4 upload rows because they have no text until video processing runs.
     embedded = False
-    if ext != ".mp4" and content and not extraction_error:
+    if library_role != "setup" and ext != ".mp4" and content and not extraction_error:
         try:
             from tutor_rag import embed_rag_docs
 
-            result = embed_rag_docs(corpus="materials")
+            result = embed_rag_docs(corpus="materials", rag_doc_ids=[material_id])
             embedded = result.get("embedded", 0) > 0
         except Exception:
             pass
@@ -1835,6 +1942,8 @@ def upload_material():
             "embedded": embedded,
             "char_count": len(content) if content else 0,
             "duplicate_of": duplicate_of,
+            "library_role": library_role,
+            "setup_kind": setup_kind or None,
         }
     ), 201
 
@@ -1854,7 +1963,16 @@ def list_materials():
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
 
-    conditions = ["COALESCE(corpus, 'materials') = 'materials'"]
+    include_setup = str(request.args.get("include_setup") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    conditions = [
+        "COALESCE(corpus, 'materials') IN ('materials', 'course_setup')"
+        if include_setup
+        else "COALESCE(corpus, 'materials') = 'materials'"
+    ]
     params: list = []
 
     if course_id is not None:
@@ -1896,6 +2014,9 @@ def list_materials():
                      END
                    ) as file_type,
                    COALESCE(file_size, 0) as file_size, course_id, topic_tags,
+                   COALESCE(corpus, 'materials') as corpus,
+                   COALESCE(doc_type, '') as doc_type,
+                   COALESCE(metadata_json, '') as metadata_json,
                    COALESCE(enabled, 1) as enabled, extraction_error,
                    COALESCE(checksum, '') as checksum,
                    created_at, updated_at
@@ -1927,6 +2048,21 @@ def list_materials():
                 asset_count = 0
         material["has_docling_assets"] = asset_count > 0
         material["docling_asset_count"] = int(asset_count)
+        metadata: dict[str, Any] = {}
+        try:
+            raw_metadata = material.get("metadata_json")
+            if raw_metadata:
+                parsed_metadata = json.loads(str(raw_metadata))
+                if isinstance(parsed_metadata, dict):
+                    metadata = parsed_metadata
+        except Exception:
+            metadata = {}
+        material["material_role"] = (
+            metadata.get("library_role")
+            or ("setup" if material.get("corpus") == "course_setup" else "study")
+        )
+        material["setup_kind"] = metadata.get("setup_kind")
+        material.pop("metadata_json", None)
 
         try:
             if int(material.get("file_size") or 0) <= 0:
@@ -1975,7 +2111,7 @@ def get_material(material_id: int):
                    COALESCE(checksum, '') as checksum,
                    created_at, updated_at
             FROM rag_docs
-            WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'""",
+            WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')""",
         (material_id,),
     )
     row = cur.fetchone()
@@ -2003,7 +2139,7 @@ def update_material(material_id: int):
     cur = conn.cursor()
 
     cur.execute(
-        "SELECT id FROM rag_docs WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'",
+        "SELECT id FROM rag_docs WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')",
         (material_id,),
     )
     if not cur.fetchone():
@@ -2051,9 +2187,10 @@ def reextract_material(material_id: int):
         SELECT id, source_path, file_path, doc_type, file_type, course_id, topic_tags,
                COALESCE(corpus, 'materials') AS corpus,
                COALESCE(folder_path, '') AS folder_path,
-               COALESCE(enabled, 1) AS enabled
+               COALESCE(enabled, 1) AS enabled,
+               COALESCE(metadata_json, '') AS metadata_json
         FROM rag_docs
-        WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'
+        WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')
         """,
         (material_id,),
     )
@@ -2072,7 +2209,7 @@ def reextract_material(material_id: int):
     doc_type = str(row["doc_type"] or row["file_type"] or "").strip().lower()
     if doc_type in {"ppt", "pptx"}:
         doc_type = "powerpoint"
-    if doc_type == "upload":
+    if doc_type in {"upload", "course_setup"}:
         file_type = str(row["file_type"] or "").strip().lower()
         if file_type in {"ppt", "pptx"}:
             doc_type = "powerpoint"
@@ -2089,7 +2226,7 @@ def reextract_material(material_id: int):
     try:
         from rag_notes import ingest_document
 
-        ingest_document(
+        reextracted_id = ingest_document(
             path=source_path,
             doc_type=doc_type,
             course_id=row["course_id"],
@@ -2098,6 +2235,24 @@ def reextract_material(material_id: int):
             folder_path=str(row["folder_path"] or ""),
             enabled=int(row["enabled"] or 1),
         )
+        if str(row["corpus"] or "").strip().lower() == "course_setup":
+            setup_metadata: dict[str, Any] = {}
+            try:
+                parsed = json.loads(str(row["metadata_json"] or ""))
+                if isinstance(parsed, dict):
+                    setup_metadata = parsed
+            except Exception:
+                setup_metadata = {}
+            setup_metadata["library_role"] = "setup"
+            setup_metadata.setdefault("setup_kind", "course_setup")
+            conn = get_connection()
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE rag_docs SET metadata_json = ? WHERE id = ?",
+                (json.dumps(setup_metadata, sort_keys=True), int(reextracted_id or material_id)),
+            )
+            conn.commit()
+            conn.close()
     except Exception as exc:
         return jsonify({"error": f"Re-extract failed: {exc}"}), 500
 
@@ -2139,7 +2294,7 @@ def delete_material(material_id: int):
     cur = conn.cursor()
 
     cur.execute(
-        "SELECT id, file_path FROM rag_docs WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'",
+        "SELECT id, file_path FROM rag_docs WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')",
         (material_id,),
     )
     row = cur.fetchone()
@@ -2201,7 +2356,7 @@ def get_material_content(material_id: int):
 
     cur.execute(
         "SELECT id, title, source_path, file_path, file_type, content, course_id "
-        "FROM rag_docs WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'",
+        "FROM rag_docs WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')",
         (material_id,),
     )
     row = cur.fetchone()
@@ -2294,7 +2449,7 @@ def get_material_file(material_id: int):
 
     cur.execute(
         "SELECT id, source_path, file_path FROM rag_docs "
-        "WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'",
+        "WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')",
         (material_id,),
     )
     row = cur.fetchone()
@@ -2332,7 +2487,7 @@ def get_material_asset(material_id: int, asset_path: str):
     cur = conn.cursor()
     cur.execute(
         "SELECT id, source_path, file_path FROM rag_docs "
-        "WHERE id = ? AND COALESCE(corpus, 'materials') = 'materials'",
+        "WHERE id = ? AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')",
         (material_id,),
     )
     row = cur.fetchone()
@@ -2412,7 +2567,7 @@ def sync_materials_folder():
     data = request.get_json(silent=True) or {}
 
     try:
-        root, allowed_exts, selected_files, course_id = _parse_sync_folder_payload(data)
+        root, allowed_exts, selected_files, setup_files, course_id = _parse_sync_folder_payload(data)
     except (ValueError, FileNotFoundError) as exc:
         return jsonify({"error": str(exc)}), 400
     except Exception as exc:
@@ -2422,7 +2577,13 @@ def sync_materials_folder():
         root,
         allowed_exts,
         selected_files=selected_files,
+        setup_files=setup_files,
         course_id=course_id,
+    )
+    selected_count = (
+        None
+        if selected_files is None and setup_files is None
+        else len(selected_files or set()) + len(setup_files or set())
     )
     return (
         jsonify(
@@ -2430,9 +2591,8 @@ def sync_materials_folder():
                 "ok": True,
                 "job_id": job_id,
                 "folder": str(root),
-                "selected_count": (
-                    len(selected_files) if selected_files is not None else None
-                ),
+                "selected_count": selected_count,
+                "setup_count": len(setup_files or set()),
                 "course_id": course_id,
             }
         ),

--- a/brain/dashboard/api_tutor_sessions.py
+++ b/brain/dashboard/api_tutor_sessions.py
@@ -70,6 +70,7 @@ from dashboard.api_tutor_vault import (
     _vault_save_note,
     _sync_graph_for_paths,
     _ensure_moc_context,
+    _is_nonblocking_moc_error,
     _resolve_tutor_preflight,
 )
 
@@ -453,24 +454,9 @@ def create_session():
             content_filter.get("focus_objective_id") or focus_objective_id
         ).strip()
 
-    requires_certified_preflight = preflight_bundle is None and (
-        bool(focus_objective_id)
-        or bool(data.get("study_unit"))
-        or (
-            isinstance(data.get("learning_objectives"), list)
-            and objective_scope != "single_focus"
-        )
-    )
-    if requires_certified_preflight:
-        return (
-            jsonify(
-                {
-                    "error": "Objective-scoped certified Tutor sessions must start from preflight.",
-                    "code": "PREFLIGHT_REQUIRED",
-                }
-            ),
-            400,
-        )
+    # Workspace Context is now the user-facing session authority. The legacy
+    # preflight endpoint remains available for preview diagnostics, but direct
+    # Tutor starts may carry objective/material context in the create payload.
     map_of_contents_refresh = bool(
         data.get(
             "map_of_contents_refresh",
@@ -540,7 +526,15 @@ def create_session():
             path_override=vault_folder,
         )
         if map_of_contents_error:
-            return jsonify({"error": map_of_contents_error}), 500
+            if source_ids and _is_nonblocking_moc_error(map_of_contents_error):
+                _LOG.warning("Proceeding without MoC context: %s", map_of_contents_error)
+                if not isinstance(content_filter, dict):
+                    content_filter = {}
+                content_filter["map_of_contents_warning"] = map_of_contents_error
+                map_of_contents_ctx = None
+                map_of_contents_error = None
+            else:
+                return jsonify({"error": map_of_contents_error}), 500
 
     if not isinstance(content_filter, dict):
         content_filter = {}

--- a/brain/dashboard/api_tutor_vault.py
+++ b/brain/dashboard/api_tutor_vault.py
@@ -773,6 +773,11 @@ def _objective_slug(description: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _is_nonblocking_moc_error(message: str) -> bool:
+    lowered = str(message or "").lower()
+    return "unmapped vault course" in lowered
+
+
 def _ensure_moc_context(
     *,
     course_id: Optional[int],
@@ -954,6 +959,11 @@ def _resolve_tutor_preflight(
         if map_of_contents_error:
             if "No mapped learning objectives were found" in map_of_contents_error:
                 resolved_objectives = []
+                map_of_contents_ctx = None
+                map_of_contents_error = None
+            elif material_ids and _is_nonblocking_moc_error(map_of_contents_error):
+                _LOG.warning("Proceeding without MoC context: %s", map_of_contents_error)
+                normalized_filter["map_of_contents_warning"] = map_of_contents_error
                 map_of_contents_ctx = None
                 map_of_contents_error = None
             else:

--- a/brain/dashboard/api_tutor_workflows.py
+++ b/brain/dashboard/api_tutor_workflows.py
@@ -946,7 +946,7 @@ def _fetch_material_rows(conn: sqlite3.Connection, material_ids: list[int]) -> l
         f"""
         SELECT id, title, source_path, folder_path, course_id, file_type, content
         FROM rag_docs
-        WHERE id IN ({placeholders}) AND COALESCE(corpus, 'materials') = 'materials'
+        WHERE id IN ({placeholders}) AND COALESCE(corpus, 'materials') IN ('materials', 'course_setup')
         ORDER BY title COLLATE NOCASE, id
         """,
         tuple(material_ids),

--- a/brain/tests/test_live_tutor_smoke.py
+++ b/brain/tests/test_live_tutor_smoke.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import requests
 
-from scripts.live_tutor_smoke import select_preflight_ready_scope
+from scripts.live_tutor_smoke import select_workspace_context_ready_scope
 
 
 class _FakeResponse:
@@ -21,7 +21,6 @@ class _FakeResponse:
 
 class _FakeSession:
     def __init__(self) -> None:
-        self.preflight_payloads: list[dict] = []
         self._materials = {
             1: [{"id": 11, "title": "Cardio deck"}],
         }
@@ -31,10 +30,6 @@ class _FakeSession:
                 {"groupName": "Respiratory", "title": "Explain ventilation.", "loCode": "OBJ-2"},
             ],
         }
-        self._preflight_responses = [
-            _FakeResponse({"error": "Unmapped vault unit 'Cardiovascular'."}, status_code=500),
-            _FakeResponse({"ok": True, "preflight_id": "pf-1"}, status_code=200),
-        ]
 
     def get(self, url: str, params=None, timeout=None):  # noqa: ARG002
         if url.endswith("/api/tutor/materials"):
@@ -44,26 +39,23 @@ class _FakeSession:
         raise AssertionError(f"unexpected GET {url}")
 
     def post(self, url: str, json=None, timeout=None):  # noqa: ARG002
-        if url.endswith("/api/tutor/session/preflight"):
-            self.preflight_payloads.append(json)
-            if not self._preflight_responses:
-                raise AssertionError("unexpected extra preflight call")
-            return self._preflight_responses.pop(0)
         raise AssertionError(f"unexpected POST {url}")
 
 
-def test_select_preflight_ready_scope_skips_failing_group_and_uses_next_group() -> None:
+def test_select_workspace_context_ready_scope_builds_direct_session_payload() -> None:
     session = _FakeSession()
     course = {"id": 1, "name": "Exercise Physiology"}
 
-    selection = select_preflight_ready_scope(
+    selection = select_workspace_context_ready_scope(
         session=session,
         base_url="http://127.0.0.1:5000",
         course_candidates=[course],
     )
 
     assert selection["course"]["id"] == 1
-    assert selection["study_unit"] == "Respiratory"
-    assert selection["preflight"]["preflight_id"] == "pf-1"
-    attempted_units = [payload["study_unit"] for payload in session.preflight_payloads]
-    assert attempted_units == ["Cardiovascular", "Respiratory"]
+    assert selection["study_unit"] == "Cardiovascular"
+    payload = selection["workspace_context_payload"]
+    assert payload["course_id"] == 1
+    assert payload["topic"] == "Cardiovascular"
+    assert payload["module_name"] == "Cardiovascular"
+    assert payload["content_filter"]["material_ids"] == [11]

--- a/brain/tests/test_macos_launcher_paths.py
+++ b/brain/tests/test_macos_launcher_paths.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_macos_launcher_prefers_onedrive_pt_school_before_plain_desktop():
+    repo_root = Path(__file__).resolve().parents[2]
+    script = (repo_root / "scripts" / "start_dashboard_macos.sh").read_text(
+        encoding="utf-8"
+    )
+
+    onedrive_path = "$HOME/Library/CloudStorage/OneDrive-Personal/Desktop/PT School"
+    desktop_path = "$HOME/Desktop/PT School"
+
+    assert onedrive_path in script
+    assert script.index(onedrive_path) < script.index(desktop_path)

--- a/brain/tests/test_semester_intake.py
+++ b/brain/tests/test_semester_intake.py
@@ -50,6 +50,22 @@ def _course_count() -> int:
         conn.close()
 
 
+def _insert_course(*, name: str, code: str | None = None) -> int:
+    conn = sqlite3.connect(config.DB_PATH)
+    try:
+        cur = conn.execute(
+            """
+            INSERT INTO courses (name, code, default_study_mode, created_at)
+            VALUES (?, ?, 'Core', '2026-05-13T00:00:00')
+            """,
+            (name, code),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+    finally:
+        conn.close()
+
+
 def test_semester_document_extractors_are_available() -> None:
     missing = [
         module_name
@@ -93,6 +109,82 @@ def test_semester_intake_preview_classifies_files_without_writing(client, tmp_pa
 
     assert payload["global_schedule_files"][0]["path"] == "00_Class schedules/Summer Schedule PT School.pdf"
     assert payload["ignored_files"][0]["path"] == "90_Misc/EXXAT Uploads/Resume_2026.pdf"
+
+
+def test_semester_intake_preview_matches_existing_course_by_file_code(
+    client, tmp_path
+):
+    existing_course_id = _insert_course(
+        name="Dx Mgmt Integumentary",
+        code="PHYT 6262",
+    )
+    root = tmp_path / "PT School"
+    _touch(root / "10_Dx Mgmt Integumtary" / "PHYT 6262 Dx Mgmt Integumentary Syllabus.docx")
+
+    response = client.post(
+        "/api/semester-intake/preview",
+        json={"folder_path": str(root)},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["counts"]["courses"] == 1
+    course = payload["courses"][0]
+    assert course["name"] == "Dx Mgmt Integumtary"
+    assert course["code"] == "PHYT 6262"
+    assert course["course_id"] == existing_course_id
+    assert course["readiness"]["course"] == "exists"
+    assert _course_count() == 1
+
+
+def test_semester_intake_preview_marks_existing_embedded_course_ready(
+    client, tmp_path
+):
+    existing_course_id = _insert_course(
+        name="Professionalism",
+        code="PHYT 6109",
+    )
+    conn = sqlite3.connect(config.DB_PATH)
+    try:
+        cur = conn.execute(
+            """
+            INSERT INTO rag_docs (
+                source_path, course_id, topic_tags, doc_type, content, checksum,
+                metadata_json, corpus, enabled, created_at
+            ) VALUES (?, ?, 'study-folder', 'pdf', 'content', 'checksum', '{}', 'materials', 1, '2026-05-13T00:00:00')
+            """,
+            (
+                "13_Professionalism/Week 1.pdf",
+                existing_course_id,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO rag_embeddings (
+                rag_doc_id, chunk_index, chunk_text, embedding_model, provider, chroma_id, created_at
+            ) VALUES (?, 0, 'content', 'gemini-embedding-2-preview', 'gemini', 'chunk-1', '2026-05-13T00:00:00')
+            """,
+            (int(cur.lastrowid),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    root = tmp_path / "PT School"
+    _touch(root / "13_Professionalism" / "PHYT 6109 Professionalism Syllabus.docx")
+
+    response = client.post(
+        "/api/semester-intake/preview",
+        json={"folder_path": str(root)},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    course = payload["courses"][0]
+    assert course["course_id"] == existing_course_id
+    assert course["readiness"]["materials"] == "found"
+    assert course["readiness"]["embeddings"] == "ready"
+    assert course["readiness"]["readyForTutor"] is True
 
 
 def test_semester_intake_apply_creates_courses_structured_data_and_sync_job(
@@ -183,7 +275,13 @@ def test_semester_intake_apply_creates_courses_structured_data_and_sync_job(
             "code": "PHYT 6262",
         }
         assert conn.execute("SELECT COUNT(*) FROM modules").fetchone()[0] == 1
-        assert conn.execute("SELECT COUNT(*) FROM learning_objectives").fetchone()[0] == 1
+        objective = conn.execute(
+            "SELECT title, group_name FROM learning_objectives"
+        ).fetchone()
+        assert tuple(objective) == (
+            "Explain wound healing phases",
+            "Week 1 Wound Healing",
+        )
         assert conn.execute("SELECT COUNT(*) FROM course_events").fetchone()[0] == 1
     finally:
         conn.close()
@@ -226,6 +324,7 @@ def test_semester_intake_apply_parses_setup_files_into_planning_tables(client, t
     assert payload["setupFilesParsed"] == 1
     assert payload["setupParseErrors"] == []
     assert payload["modulesCreated"] == 1
+    assert payload["objectivesCreated"] == 1
     assert payload["eventsCreated"] == 2
 
     conn = sqlite3.connect(config.DB_PATH)
@@ -234,6 +333,14 @@ def test_semester_intake_apply_parses_setup_files_into_planning_tables(client, t
             row[0] for row in conn.execute("SELECT name FROM modules ORDER BY order_index")
         ]
         assert module_names == ["Week 1: Wound Healing"]
+        objective = conn.execute(
+            "SELECT lo_code, title, group_name FROM learning_objectives"
+        ).fetchone()
+        assert tuple(objective) == (
+            "MOD-1",
+            "Study Week 1: Wound Healing",
+            "Week 1: Wound Healing",
+        )
         events = conn.execute(
             "SELECT type, title, date, due_date FROM course_events ORDER BY type"
         ).fetchall()

--- a/brain/tests/test_text_extractor.py
+++ b/brain/tests/test_text_extractor.py
@@ -113,6 +113,41 @@ def test_extract_text_uses_resolved_filesystem_path(
     assert result["metadata"]["file_name"] == "resolved.md"
 
 
+def test_normalize_extracted_text_recovers_private_use_th_glyphs() -> None:
+    content = (
+        "I will share that story. \ue062 ere are only 5 stops. \ue062 ank you!\n"
+        "Physical \ue0bb erapy. \ue0bb e author declares no conflicts.\n"
+        "Force and Torques are Balanced \uf0e0 Muscle activities"
+    )
+
+    result = text_extractor.normalize_extracted_text(content)
+
+    assert "\ue062" not in result
+    assert "\ue0bb" not in result
+    assert "There are only 5 stops" in result
+    assert "Thank you!" in result
+    assert "Physical Therapy" in result
+    assert "The author declares no conflicts" in result
+    assert "Balanced -> Muscle activities" in result
+
+
+def test_normalize_extracted_text_repairs_split_ligatures_and_apostrophes() -> None:
+    content = "e ff orts, con fi dence, ef fi cient, isn ' t, journal ' s"
+
+    result = text_extractor.normalize_extracted_text(content)
+
+    assert result == "efforts, confidence, efficient, isn't, journal's"
+
+
+def test_normalize_extracted_text_does_not_collapse_quoted_phrases() -> None:
+    content = "she asked: ' Why is this important? ' and ' How did you get here? '"
+
+    result = text_extractor.normalize_extracted_text(content)
+
+    assert "' and '" in result
+    assert "and'How" not in result
+
+
 # ---------------------------------------------------------------------------
 # Garbled content detection
 # ---------------------------------------------------------------------------

--- a/brain/tests/test_tutor_material_pipeline_certification.py
+++ b/brain/tests/test_tutor_material_pipeline_certification.py
@@ -440,6 +440,28 @@ def test_sync_preview_lists_supported_files_only(client, tmp_path: Path) -> None
     assert "ignore.png" not in names
 
 
+def test_sync_preview_uses_configured_material_folder_when_path_omitted(
+    client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "pt-school"
+    (root / "Dx Mgmt").mkdir(parents=True)
+    (root / "Dx Mgmt" / "skin-anatomy.pptx").write_bytes(b"pptx")
+    monkeypatch.setenv("PT_SCHOOL_MATERIALS_DIR", str(root))
+    monkeypatch.delenv("TUTOR_MATERIALS_DIR", raising=False)
+
+    resp = client.post("/api/tutor/materials/sync/preview", json={})
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["ok"] is True
+    assert payload["folder"] == str(root.resolve())
+    assert payload["counts"]["files"] == 1
+    dx_folder = next(
+        child for child in payload["tree"]["children"] if child["name"] == "Dx Mgmt"
+    )
+    assert dx_folder["children"][0]["name"] == "skin-anatomy.pptx"
+
+
 def test_sync_start_validates_selected_files_and_course_id(client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _insert_course(303, name="Brain Structure")
     root = tmp_path / "sync"

--- a/brain/tests/test_tutor_material_pipeline_certification.py
+++ b/brain/tests/test_tutor_material_pipeline_certification.py
@@ -37,6 +37,7 @@ def app():
     orig_db_setup = db_setup.DB_PATH
     orig_api_data = _api_data_mod.DB_PATH
     orig_uploads = _api_tutor_mod.UPLOADS_DIR
+    orig_material_uploads = _api_tutor_materials_mod.UPLOADS_DIR
 
     uploads_dir = Path(tempfile.mkdtemp(prefix="tutor-materials-uploads-"))
 
@@ -45,6 +46,7 @@ def app():
     db_setup.DB_PATH = tmp_path
     _api_data_mod.DB_PATH = tmp_path
     _api_tutor_mod.UPLOADS_DIR = uploads_dir
+    _api_tutor_materials_mod.UPLOADS_DIR = uploads_dir
 
     db_setup.init_database()
     app_obj = create_app()
@@ -52,6 +54,7 @@ def app():
     yield app_obj
 
     _api_tutor_mod.UPLOADS_DIR = orig_uploads
+    _api_tutor_materials_mod.UPLOADS_DIR = orig_material_uploads
     config.DB_PATH = orig_config
     db_setup.DB_PATH = orig_db_setup
     _api_data_mod.DB_PATH = orig_api_data
@@ -100,15 +103,18 @@ def test_upload_material_supported_formats_persist_in_rag_docs(
     client, monkeypatch: pytest.MonkeyPatch, filename: str, expected_file_type: str
 ) -> None:
     _insert_course(301)
+    embed_calls: list[dict] = []
 
     monkeypatch.setattr(
         "text_extractor.extract_text",
         lambda _path: {"content": f"content for {filename}", "error": None, "metadata": {}},
     )
-    monkeypatch.setattr(
-        "tutor_rag.embed_rag_docs",
-        lambda **_kwargs: {"embedded": 1},
-    )
+
+    def fake_embed_rag_docs(**kwargs):
+        embed_calls.append(kwargs)
+        return {"embedded": 1}
+
+    monkeypatch.setattr("tutor_rag.embed_rag_docs", fake_embed_rag_docs)
 
     resp = client.post(
         "/api/tutor/materials/upload",
@@ -125,6 +131,9 @@ def test_upload_material_supported_formats_persist_in_rag_docs(
     assert payload["file_type"] == expected_file_type
     assert payload["embedded"] is True
     assert payload["char_count"] == len(f"content for {filename}")
+    assert embed_calls == [
+        {"corpus": "materials", "rag_doc_ids": [payload["id"]]},
+    ]
 
     conn = sqlite3.connect(config.DB_PATH)
     conn.row_factory = sqlite3.Row
@@ -160,6 +169,207 @@ def test_upload_material_mp4_stays_fast_and_metadata_only(client) -> None:
     assert payload["char_count"] == 0
     assert payload["embedded"] is False
     assert payload["extraction_error"] is None
+
+
+def test_upload_course_setup_file_is_raw_setup_source_not_embedded_study_material(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _insert_course(6262, name="Dx Mgmt Integumentary")
+    embed_calls: list[dict] = []
+
+    monkeypatch.setattr(
+        "text_extractor.extract_text",
+        lambda _path: {
+            "content": "Course schedule and objectives for integumentary management",
+            "error": None,
+            "metadata": {},
+        },
+    )
+
+    def fake_embed_rag_docs(**kwargs):
+        embed_calls.append(kwargs)
+        return {"embedded": 1}
+
+    monkeypatch.setattr("tutor_rag.embed_rag_docs", fake_embed_rag_docs)
+
+    resp = client.post(
+        "/api/tutor/materials/upload",
+        data={
+            "file": (io.BytesIO(b"dummy setup"), "dx-syllabus-schedule.docx"),
+            "course_id": "6262",
+            "title": "Dx Mgmt Syllabus and Schedule",
+            "library_role": "setup",
+            "setup_kind": "syllabus_schedule",
+        },
+        content_type="multipart/form-data",
+    )
+
+    assert resp.status_code == 201
+    payload = resp.get_json()
+    assert payload["embedded"] is False
+    assert payload["library_role"] == "setup"
+    assert payload["setup_kind"] == "syllabus_schedule"
+    assert embed_calls == []
+
+    conn = sqlite3.connect(config.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        """
+        SELECT title, file_type, doc_type, corpus, content, course_id, metadata_json
+        FROM rag_docs
+        WHERE id = ?
+        """,
+        (payload["id"],),
+    ).fetchone()
+    listed = conn.execute(
+        """
+        SELECT id, doc_type, corpus, metadata_json
+        FROM rag_docs
+        WHERE id = ?
+        """,
+        (payload["id"],),
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row["title"] == "Dx Mgmt Syllabus and Schedule"
+    assert row["file_type"] == "docx"
+    assert row["doc_type"] == "course_setup"
+    assert row["corpus"] == "course_setup"
+    assert row["content"] == "Course schedule and objectives for integumentary management"
+    assert row["course_id"] == 6262
+    assert '"library_role": "setup"' in row["metadata_json"]
+    assert '"setup_kind": "syllabus_schedule"' in row["metadata_json"]
+    assert listed is not None
+
+
+def test_materials_list_excludes_setup_files_unless_requested(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _insert_course(6263, name="Dx Mgmt Integumentary")
+
+    monkeypatch.setattr(
+        "text_extractor.extract_text",
+        lambda path: {
+            "content": f"extracted {Path(path).name}",
+            "error": None,
+            "metadata": {},
+        },
+    )
+    monkeypatch.setattr(
+        "tutor_rag.embed_rag_docs",
+        lambda **_kwargs: {"embedded": 1},
+    )
+
+    setup_resp = client.post(
+        "/api/tutor/materials/upload",
+        data={
+            "file": (io.BytesIO(b"setup bytes"), "dx-syllabus-schedule.docx"),
+            "course_id": "6263",
+            "title": "Dx Syllabus and Schedule",
+            "library_role": "setup",
+            "setup_kind": "syllabus_schedule",
+        },
+        content_type="multipart/form-data",
+    )
+    study_resp = client.post(
+        "/api/tutor/materials/upload",
+        data={
+            "file": (io.BytesIO(b"study bytes"), "dx-week-1.pdf"),
+            "course_id": "6263",
+            "title": "Dx Week 1",
+        },
+        content_type="multipart/form-data",
+    )
+    assert setup_resp.status_code == 201
+    assert study_resp.status_code == 201
+    setup_id = setup_resp.get_json()["id"]
+    study_id = study_resp.get_json()["id"]
+
+    default_list = client.get("/api/tutor/materials?course_id=6263")
+    assert default_list.status_code == 200
+    assert [item["id"] for item in default_list.get_json()] == [study_id]
+
+    library_list = client.get("/api/tutor/materials?course_id=6263&include_setup=1")
+    assert library_list.status_code == 200
+    ids = [item["id"] for item in library_list.get_json()]
+    assert setup_id in ids
+    assert study_id in ids
+
+
+def test_course_setup_file_can_be_served_to_priming_reader(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _insert_course(6264, name="Professionalism")
+    raw_pdf = b"%PDF-1.4 setup syllabus"
+    monkeypatch.setattr(
+        "text_extractor.extract_text",
+        lambda _path: {"content": "setup text", "error": None, "metadata": {}},
+    )
+
+    resp = client.post(
+        "/api/tutor/materials/upload",
+        data={
+            "file": (io.BytesIO(raw_pdf), "professionalism-syllabus.pdf"),
+            "course_id": "6264",
+            "title": "Professionalism Syllabus",
+            "library_role": "setup",
+            "setup_kind": "syllabus",
+        },
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 201
+    material_id = resp.get_json()["id"]
+
+    file_resp = client.get(f"/api/tutor/materials/{material_id}/file")
+    assert file_resp.status_code == 200
+    assert file_resp.data == raw_pdf
+
+
+def test_course_setup_reextract_uses_file_type_and_course_setup_corpus(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _insert_course(6265, name="Cardiovascular Pulmonary")
+    monkeypatch.setattr(
+        "text_extractor.extract_text",
+        lambda _path: {"content": "setup text", "error": None, "metadata": {}},
+    )
+
+    resp = client.post(
+        "/api/tutor/materials/upload",
+        data={
+            "file": (io.BytesIO(b"setup docx"), "cardiopulm-schedule.docx"),
+            "course_id": "6265",
+            "title": "Cardiopulm Schedule",
+            "library_role": "setup",
+            "setup_kind": "schedule",
+        },
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 201
+    material_id = resp.get_json()["id"]
+    calls: list[dict] = []
+
+    def fake_ingest_document(**kwargs):
+        calls.append(kwargs)
+        return material_id
+
+    monkeypatch.setattr("rag_notes.ingest_document", fake_ingest_document)
+
+    reextract_resp = client.post(f"/api/tutor/materials/{material_id}/reextract")
+    assert reextract_resp.status_code == 200
+    assert calls == [
+        {
+            "path": ANY,
+            "doc_type": "docx",
+            "course_id": 6265,
+            "topic_tags": [],
+            "corpus": "course_setup",
+            "folder_path": "",
+            "enabled": 1,
+        }
+    ]
+    assert calls[0]["path"].endswith("cardiopulm-schedule.docx")
 
 
 def test_upload_material_reports_duplicate_of_existing_checksum(
@@ -239,7 +449,7 @@ def test_sync_start_validates_selected_files_and_course_id(client, monkeypatch: 
     monkeypatch.setattr(
         _api_tutor_mod,
         "_launch_materials_sync_job",
-        lambda root, allowed_exts, selected_files=None, course_id=None: "job-sync-123",
+        lambda root, allowed_exts, selected_files=None, setup_files=None, course_id=None: "job-sync-123",
     )
 
     resp = client.post(
@@ -257,6 +467,56 @@ def test_sync_start_validates_selected_files_and_course_id(client, monkeypatch: 
     assert payload["job_id"] == "job-sync-123"
     assert payload["selected_count"] == 1
     assert payload["course_id"] == 303
+
+
+def test_sync_start_accepts_setup_files_without_study_embedding_selection(
+    client, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _insert_course(304, name="Dx Mgmt Integumentary")
+    root = tmp_path / "source-refresh"
+    (root / "Dx").mkdir(parents=True)
+    (root / "Dx" / "syllabus.docx").write_text("syllabus", encoding="utf-8")
+    (root / "Dx" / "week1.pptx").write_text("slides", encoding="utf-8")
+    launch_calls: list[dict] = []
+
+    def fake_launch(root, allowed_exts, selected_files=None, setup_files=None, course_id=None):
+        launch_calls.append(
+            {
+                "root": root,
+                "selected_files": selected_files,
+                "setup_files": setup_files,
+                "course_id": course_id,
+            }
+        )
+        return "job-source-refresh"
+
+    monkeypatch.setattr(_api_tutor_mod, "_launch_materials_sync_job", fake_launch)
+
+    resp = client.post(
+        "/api/tutor/materials/sync/start",
+        json={
+            "folder_path": str(root),
+            "selected_files": ["Dx/week1.pptx"],
+            "setup_files": ["Dx/syllabus.docx"],
+            "course_id": 304,
+        },
+    )
+
+    assert resp.status_code == 202
+    payload = resp.get_json()
+    assert payload["ok"] is True
+    assert payload["job_id"] == "job-source-refresh"
+    assert payload["selected_count"] == 2
+    assert payload["setup_count"] == 1
+    assert payload["course_id"] == 304
+    assert launch_calls == [
+        {
+            "root": root,
+            "selected_files": {"Dx/week1.pptx"},
+            "setup_files": {"Dx/syllabus.docx"},
+            "course_id": 304,
+        }
+    ]
 
 
 def test_material_sync_job_embeds_only_docs_from_that_sync(

--- a/brain/tests/test_tutor_material_pipeline_certification.py
+++ b/brain/tests/test_tutor_material_pipeline_certification.py
@@ -7,7 +7,10 @@ import os
 import sqlite3
 import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
+from unittest.mock import ANY
 
 import pytest
 
@@ -18,6 +21,7 @@ import db_setup
 import dashboard.api_data as _api_data_mod
 import dashboard.api_tutor as _api_tutor_mod
 import dashboard.api_adapter as _api_adapter_mod
+import dashboard.api_tutor_materials as _api_tutor_materials_mod
 from dashboard.app import create_app
 import rag_notes
 
@@ -253,6 +257,60 @@ def test_sync_start_validates_selected_files_and_course_id(client, monkeypatch: 
     assert payload["job_id"] == "job-sync-123"
     assert payload["selected_count"] == 1
     assert payload["course_id"] == 303
+
+
+def test_material_sync_job_embeds_only_docs_from_that_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "materials"
+    root.mkdir(parents=True)
+    finished = threading.Event()
+    embed_calls: list[dict] = []
+
+    def fake_sync_folder_to_rag(*args, **kwargs):  # noqa: ANN002, ANN003
+        return {
+            "ok": True,
+            "total": 2,
+            "processed": 2,
+            "failed": 0,
+            "errors": [],
+            "doc_ids": [101, 102],
+        }
+
+    def fake_embed_rag_docs(**kwargs):
+        embed_calls.append(kwargs)
+        finished.set()
+        return {"embedded": 2, "skipped": 0, "total_chunks": 2}
+
+    monkeypatch.setattr("rag_notes.sync_folder_to_rag", fake_sync_folder_to_rag)
+    monkeypatch.setattr("tutor_rag.embed_rag_docs", fake_embed_rag_docs)
+
+    job_id = _api_tutor_materials_mod._launch_materials_sync_job(
+        root,
+        None,
+        selected_files={"week1/slides.pdf", "week1/objectives.docx"},
+        course_id=77,
+    )
+
+    assert finished.wait(timeout=2), "sync job did not reach embedding"
+
+    deadline = time.time() + 2
+    status = None
+    while time.time() < deadline:
+        with _api_tutor_materials_mod.SYNC_JOBS_LOCK:
+            status = (_api_tutor_materials_mod.SYNC_JOBS.get(job_id) or {}).get("status")
+        if status == "completed":
+            break
+        time.sleep(0.01)
+
+    assert status == "completed"
+    assert embed_calls == [
+        {
+            "corpus": "materials",
+            "rag_doc_ids": [101, 102],
+            "progress_callback": ANY,
+        }
+    ]
 
 
 def test_sync_folder_to_rag_prunes_missing_files_on_full_sync(

--- a/brain/tests/test_tutor_session_linking.py
+++ b/brain/tests/test_tutor_session_linking.py
@@ -435,12 +435,12 @@ def test_preflight_reports_focus_objective_blocker(client):
     assert body["map_of_contents"]["path"] == "Courses/Neuroscience/Week 7/_Map of Contents.md"
 
 
-def test_create_session_requires_preflight_for_objective_scoped_setup(client):
+def test_create_session_accepts_workspace_context_without_preflight(client):
     resp = client.post(
         "/api/tutor/session",
         json={
             "mode": "Core",
-            "topic": "Week 7 without preflight",
+            "topic": "Week 7 from Workspace Context",
             "focus_objective_id": "OBJ-6",
             "objective_scope": "single_focus",
             "learning_objectives": [
@@ -455,9 +455,63 @@ def test_create_session_requires_preflight_for_objective_scoped_setup(client):
         },
     )
 
-    assert resp.status_code == 400
+    assert resp.status_code == 201
     body = resp.get_json()
-    assert body["code"] == "PREFLIGHT_REQUIRED"
+    assert body["focus_objective_id"] == "OBJ-6"
+    assert body["objective_scope"] == "single_focus"
+    conn = sqlite3.connect(config.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT content_filter_json FROM tutor_sessions WHERE session_id = ?",
+        (body["session_id"],),
+    ).fetchone()
+    conn.close()
+    saved_filter = json.loads(row["content_filter_json"] or "{}")
+    assert saved_filter["material_ids"] == [11, 12]
+
+
+def test_create_session_allows_material_backed_unmapped_workspace_context(client):
+    conn = sqlite3.connect(config.DB_PATH)
+    conn.execute(
+        """
+        INSERT INTO courses (id, name, code, color, created_at)
+        VALUES (?, ?, ?, ?, datetime('now'))
+        """,
+        (17, "Professionalism", "PHYT 6109", "#ff0000"),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = client.post(
+        "/api/tutor/session",
+        json={
+            "course_id": 17,
+            "mode": "Core",
+            "topic": "Week 0: Getting Started",
+            "module_name": "Week 0: Getting Started",
+            "objective_scope": "module_all",
+            "learning_objectives": [
+                {"lo_code": "MOD-1", "title": "Study Week 0: Getting Started"}
+            ],
+            "content_filter": {
+                "material_ids": [11, 12],
+                "accuracy_profile": "strict",
+            },
+        },
+    )
+
+    assert resp.status_code == 201
+    body = resp.get_json()
+    conn = sqlite3.connect(config.DB_PATH)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT content_filter_json FROM tutor_sessions WHERE session_id = ?",
+        (body["session_id"],),
+    ).fetchone()
+    conn.close()
+    saved_filter = json.loads(row["content_filter_json"] or "{}")
+    assert saved_filter["material_ids"] == [11, 12]
+    assert "Unmapped vault course" in saved_filter["map_of_contents_warning"]
 
 
 def test_create_session_rejects_non_integer_course_id(client):
@@ -600,6 +654,62 @@ def test_preflight_missing_mapped_objectives_returns_blocker_instead_of_500(
         blocker["code"] == "APPROVED_OBJECTIVES_REQUIRED"
         for blocker in body["blockers"]
     )
+
+
+def test_preflight_allows_material_backed_session_when_vault_course_unmapped(
+    client,
+    monkeypatch,
+):
+    conn = sqlite3.connect(config.DB_PATH)
+    conn.execute(
+        """
+        INSERT INTO courses (id, name, code, color, created_at)
+        VALUES (?, ?, ?, ?, datetime('now'))
+        """,
+        (12, "Professionalism", "PHYT 6109", "#ff0066"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(
+        _api_tutor_vault_mod,
+        "_resolve_learning_objectives_for_scope",
+        lambda **_kwargs: [
+            {
+                "objective_id": "MOD-1",
+                "title": "Study Week 1.",
+                "status": "active",
+                "group": "Week 1",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        _api_tutor_mod,
+        "_ensure_moc_context",
+        lambda **_kwargs: (
+            None,
+            "Unmapped vault course 'Professionalism' for module 'Week 1'.",
+        ),
+    )
+
+    resp = client.post(
+        "/api/tutor/session/preflight",
+        json={
+            "course_id": 12,
+            "study_unit": "Week 1",
+            "objective_scope": "module_all",
+            "content_filter": {
+                "material_ids": [561],
+            },
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["blockers"] == []
+    assert body["map_of_contents"] is None
+    assert body["resolved_learning_objectives"][0]["objective_id"] == "MOD-1"
 
 
 def test_template_chains_endpoint_exposes_certification_metadata(client):

--- a/brain/text_extractor.py
+++ b/brain/text_extractor.py
@@ -26,6 +26,12 @@ from path_utils import resolve_existing_path
 
 logger = logging.getLogger(__name__)
 
+_PDF_PRIVATE_USE_REPLACEMENTS: dict[str, str] = {
+    "\ue062": "Th",
+    "\ue0bb": "Th",
+    "\uf0e0": " -> ",
+}
+
 # ---------------------------------------------------------------------------
 # Tier availability checks (cached — only run once per process)
 # ---------------------------------------------------------------------------
@@ -172,6 +178,30 @@ def _has_garbled_content(content: str, threshold: float = 0.05) -> bool:
     bad += sum(len(m.group()) for m in re.finditer(r"GLYPH<[^>]*>", content))
     bad += sum(1 for c in content if "\u0100" <= c <= "\u024f")
     return bad / n > threshold
+
+
+def normalize_extracted_text(content: str) -> str:
+    """Clean common embedded-font artifacts from extracted course materials."""
+    if not content:
+        return content
+
+    text = content
+    for glyph, replacement in _PDF_PRIVATE_USE_REPLACEMENTS.items():
+        text = text.replace(glyph, replacement)
+
+    # Some PDFs extract ligatures as separated fragments: e ff orts, con fi dence.
+    text = re.sub(r"(?<=\w)\s+(ffi|ffl|fi|fl|ff)\s+(?=\w)", r"\1", text)
+    text = re.sub(r"\bTh\s+(?=[A-Za-z])", "Th", text)
+    text = re.sub(
+        r"\b([A-Za-z0-9]+)\s+'\s+(s|t|re|ve|ll|d|m)\b",
+        r"\1'\2",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"@\s+(?=[A-Za-z0-9])", "@", text)
+    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    return text
 
 
 def _build_pdf_pipeline_options(*, ocr_mode: bool = False) -> "PdfPipelineOptions":
@@ -603,6 +633,9 @@ def extract_text(file_path: str) -> dict:
                 "error": f"Unsupported file type: {ext}",
                 "metadata": metadata,
             }
+
+        if ext in (".pdf", ".docx", ".pptx"):
+            content = normalize_extracted_text(content)
 
         if extractor_name:
             metadata["extraction_method"] = extractor_name

--- a/brain/tutor_rag.py
+++ b/brain/tutor_rag.py
@@ -724,6 +724,7 @@ def embed_rag_docs(
     course_id: Optional[int] = None,
     folder_path: Optional[str] = None,
     corpus: Optional[str] = None,
+    rag_doc_ids: Optional[Iterable[int]] = None,
     progress_callback: Optional[Callable[[int, int, str], None]] = None,
 ) -> dict:
     """
@@ -755,6 +756,21 @@ def embed_rag_docs(
     if folder_path:
         conditions.append("folder_path LIKE ?")
         params.append(f"%{folder_path}%")
+    if rag_doc_ids is not None:
+        scoped_ids = []
+        for raw_id in rag_doc_ids:
+            try:
+                doc_id = int(raw_id)
+            except (TypeError, ValueError):
+                continue
+            if doc_id > 0:
+                scoped_ids.append(doc_id)
+        if scoped_ids:
+            placeholders = ",".join("?" for _ in scoped_ids)
+            conditions.append(f"id IN ({placeholders})")
+            params.extend(scoped_ids)
+        else:
+            conditions.append("0 = 1")
 
     where = " AND ".join(conditions)
     cur.execute(

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2712,3 +2712,11 @@ Recommended next steps:
 - Each source-file candidate has an explicit checkbox and `Upload Selected` action backed by the existing selected-file sync endpoint, keeping imports file-by-file instead of bulk folder ingestion.
 - Converted source folder rail rows from custom `div role="button"` controls to real buttons so browser clicks reliably activate folder selection.
 - Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `.venv/bin/python -m pytest brain/tests/test_tutor_material_pipeline_certification.py -q`; `npm run check`; `npm run build`; built-in browser verification on `/library` confirmed `10_Dx Mgmt Integumentary` opens Upload with source checkboxes and a checked candidate updates the button to `Upload Selected (1)`.
+
+## 2026-05-15 - Library file explorer table controls
+
+- Added basic file-explorer behavior to the `/library` file table: column widths are stateful, separators drag-resize, double-click auto-fits to visible file text, and headers can be dragged to reorder columns.
+- Added simple header filters for Title, Folder, Type, and Status while preserving the catalog-only Library boundary.
+- Persisted column width/order preferences in local storage and hardened table-state loading against invalid stored JSON.
+- Fixed right-edge filter menus to align inward so Type/Status menus do not clip their Clear/Done controls.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification before the final alignment tweak confirmed header controls render and the Type filter narrowed 11 rows to 1 TXT row. The final post-build reload was blocked by Browser Use URL policy, so the next operator refresh should visually confirm the right-edge menu placement.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2705,3 +2705,10 @@ Recommended next steps:
 - Added a Refresh source folders control and copy that explains counts are source files but rows are uploaded Library files.
 - Added regression coverage for env-backed sync preview with omitted `folder_path` and Library source-tree folder rendering.
 - Validation: `.venv/bin/python -m pytest brain/tests/test_tutor_material_pipeline_certification.py -q`; `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `/library` confirmed Dx Mgmt, Cardiovascular Pulmonary, class schedules, and other OneDrive PT School source folders appear in the Folders rail.
+
+## 2026-05-15 - Library source-file upload picker
+
+- Added a source-file picker to `/library` Upload: selecting a live PT School folder opens Upload and lists source files that are not already matched to uploaded Library rows.
+- Each source-file candidate has an explicit checkbox and `Upload Selected` action backed by the existing selected-file sync endpoint, keeping imports file-by-file instead of bulk folder ingestion.
+- Converted source folder rail rows from custom `div role="button"` controls to real buttons so browser clicks reliably activate folder selection.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `.venv/bin/python -m pytest brain/tests/test_tutor_material_pipeline_certification.py -q`; `npm run check`; `npm run build`; built-in browser verification on `/library` confirmed `10_Dx Mgmt Integumentary` opens Upload with source checkboxes and a checked candidate updates the button to `Upload Selected (1)`.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2689,3 +2689,11 @@ Recommended next steps:
 - Added scoped table reader CSS for normal cell wrapping, top-aligned cells, readable sans text, and wide-table horizontal scroll.
 - Added Library regression coverage proving extracted tables render through the table-scroll wrapper.
 - Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `http://127.0.0.1:5127/library` confirmed a real extracted material table renders with 4 table wrappers, scrollable overflow, wrapped cells, and clean console logs.
+
+## 2026-05-15 - Library material reader extraction cleanup
+
+- Fixed `/library` material content cleanup for embedded-PDF private-use glyphs that rendered as blocky missing letters, normalizing examples such as `\ue062 ere` -> `There`, `\ue062 ank` -> `Thank`, and `\ue0bb erapy` -> `Therapy`.
+- Tightened extracted-document formatting: the modal title now uses the material filename with readable sans typography, and the document body uses a narrower `86ch` reading column with improved paragraph spacing.
+- Added tests for private-use glyph cleanup, split-ligature cleanup, quoted-phrase safety, and the narrower material reader class.
+- Backed up `brain/data/pt_study.db` to `brain/data/backups/pt_study_before_extract_text_normalize_20260515_025808.db`, then normalized existing extracted rows in place so the current Library view is cleaned immediately.
+- Validation: `.venv/bin/python -m pytest brain/tests/test_text_extractor.py -q`; `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `/library` confirmed the cleaned PDF text and readable modal formatting.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2667,3 +2667,11 @@ Recommended next steps:
 - Removed the redundant lower workflow card stack and moved Tutor queue actions into the single `STUDY READINESS` panel.
 - Added compact Library hero styling so the actual course/material workspace is visible much sooner in narrow in-app browser windows.
 - Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; `curl -fsS http://127.0.0.1:5127/api/brain/status`; built-in browser DOM verification for `/library`.
+
+## 2026-05-15 - Library readable file viewer fix
+
+- Fixed `/library` material catalog metadata overlap by widening the table shell and giving the Type column room to wrap multiple badges such as file type, `COURSE REF`, and Docling asset counts.
+- Fixed the extracted-material viewer so the document body is the scrollable reader instead of being clipped by shared HUD panel overflow styling.
+- Increased material-reader typography and cleaned dialog description markup so long extracted PDFs/DOCX/PPTX content is readable and valid HTML.
+- Added Library regression coverage for opening extracted material content in a scrollable reader.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `http://127.0.0.1:5127/library` confirmed reader scrollTop changes inside the modal and console logs stay clean.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2682,3 +2682,10 @@ Recommended next steps:
 - Confirmed the extracted material text still includes `t/T` characters; the issue was rendering-only, not extraction loss.
 - Added a scoped `library-material-markdown` reader class and regression coverage so document headings cannot silently fall back to `font-arcade`.
 - Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `http://127.0.0.1:5127/library` confirmed reader headings render with system sans, normal tracking, normal case, and clean console logs.
+
+## 2026-05-15 - Library material reader table fix
+
+- Fixed extracted Markdown tables in `/library` material content so each table renders inside a horizontal scroll wrapper instead of squeezing or overflowing the document reader.
+- Added scoped table reader CSS for normal cell wrapping, top-aligned cells, readable sans text, and wide-table horizontal scroll.
+- Added Library regression coverage proving extracted tables render through the table-scroll wrapper.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `http://127.0.0.1:5127/library` confirmed a real extracted material table renders with 4 table wrappers, scrollable overflow, wrapped cells, and clean console logs.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2598,3 +2598,38 @@ Recommended next steps:
 - Added the Library `SEMESTER INTAKE` panel with folder scan, course readiness counts, and apply controls for the Mac PT School folder.
 - Added semester intake, fresh-DB, and Mac-local integration precondition regression tests.
 - Validation: `pytest brain/tests/ -q`; `npm run test`; `npm run check`; `npm run build`; `bash -n scripts/start_dashboard_macos.sh`.
+
+## 2026-05-13 - Complete study loop map, real-folder apply, and Tutor readiness
+
+- Added `docs/root/STUDY_LOOP_FLOW_AND_GAP_REVIEW.md` with the current coursework-to-study loop, Mermaid flowchart, validation matrix, gap register, and study-now handoff.
+- Real PT School preview on `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School` found 3 course folders, 6 syllabus files, 6 schedule files, 27 material files, 14 ignored/admin files, and no unassigned material files.
+- Backed up `brain/data/pt_study.db` to `brain/data/backups/pt_study_before_study_loop_apply_2026-05-13.db`, then applied reviewed structure only: 0 new courses, 3 updated courses, 6 setup files parsed, 14 grouped objectives created, no setup parse errors, and no material sync jobs.
+- Fixed real study blockers: course-code matching for typo folders, module fallback objectives/grouping, material-backed Tutor preflight when Obsidian course mapping is absent, and preview readiness from existing embedded `rag_docs`.
+- Verified Professionalism Week 1 can preflight and restore as session `tutor-20260513-101225-0c7ef7`; Library and Tutor browser screenshots rendered. Full model-backed `live_tutor_smoke.py` turn was deferred because it can send coursework to the configured external LLM provider.
+- Validation: `npm run check`; `npm run build`; `npm run test -- client/src/pages/__tests__/library.test.tsx`; `pytest brain/tests/test_semester_intake.py -q`; focused Tutor preflight regression tests.
+
+## 2026-05-13 - Dashboard high-CPU material sync fix
+
+- Reviewed `scratch/bug_dashboard_high_cpu_2026-05-13.md`, `brain/dashboard_web.py`, `dashboard.create_app`, the macOS launcher, request-triggered background jobs, and material sync/embedding flow.
+- Confirmed no dashboard process was currently listening on `127.0.0.1:5127`, so the previously hot process had already been killed before this fix pass.
+- Root cause addressed: `_launch_materials_sync_job()` embedded the entire `materials` corpus after a selected course/folder sync. That could make one coursework intake keep the Flask process busy across unrelated library files.
+- Added `rag_doc_ids` scoping to `embed_rag_docs()` and now pass the `doc_ids` returned by `sync_folder_to_rag()`, so post-sync embedding is limited to the files touched by that job.
+- Added regression coverage in `test_tutor_material_pipeline_certification.py` proving sync jobs pass only their synced document IDs into embedding.
+- Validation: `.venv/bin/python -m pytest brain/tests/test_harness_startup.py brain/tests/test_tutor_material_pipeline_certification.py brain/tests/test_tutor_rag_embedding_provider.py brain/tests/test_semester_intake.py -q` passed.
+
+## 2026-05-13 - Library explicit file loading
+
+- Changed Library so folder-based workflows no longer imply mass loading.
+- Semester Intake still scans the semester folder for classification, syllabus, schedule, and course setup, but material files start unselected and only checked files are included in the apply payload.
+- Folder Sync preview now starts with zero selected files after scan; `SYNC SELECTED FILES` stays disabled until at least one file is checked.
+- Added file-level checkbox labels for Semester Intake and Folder Sync so tests and keyboard/screen-reader flows can target exact files.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`.
+
+## 2026-05-13 - Library course operations redesign
+
+- Redesigned `/library` around a course-first operations workflow: left Course Rail, central Add Coursework source switcher, Study Readiness handoff panel, and cleaner material table flow.
+- Course names are now the primary navigation label, with PHYT codes shown as secondary metadata.
+- Consolidated Semester Intake, Folder Sync, and Direct Upload into one `ADD COURSEWORK` control area so only one source workflow is active at a time.
+- Removed the redundant lower workflow card stack and moved Tutor queue actions into the single `STUDY READINESS` panel.
+- Added compact Library hero styling so the actual course/material workspace is visible much sooner in narrow in-app browser windows.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; `curl -fsS http://127.0.0.1:5127/api/brain/status`; built-in browser DOM verification for `/library`.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2697,3 +2697,11 @@ Recommended next steps:
 - Added tests for private-use glyph cleanup, split-ligature cleanup, quoted-phrase safety, and the narrower material reader class.
 - Backed up `brain/data/pt_study.db` to `brain/data/backups/pt_study_before_extract_text_normalize_20260515_025808.db`, then normalized existing extracted rows in place so the current Library view is cleaned immediately.
 - Validation: `.venv/bin/python -m pytest brain/tests/test_text_extractor.py -q`; `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `/library` confirmed the cleaned PDF text and readable modal formatting.
+
+## 2026-05-15 - Library live PT School folder rail
+
+- Fixed `/library` Folders rail so it scans the configured PT School source folder through `/api/tutor/materials/sync/preview` instead of deriving folder names only from already-uploaded `rag_docs`.
+- Folder counts now reflect live PT School source files while the material table remains catalog-only for uploaded Library files.
+- Added a Refresh source folders control and copy that explains counts are source files but rows are uploaded Library files.
+- Added regression coverage for env-backed sync preview with omitted `folder_path` and Library source-tree folder rendering.
+- Validation: `.venv/bin/python -m pytest brain/tests/test_tutor_material_pipeline_certification.py -q`; `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `/library` confirmed Dx Mgmt, Cardiovascular Pulmonary, class schedules, and other OneDrive PT School source folders appear in the Folders rail.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2675,3 +2675,10 @@ Recommended next steps:
 - Increased material-reader typography and cleaned dialog description markup so long extracted PDFs/DOCX/PPTX content is readable and valid HTML.
 - Added Library regression coverage for opening extracted material content in a scrollable reader.
 - Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `http://127.0.0.1:5127/library` confirmed reader scrollTop changes inside the modal and console logs stay clean.
+
+## 2026-05-15 - Library material reader heading font fix
+
+- Fixed `/library` material content headings so extracted documents use readable sans typography instead of the global arcade heading treatment, which could make letters such as `T` appear missing or broken.
+- Confirmed the extracted material text still includes `t/T` characters; the issue was rendering-only, not extraction loss.
+- Added a scoped `library-material-markdown` reader class and regression coverage so document headings cannot silently fall back to `font-arcade`.
+- Validation: `npm run test -- client/src/pages/__tests__/library.test.tsx`; `npm run check`; `npm run build`; built-in browser verification on `http://127.0.0.1:5127/library` confirmed reader headings render with system sans, normal tracking, normal case, and clean console logs.

--- a/conductor/tracks/GENERAL/log.md
+++ b/conductor/tracks/GENERAL/log.md
@@ -2,6 +2,40 @@
 
 Changes not tied to a specific conductor track. Append dated entries below.
 
+## 2026-05-15 - Library catalog-only boundary
+
+- Simplified `/library` into an uploaded-file catalog and upload surface: primary tabs are now `All Files` and `Upload`.
+- Removed Library workflow paths for Semester Intake, Folder Sync, Tutor selection/handoff, Course Setup processing, Send to Priming, Obsidian destination, and PT School source refresh/import.
+- Added file search across uploaded Library rows and kept setup files visible as normal catalog rows with a `SETUP` badge.
+- Validation:
+  - `npm run test -- client/src/pages/__tests__/library.test.tsx`
+  - `npm run check`
+  - `npm run build`
+  - Built-in browser verification at `http://127.0.0.1:5127/library`; `All Files` and `Upload` render, search exists, and removed intake/Tutor/Obsidian controls are absent.
+
+## 2026-05-14 - Library visual design tightened
+
+- Made `/library` calmer and easier to read by reducing the Library hero/status strip height, muting the red HUD glow, and shifting the page-specific palette toward graphite surfaces with crimson accents.
+- Converted the Library workflow selector into semantic tabs so Source, Course Setup, Study Materials, Tutor Handoff, and Advanced behave like the primary navigation for the page.
+- Increased the readability of Library helper text, course rail rows, workflow tabs, and action controls while preserving the existing Library upload, intake, folder sync, and Tutor handoff behavior.
+- Validation:
+  - `npm run test -- client/src/pages/__tests__/library.test.tsx`
+  - `npm run check`
+  - `npm run build`
+  - Browser verification at `http://127.0.0.1:5127/library`; workflow tabs clicked successfully and console logs stayed clean.
+
+## 2026-05-14 - Library primary tabs simplified
+
+- Simplified `/library` primary navigation to the two user-facing surfaces Trey kept: `Study Materials` and `Add Files`.
+- Removed Course Setup, Tutor Handoff, and Advanced from the primary tab row while preserving setup upload, syllabus/schedule setup source rows, setup-to-Priming, one-file Study launch, and selective import/sync behavior.
+- Moved setup files into a compact syllabus/schedule collapsible inside Study Materials and kept Tutor selection controls inline instead of as a separate Tutor Handoff destination.
+- Renamed the inline handoff controls from vague `Study Run` language to `Selected for Tutor`, `Use Visible`, and `Add Visible`.
+- Validation:
+  - `npm run test -- client/src/pages/__tests__/library.test.tsx`
+  - `npm run check`
+  - `npm run build`
+  - Browser verification at `http://127.0.0.1:5127/library`; only Study Materials and Add Files appeared as primary tabs, both rendered correctly, and console logs stayed clean.
+
 ## 2026-04-01 - KWIK Hook aligned to literal word-sound -> meaning -> link flow
 
 - Rewrote `sop/library/methods/M-ENC-001.yaml` so full `KWIK Hook` now literally walks through `Word Sound -> Real Meaning -> Meaning Picture -> Link -> Personalize -> Lock`, which matches the mnemonic flow Trey wants to use during study.

--- a/dashboard_rebuild/client/src/__tests__/api.test.ts
+++ b/dashboard_rebuild/client/src/__tests__/api.test.ts
@@ -745,10 +745,11 @@ describe("api.tutor", () => {
 
   it("getMaterials builds query string", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse([]));
-    await api.tutor.getMaterials({ course_id: 2, enabled: true });
+    await api.tutor.getMaterials({ course_id: 2, enabled: true, include_setup: true });
     const url = mockFetch.mock.calls[0][0] as string;
     expect(url).toContain("course_id=2");
     expect(url).toContain("enabled=1");
+    expect(url).toContain("include_setup=1");
   });
 
   it("uploadMaterial sends FormData via fetch", async () => {

--- a/dashboard_rebuild/client/src/api.ts
+++ b/dashboard_rebuild/client/src/api.ts
@@ -1090,21 +1090,33 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ material_id: materialId, ...(opts || {}) }),
       }),
-    uploadMaterial: async (file: File, opts?: { course_id?: number; title?: string; tags?: string }) => {
+    uploadMaterial: async (
+      file: File,
+      opts?: {
+        course_id?: number;
+        title?: string;
+        tags?: string;
+        library_role?: "study" | "setup" | string;
+        setup_kind?: "syllabus" | "schedule" | "syllabus_schedule" | "course_setup" | string;
+      },
+    ) => {
       const form = new FormData();
       form.append("file", file);
       if (opts?.course_id) form.append("course_id", String(opts.course_id));
       if (opts?.title) form.append("title", opts.title);
       if (opts?.tags) form.append("tags", opts.tags);
+      if (opts?.library_role) form.append("library_role", opts.library_role);
+      if (opts?.setup_kind) form.append("setup_kind", opts.setup_kind);
       const res = await fetch(`${API_BASE}/tutor/materials/upload`, { method: "POST", body: form });
       if (!res.ok) throw new Error(`Upload failed: ${res.statusText}`);
       return res.json() as Promise<MaterialUploadResponse>;
     },
-    getMaterials: (params?: { course_id?: number; file_type?: string; enabled?: boolean }) => {
+    getMaterials: (params?: { course_id?: number; file_type?: string; enabled?: boolean; include_setup?: boolean }) => {
       const qs = new URLSearchParams();
       if (params?.course_id) qs.set("course_id", String(params.course_id));
       if (params?.file_type) qs.set("file_type", params.file_type);
       if (params?.enabled !== undefined) qs.set("enabled", params.enabled ? "1" : "0");
+      if (params?.include_setup) qs.set("include_setup", "1");
       const q = qs.toString();
       return request<Material[]>(`/tutor/materials${q ? `?${q}` : ""}`);
     },

--- a/dashboard_rebuild/client/src/api.types.ts
+++ b/dashboard_rebuild/client/src/api.types.ts
@@ -2227,7 +2227,7 @@ export interface TutorEmbedResult {
 }
 
 export interface TutorSyncPreviewPayload {
-  folder_path: string;
+  folder_path?: string;
   allowed_exts?: string[];
 }
 

--- a/dashboard_rebuild/client/src/api.types.ts
+++ b/dashboard_rebuild/client/src/api.types.ts
@@ -2233,6 +2233,7 @@ export interface TutorSyncPreviewPayload {
 
 export interface TutorSyncStartPayload extends TutorSyncPreviewPayload {
   selected_files?: string[];
+  setup_files?: string[];
   course_id?: number | null;
 }
 
@@ -2263,6 +2264,7 @@ export interface TutorSyncStartResult {
   job_id: string;
   folder?: string;
   selected_count?: number | null;
+  setup_count?: number | null;
   course_id?: number | null;
 }
 
@@ -2444,6 +2446,11 @@ export interface Material {
   title: string | null;
   source_path: string | null;
   folder_path: string | null;
+  corpus?: string | null;
+  doc_type?: string | null;
+  topic_tags?: string | null;
+  material_role?: "study" | "setup" | "reference" | string | null;
+  setup_kind?: "syllabus" | "schedule" | "syllabus_schedule" | "course_setup" | string | null;
   file_type: string | null;
   file_size: number | null;
   course_id: number | null;
@@ -2480,6 +2487,8 @@ export interface MaterialUploadResponse {
   file_size: number;
   char_count: number;
   embedded: boolean;
+  library_role?: string | null;
+  setup_kind?: string | null;
   duplicate_of: { id: number; title: string } | null;
 }
 

--- a/dashboard_rebuild/client/src/api.types.ts
+++ b/dashboard_rebuild/client/src/api.types.ts
@@ -2276,6 +2276,7 @@ export interface SemesterIntakeFile {
 
 export interface SemesterIntakeCoursePreview {
   name: string;
+  code?: string | null;
   folder_path: string;
   course_id?: number;
   syllabus_files: SemesterIntakeFile[];

--- a/dashboard_rebuild/client/src/components/MaterialUploader.tsx
+++ b/dashboard_rebuild/client/src/components/MaterialUploader.tsx
@@ -16,10 +16,17 @@ const ACCEPTED = ".pdf,.md,.docx,.pptx,.txt,.mp4";
 
 interface MaterialUploaderProps {
   courseId?: number;
+  role?: "study" | "setup";
+  setupKind?: "syllabus" | "schedule" | "syllabus_schedule" | "course_setup";
   onUploadComplete?: () => void;
 }
 
-export function MaterialUploader({ courseId, onUploadComplete }: MaterialUploaderProps) {
+export function MaterialUploader({
+  courseId,
+  role = "study",
+  setupKind,
+  onUploadComplete,
+}: MaterialUploaderProps) {
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
@@ -50,7 +57,11 @@ export function MaterialUploader({ courseId, onUploadComplete }: MaterialUploade
 
     for (const file of queue) {
       try {
-        await api.tutor.uploadMaterial(file, { course_id: courseId });
+        await api.tutor.uploadMaterial(file, {
+          course_id: courseId,
+          ...(role !== "study" ? { library_role: role } : {}),
+          ...(setupKind ? { setup_kind: setupKind } : {}),
+        });
         successes++;
       } catch (err) {
         failures++;
@@ -67,7 +78,7 @@ export function MaterialUploader({ courseId, onUploadComplete }: MaterialUploade
       queryClient.invalidateQueries({ queryKey: ["tutor-content-sources"] });
       onUploadComplete?.();
     }
-  }, [queue, courseId, queryClient, onUploadComplete]);
+  }, [queue, courseId, role, setupKind, queryClient, onUploadComplete]);
 
   const onDrop = useCallback(
     (e: React.DragEvent) => {

--- a/dashboard_rebuild/client/src/components/TutorShell.tsx
+++ b/dashboard_rebuild/client/src/components/TutorShell.tsx
@@ -2055,7 +2055,9 @@ export function TutorShell({
             >
               <Upload className="mx-auto h-4 w-4 text-[#ffb9c7]" aria-hidden="true" />
               <div className="mt-2 text-[11px] uppercase tracking-[0.18em] text-white">
-                {sourceShelfUploading ? "Uploading Materials..." : "Upload New Materials"}
+                {sourceShelfUploading
+                  ? "Adding to Current Run..."
+                  : "Upload to Library + Current Run"}
               </div>
               <div className="mt-1 text-[11px] text-[#ffc8d3]/68">
                 PDF, DOCX, MP4, PPTX
@@ -2064,7 +2066,7 @@ export function TutorShell({
             <input
               ref={entryUploadInputRef}
               data-testid="studio-entry-upload-input"
-              aria-label="Upload new materials"
+              aria-label="Upload to Library and Current Run"
               type="file"
               accept={ENTRY_CARD_UPLOAD_ACCEPT}
               multiple
@@ -2076,7 +2078,7 @@ export function TutorShell({
                 data-testid="studio-entry-upload-status"
                 className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#ffb9c7]"
               >
-                Uploading selected files to this course...
+                Uploading to Library and Current Run...
               </div>
             ) : null}
           </div>

--- a/dashboard_rebuild/client/src/components/TutorShell.tsx
+++ b/dashboard_rebuild/client/src/components/TutorShell.tsx
@@ -29,6 +29,7 @@ import {
   buildStudioWorkspaceObjects,
   normalizeStudioWorkspaceObjects,
   type StudioWorkspaceObject,
+  type StudioWorkspaceObjectUpdate,
 } from "@/lib/studioWorkspaceObjects";
 import {
   readTutorWorkspaceDraftObjects,
@@ -68,6 +69,22 @@ function isPrimePromotedWorkspaceObject(
   workspaceObject: StudioWorkspaceObject,
 ): workspaceObject is PrimePromotedWorkspaceObject {
   return workspaceObject.kind === "excerpt" || workspaceObject.kind === "text_note";
+}
+
+function applyWorkspaceObjectUpdate<T extends StudioWorkspaceObject>(
+  workspaceObject: T,
+  patch: StudioWorkspaceObjectUpdate,
+): T {
+  return {
+    ...workspaceObject,
+    ...patch,
+    workspace: patch.workspace
+      ? {
+          ...workspaceObject.workspace,
+          ...patch.workspace,
+        }
+      : workspaceObject.workspace,
+  } as T;
 }
 
 function readCapsuleRecordLabel(record: Record<string, unknown> | null | undefined): string | null {
@@ -493,9 +510,31 @@ export function TutorShell({
 
     return Array.from(merged.values());
   }, [controlledPromotedPrimePacketObjects, localPromotedPrimePacketObjects]);
+  const tutorContextWorkspaceObjects = useMemo(
+    () =>
+      workspaceDraftObjects.filter(
+        (workspaceObject): workspaceObject is PrimePromotedWorkspaceObject =>
+          isPrimePromotedWorkspaceObject(workspaceObject) &&
+          workspaceObject.workspace?.tutorContext === true,
+      ),
+    [workspaceDraftObjects],
+  );
+  const tutorContextPacketObjects = useMemo(() => {
+    const merged = new Map<string, PrimePromotedWorkspaceObject>();
+
+    for (const workspaceObject of promotedPrimePacketObjects) {
+      merged.set(workspaceObject.id, workspaceObject);
+    }
+
+    for (const workspaceObject of tutorContextWorkspaceObjects) {
+      merged.set(workspaceObject.id, workspaceObject);
+    }
+
+    return Array.from(merged.values());
+  }, [promotedPrimePacketObjects, tutorContextWorkspaceObjects]);
   const promotedPrimeObjectIds = useMemo(
-    () => promotedPrimePacketObjects.map((workspaceObject) => workspaceObject.id),
-    [promotedPrimePacketObjects],
+    () => tutorContextPacketObjects.map((workspaceObject) => workspaceObject.id),
+    [tutorContextPacketObjects],
   );
   const documentTabs = controlledDocumentTabs ?? localDocumentTabs;
   const activeDocumentTabId =
@@ -543,23 +582,23 @@ export function TutorShell({
   );
   const promotedPrimeExcerptObjects = useMemo(
     () =>
-      promotedPrimePacketObjects.filter(
+      tutorContextPacketObjects.filter(
         (
           workspaceObject,
         ): workspaceObject is Extract<StudioWorkspaceObject, { kind: "excerpt" }> =>
           workspaceObject.kind === "excerpt",
       ),
-    [promotedPrimePacketObjects],
+    [tutorContextPacketObjects],
   );
   const promotedPrimeArtifactObjects = useMemo(
     () =>
-      promotedPrimePacketObjects.filter(
+      tutorContextPacketObjects.filter(
         (
           workspaceObject,
         ): workspaceObject is Extract<StudioWorkspaceObject, { kind: "text_note" }> =>
           workspaceObject.kind === "text_note",
       ),
-    [promotedPrimePacketObjects],
+    [tutorContextPacketObjects],
   );
   const primePacketSections = useMemo(
     () =>
@@ -672,6 +711,34 @@ export function TutorShell({
     },
     [],
   );
+  const handleUpdateWorkspaceObject = useCallback(
+    (objectId: string, patch: StudioWorkspaceObjectUpdate) => {
+      setWorkspaceDraftObjects((prev) =>
+        prev.map((workspaceObject) =>
+          workspaceObject.id === objectId
+            ? applyWorkspaceObjectUpdate(workspaceObject, patch)
+            : workspaceObject,
+        ),
+      );
+      setLocalPromotedPrimePacketObjects((prev) =>
+        prev.map((workspaceObject) =>
+          workspaceObject.id === objectId
+            ? applyWorkspaceObjectUpdate(workspaceObject, patch)
+            : workspaceObject,
+        ),
+      );
+    },
+    [],
+  );
+  const handleDeleteWorkspaceObject = useCallback((objectId: string) => {
+    setWorkspaceDraftObjects((prev) =>
+      prev.filter((workspaceObject) => workspaceObject.id !== objectId),
+    );
+    setCanvasObjectIds((prev) => prev.filter((existingId) => existingId !== objectId));
+    setLocalPromotedPrimePacketObjects((prev) =>
+      prev.filter((workspaceObject) => workspaceObject.id !== objectId),
+    );
+  }, []);
   const handleOpenSourceInDocumentDock = useCallback(
     (
       workspaceObject: Extract<
@@ -1453,7 +1520,7 @@ export function TutorShell({
     artifacts: session.artifacts,
     turnCount: session.turnCount ?? 0,
     capturedNotes: workflow.activeWorkflowDetail?.captured_notes ?? [],
-    primePacket: promotedPrimePacketObjects,
+    primePacket: tutorContextPacketObjects,
     polishPacket: promotedPolishPacketNotes,
     hasWorkflowDetail: Boolean(workflow.activeWorkflowDetail),
   });
@@ -1473,6 +1540,8 @@ export function TutorShell({
         sessionMaterialBundle={sessionMaterialBundle}
         onPromoteExcerptToPrime={handlePromoteExcerptToPrime}
         onPromoteTextNoteToPrime={handlePromoteTextNoteToPrime}
+        onUpdateWorkspaceObject={handleUpdateWorkspaceObject}
+        onDeleteWorkspaceObject={handleDeleteWorkspaceObject}
       />
     </div>
   );
@@ -1521,9 +1590,9 @@ export function TutorShell({
           sourceInventory={workflow.mergedPrimingSourceInventory}
           vaultFolderPreview={hub.derivedVaultFolder}
           readinessItems={workflow.primingReadinessItems}
-          preflightBlockers={session.preflight?.blockers || []}
-          preflightLoading={session.preflightLoading}
-          preflightError={session.preflightError}
+          preflightBlockers={[]}
+          preflightLoading={false}
+          preflightError={null}
           onBackToStudio={() => undefined}
           onSaveDraft={() => {
             void workflow.saveWorkflowPriming("draft");

--- a/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
+++ b/dashboard_rebuild/client/src/components/TutorWorkflowPrimingPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { CheckSquare2, Loader2, Play, SendHorizontal, Sparkles, Square } from "lucide-react";
 import { toast } from "sonner";
@@ -674,6 +674,7 @@ export function TutorWorkflowPrimingPanel({
   isRunningAssist,
 }: TutorWorkflowPrimingPanelProps) {
   const previousAssistRunningRef = useRef(isRunningAssist);
+  const autoCapturedRunKeyRef = useRef<string | null>(null);
 
   const {
     data: primeMethodResponse = [],
@@ -1015,25 +1016,36 @@ export function TutorWorkflowPrimingPanel({
     }
   };
 
-  const handlePromote = (block: ResultBlock) => {
-    const workspaceObject = createStudioPrimingResultWorkspaceObject({
+  const buildWorkspaceObjectFromBlock = useCallback((block: ResultBlock) => {
+    return createStudioPrimingResultWorkspaceObject({
       resultKey: block.id,
       title: block.title,
       detail: buildBlockMarkdown(block),
       badge: block.badge,
       sourceLabel: block.sourceLabel,
     }) as Extract<StudioWorkspaceObject, { kind: "text_note" }>;
+  }, []);
+
+  useEffect(() => {
+    if (!displayedRun || displayedRun.blocks.length === 0 || !onSendResultToWorkspace) {
+      return;
+    }
+    if (autoCapturedRunKeyRef.current === displayedRun.key) {
+      return;
+    }
+    autoCapturedRunKeyRef.current = displayedRun.key;
+    displayedRun.blocks.forEach((block) => {
+      onSendResultToWorkspace(buildWorkspaceObjectFromBlock(block));
+    });
+  }, [buildWorkspaceObjectFromBlock, displayedRun, onSendResultToWorkspace]);
+
+  const handlePromote = (block: ResultBlock) => {
+    const workspaceObject = buildWorkspaceObjectFromBlock(block);
     onPromoteResultToPrimePacket?.(workspaceObject);
   };
 
   const handleSendToWorkspace = (block: ResultBlock) => {
-    const workspaceObject = createStudioPrimingResultWorkspaceObject({
-      resultKey: block.id,
-      title: block.title,
-      detail: buildBlockMarkdown(block),
-      badge: block.badge,
-      sourceLabel: block.sourceLabel,
-    }) as Extract<StudioWorkspaceObject, { kind: "text_note" }>;
+    const workspaceObject = buildWorkspaceObjectFromBlock(block);
     onSendResultToWorkspace?.(workspaceObject);
   };
 

--- a/dashboard_rebuild/client/src/components/__tests__/MaterialUploader.test.tsx
+++ b/dashboard_rebuild/client/src/components/__tests__/MaterialUploader.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MaterialUploader } from "@/components/MaterialUploader";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { api } from "@/lib/api";
 
 // Mock api
 vi.mock("@/lib/api", () => ({
@@ -219,5 +220,26 @@ describe("MaterialUploader", () => {
     fireEvent.change(input);
 
     expect(screen.queryByText(/UPLOAD/)).not.toBeInTheDocument();
+  });
+
+  it("uploads Course Setup files with setup role metadata and no study embedding request", async () => {
+    render(
+      <MaterialUploader courseId={6262} role="setup" setupKind="syllabus_schedule" />,
+      { wrapper: createWrapper() },
+    );
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const docx = new File(["doc data"], "dx-syllabus-schedule.docx", {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    Object.defineProperty(input, "files", { value: [docx] });
+    fireEvent.change(input);
+    fireEvent.click(screen.getByText("UPLOAD 1 FILE"));
+
+    expect(api.tutor.uploadMaterial).toHaveBeenCalledWith(docx, {
+      course_id: 6262,
+      library_role: "setup",
+      setup_kind: "syllabus_schedule",
+    });
   });
 });

--- a/dashboard_rebuild/client/src/components/__tests__/TutorShell.test.tsx
+++ b/dashboard_rebuild/client/src/components/__tests__/TutorShell.test.tsx
@@ -1854,7 +1854,7 @@ describe("TutorShell studio routing", () => {
     );
 
     expect(await screen.findByTestId("studio-entry-upload-status")).toHaveTextContent(
-      "Uploading selected files to this course...",
+      "Uploading to Library and Current Run...",
     );
     (resolveUpload as unknown as (value: { id: number }) => void)({ id: 104 });
     await uploadPromise;

--- a/dashboard_rebuild/client/src/components/__tests__/TutorShell.test.tsx
+++ b/dashboard_rebuild/client/src/components/__tests__/TutorShell.test.tsx
@@ -24,11 +24,13 @@ vi.mock("@/components/TutorWorkflowPrimingPanel", () => ({
     onStartTutor,
     onRunAssistForSelected,
     onOpenConceptMapInWorkspace,
+    onSendResultToWorkspace,
     selectedMaterials = [],
   }: {
     onStartTutor?: () => void;
     onRunAssistForSelected?: (methodIdOverride?: string) => void;
     onOpenConceptMapInWorkspace?: (mermaid: string) => void;
+    onSendResultToWorkspace?: (workspaceObject: unknown) => void;
     selectedMaterials?: number[];
   }) => (
     <div data-testid="mock-priming-panel">
@@ -41,6 +43,29 @@ vi.mock("@/components/TutorWorkflowPrimingPanel", () => ({
       </button>
       <button type="button" onClick={() => onRunAssistForSelected?.()}>
         Run Priming Assist from priming panel
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onSendResultToWorkspace?.({
+            id: "priming-result:workspace-objectives",
+            kind: "text_note",
+            title: "Workspace-selected objectives",
+            detail: "Use selected Workspace cards as Tutor context.",
+            badge: "OBJECTIVES",
+            workspace: {
+              tutorContext: true,
+              obsidianHandoff: true,
+            },
+            provenance: {
+              sourceType: "priming_result",
+              resultKey: "learning-objectives",
+              sourceLabel: "Learning Objectives Primer",
+            },
+          })
+        }
+      >
+        Capture Workspace priming note
       </button>
       <button
         type="button"
@@ -3119,6 +3144,50 @@ describe("TutorShell studio routing", () => {
       expect.objectContaining({
         packet_context: expect.stringContaining(
           "The learner mixed preload effects with heart-rate regulation.",
+        ),
+      }),
+    );
+  });
+
+  it("passes Workspace cards marked for Tutor into Tutor startup packet context", async () => {
+    const user = userEvent.setup();
+    const startTutorFromWorkflow = vi.fn();
+
+    renderTutorShell("priming", {
+      hubOverrides: {
+        selectedMaterials: [101],
+        chatMaterials: [
+          {
+            id: 101,
+            title: "Cardiac Output Lecture",
+            source_path: "uploads/cardio-output.pdf",
+            file_type: "pdf",
+          },
+        ],
+      },
+      workflowOverrides: {
+        startTutorFromWorkflow,
+      },
+    });
+
+    expect(await screen.findByTestId("mock-priming-panel")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /capture workspace priming note/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Start Tutor from priming panel/i }),
+    );
+
+    expect(startTutorFromWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packet_context: expect.stringContaining("Workspace-selected objectives"),
+      }),
+    );
+    expect(startTutorFromWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packet_context: expect.stringContaining(
+          "Use selected Workspace cards as Tutor context.",
         ),
       }),
     );

--- a/dashboard_rebuild/client/src/components/__tests__/TutorWorkflowPrimingPanel.test.tsx
+++ b/dashboard_rebuild/client/src/components/__tests__/TutorWorkflowPrimingPanel.test.tsx
@@ -560,7 +560,7 @@ describe("TutorWorkflowPrimingPanel", () => {
     expect(screen.getAllByText("Trey's Favorite: Start Here").length).toBeGreaterThan(0);
   });
 
-  it("runs a selected method, renders formatted objectives, and sends the result to Prime Packet and Workspace", async () => {
+  it("runs a selected method, renders formatted objectives, and auto-captures the result as a Workspace card", async () => {
     const onRunAssistForSelected = vi.fn();
     const onPromoteResultToPrimePacket = vi.fn();
     const onSendResultToWorkspace = vi.fn();
@@ -742,13 +742,18 @@ describe("TutorWorkflowPrimingPanel", () => {
       }),
     );
 
-    // Text-only result blocks (objectives) don't expose a Send to Workspace
-    // button — Workspace canvas is reserved for visual constructs. The
-    // onSendResultToWorkspace callback should remain unfired for this flow.
-    expect(
-      screen.queryByRole("button", { name: /send to workspace/i }),
-    ).not.toBeInTheDocument();
-    expect(onSendResultToWorkspace).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(onSendResultToWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "text_note",
+          title: expect.stringContaining("Learning Objectives"),
+          badge: "OBJECTIVES",
+          provenance: expect.objectContaining({
+            sourceType: "priming_result",
+          }),
+        }),
+      ),
+    );
   });
 
   it("enables Priming chat after RUN, sends a follow-up, and applies revised results", async () => {

--- a/dashboard_rebuild/client/src/components/layout.tsx
+++ b/dashboard_rebuild/client/src/components/layout.tsx
@@ -777,7 +777,7 @@ function useLayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <div
       className={cn(
-        "relative flex min-h-[100dvh] flex-col bg-transparent font-terminal text-foreground",
+        "relative flex min-h-[100dvh] w-full min-w-0 flex-col overflow-x-hidden bg-background font-terminal text-foreground",
       )}
     >
       <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden">
@@ -1375,11 +1375,11 @@ function useLayoutContent({ children }: { children: React.ReactNode }) {
       </button>
 
       {/* Hero portal — PageScaffold renders the page hero here, outside main */}
-      <div id="page-hero-portal" className="relative z-10" />
+      <div id="page-hero-portal" className="relative z-10 w-full min-w-0 overflow-x-hidden" />
 
       <main
         className={cn(
-          "relative z-10 w-full flex-1",
+          "relative z-10 w-full min-w-0 flex-1 overflow-x-hidden",
           isWorkspaceRoute ? "" : "px-2 py-3 sm:px-3 md:px-5 md:py-4",
         )}
       >

--- a/dashboard_rebuild/client/src/components/studio/SourceShelf.tsx
+++ b/dashboard_rebuild/client/src/components/studio/SourceShelf.tsx
@@ -1039,7 +1039,7 @@ export function SourceShelf({
             className="h-10 rounded-full border-primary/20 bg-black/20 px-4 font-mono text-[10px] uppercase tracking-[0.18em] text-white/82 hover:bg-black/30 hover:text-white"
           >
             <Upload className="mr-2 h-3.5 w-3.5" />
-            {isUploading ? "Uploading..." : "Upload"}
+            {isUploading ? "Uploading..." : "Upload to Current Run"}
           </Button>
           <input
             ref={uploadInputRef}

--- a/dashboard_rebuild/client/src/components/studio/StudioTldrawWorkspace.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioTldrawWorkspace.tsx
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import type { Editor } from "tldraw";
-import type { StudioWorkspaceObject } from "@/lib/studioWorkspaceObjects";
+import type {
+  StudioWorkspaceCardState,
+  StudioWorkspaceObject,
+  StudioWorkspaceObjectUpdate,
+} from "@/lib/studioWorkspaceObjects";
+import { buildObsidianHandoffMarkdown } from "@/lib/obsidianHandoffPacket";
 import {
   buildStudioCanvasShape,
   getStudioCanvasShapeId,
@@ -17,6 +23,8 @@ import { Tldraw } from "tldraw";
 import "tldraw/tldraw.css";
 
 const TLDRAW_VENDOR_CTA_RE = /get a license for production|made with tldraw/i;
+const WORKSPACE_CARD_BUTTON_CLASS =
+  "h-7 rounded-full border-primary/20 bg-black/20 px-2.5 font-mono text-[9px] uppercase tracking-[0.14em] text-primary/84 hover:bg-black/30 disabled:cursor-default disabled:opacity-100 disabled:text-foreground/60";
 
 function stripVendorCtas(root: ParentNode) {
   root.querySelectorAll("a, button").forEach((element) => {
@@ -45,6 +53,11 @@ export interface StudioTldrawWorkspaceProps {
   onPromoteTextNoteToPrime?: (
     workspaceObject: Extract<StudioWorkspaceObject, { kind: "text_note" }>,
   ) => void;
+  onUpdateWorkspaceObject?: (
+    objectId: string,
+    patch: StudioWorkspaceObjectUpdate,
+  ) => void;
+  onDeleteWorkspaceObject?: (objectId: string) => void;
 }
 
 export function StudioTldrawWorkspace({
@@ -56,11 +69,41 @@ export function StudioTldrawWorkspace({
   sessionBundle,
   onPromoteExcerptToPrime,
   onPromoteTextNoteToPrime,
+  onUpdateWorkspaceObject,
+  onDeleteWorkspaceObject,
 }: StudioTldrawWorkspaceProps) {
   const [editor, setEditor] = useState<Editor | null>(null);
+  const [editingCardId, setEditingCardId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState("");
+  const [editingDetail, setEditingDetail] = useState("");
   const syncedObjectIdsRef = useRef<string[]>([]);
   const workspaceRootRef = useRef<HTMLDivElement | null>(null);
   const sessionSeedKeyRef = useRef<string | null>(null);
+  const visibleCanvasObjects = useMemo(
+    () => canvasObjects.filter((workspaceObject) => !workspaceObject.workspace?.hidden),
+    [canvasObjects],
+  );
+  const obsidianHandoffObjects = useMemo(
+    () =>
+      canvasObjects.filter(
+        (workspaceObject) => workspaceObject.workspace?.obsidianHandoff === true,
+      ),
+    [canvasObjects],
+  );
+  const materialTitles = useMemo(
+    () =>
+      canvasObjects
+        .filter((workspaceObject) => workspaceObject.kind === "material")
+        .map((workspaceObject) => workspaceObject.title),
+    [canvasObjects],
+  );
+  const sessionGoal = useMemo(
+    () =>
+      [sessionBundle?.studyUnit, sessionBundle?.topic]
+        .filter((value): value is string => Boolean(value?.trim()))
+        .join(" / ") || null,
+    [sessionBundle?.studyUnit, sessionBundle?.topic],
+  );
 
   const deleteSessionSeedShapes = useCallback(
     (targetEditor: Editor) => {
@@ -95,7 +138,7 @@ export function StudioTldrawWorkspace({
     if (sessionSeedKeyRef.current === sessionBundle.sessionKey) return;
     // Only auto-seed a clean canvas: no synced workspace objects AND no
     // user-created shapes yet (beyond stale session seeds we control).
-    if (canvasObjects.length > 0) {
+    if (visibleCanvasObjects.length > 0) {
       sessionSeedKeyRef.current = sessionBundle.sessionKey;
       return;
     }
@@ -111,7 +154,7 @@ export function StudioTldrawWorkspace({
     if (applied) {
       sessionSeedKeyRef.current = sessionBundle.sessionKey;
     }
-  }, [applySessionSeed, canvasObjects.length, editor, sessionBundle]);
+  }, [applySessionSeed, editor, sessionBundle, visibleCanvasObjects.length]);
 
   const handleRefreshFromSession = useCallback(() => {
     if (!editor || !sessionBundle?.isReady) return;
@@ -126,6 +169,78 @@ export function StudioTldrawWorkspace({
       sessionSeedKeyRef.current = sessionBundle.sessionKey;
     }
   }, [applySessionSeed, editor, sessionBundle]);
+  const patchWorkspaceState = useCallback(
+    (workspaceObject: StudioWorkspaceObject, patch: StudioWorkspaceCardState) => {
+      onUpdateWorkspaceObject?.(workspaceObject.id, {
+        workspace: {
+          ...workspaceObject.workspace,
+          ...patch,
+        },
+      });
+    },
+    [onUpdateWorkspaceObject],
+  );
+
+  const beginCardEdit = useCallback((workspaceObject: StudioWorkspaceObject) => {
+    setEditingCardId(workspaceObject.id);
+    setEditingTitle(workspaceObject.title);
+    setEditingDetail(workspaceObject.detail);
+  }, []);
+
+  const cancelCardEdit = useCallback(() => {
+    setEditingCardId(null);
+    setEditingTitle("");
+    setEditingDetail("");
+  }, []);
+
+  const saveCardEdit = useCallback(() => {
+    if (!editingCardId) return;
+    onUpdateWorkspaceObject?.(editingCardId, {
+      title: editingTitle.trim() || "Untitled Workspace card",
+      detail: editingDetail.trim(),
+    });
+    cancelCardEdit();
+  }, [
+    cancelCardEdit,
+    editingCardId,
+    editingDetail,
+    editingTitle,
+    onUpdateWorkspaceObject,
+  ]);
+
+  const handleCopyObsidianHandoff = useCallback(async () => {
+    if (obsidianHandoffObjects.length === 0) {
+      toast.error("Select at least one Workspace card for Obsidian first");
+      return;
+    }
+    try {
+      if (
+        typeof window === "undefined" ||
+        !window.navigator.clipboard?.writeText
+      ) {
+        throw new Error("Clipboard unavailable");
+      }
+      const markdown = buildObsidianHandoffMarkdown({
+        courseName,
+        sessionGoal,
+        materialTitles,
+        workspaceObjects: canvasObjects,
+      });
+      await window.navigator.clipboard.writeText(markdown);
+      toast.success("Copied Obsidian handoff markdown");
+    } catch (err) {
+      toast.error("Could not copy Obsidian handoff", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }, [
+    canvasObjects,
+    courseName,
+    materialTitles,
+    obsidianHandoffObjects.length,
+    sessionGoal,
+  ]);
+
   const excerptObjects = canvasObjects.filter(
     (
       workspaceObject,
@@ -148,12 +263,12 @@ export function StudioTldrawWorkspace({
   useEffect(() => {
     if (!editor) return;
 
-    const nextObjectIds = canvasObjects.map((workspaceObject) => workspaceObject.id);
+    const nextObjectIds = visibleCanvasObjects.map((workspaceObject) => workspaceObject.id);
     const previousObjectIds = syncedObjectIdsRef.current;
     const previousObjectIdSet = new Set(previousObjectIds);
     const nextObjectIdSet = new Set(nextObjectIds);
 
-    const shapesToCreate = canvasObjects
+    const shapesToCreate = visibleCanvasObjects
       .filter((workspaceObject) => !previousObjectIdSet.has(workspaceObject.id))
       .map((workspaceObject, index) => buildStudioCanvasShape(workspaceObject, index));
 
@@ -161,7 +276,7 @@ export function StudioTldrawWorkspace({
       editor.createShapes(shapesToCreate);
     }
 
-    const shapesToUpdate = canvasObjects
+    const shapesToUpdate = visibleCanvasObjects
       .filter((workspaceObject) => previousObjectIdSet.has(workspaceObject.id))
       .map((workspaceObject, index) => buildStudioCanvasShape(workspaceObject, index));
 
@@ -178,7 +293,7 @@ export function StudioTldrawWorkspace({
     }
 
     syncedObjectIdsRef.current = nextObjectIds;
-  }, [canvasObjects, editor]);
+  }, [editor, visibleCanvasObjects]);
 
   useEffect(() => {
     const root = workspaceRootRef.current;
@@ -210,6 +325,16 @@ export function StudioTldrawWorkspace({
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCopyObsidianHandoff}
+            disabled={obsidianHandoffObjects.length === 0}
+            aria-label="Copy Obsidian markdown handoff"
+            className="h-8 rounded-full border-primary/20 bg-black/20 px-3 font-mono text-[10px] uppercase tracking-[0.18em] text-primary/84 hover:bg-black/30 disabled:cursor-default disabled:opacity-50"
+          >
+            Obsidian Handoff ({obsidianHandoffObjects.length})
+          </Button>
           <Button
             type="button"
             variant="outline"
@@ -250,8 +375,8 @@ export function StudioTldrawWorkspace({
               Canvas Objects
             </div>
             <div className="mt-1 text-sm text-foreground">
-              {canvasObjects.length} active canvas object
-              {canvasObjects.length === 1 ? "" : "s"}
+              {visibleCanvasObjects.length} active canvas object
+              {visibleCanvasObjects.length === 1 ? "" : "s"}
             </div>
           </div>
 
@@ -310,19 +435,141 @@ export function StudioTldrawWorkspace({
                   const isPromoted = promotedPrimeObjectIds.includes(
                     workspaceObject.id,
                   );
+                  const isEditing = editingCardId === workspaceObject.id;
+                  const isHidden = Boolean(workspaceObject.workspace?.hidden);
+                  const isTutorContext = Boolean(
+                    workspaceObject.workspace?.tutorContext || isPromoted,
+                  );
+                  const isObsidianHandoff = Boolean(
+                    workspaceObject.workspace?.obsidianHandoff,
+                  );
 
                   return (
                     <div
                       key={workspaceObject.id}
                       className="rounded-[0.75rem] border border-primary/12 bg-black/30 p-2.5"
                     >
-                      <div className="text-sm text-foreground">
-                        {workspaceObject.title}
-                      </div>
-                      <div className="mt-1 text-xs leading-5 text-foreground/62">
-                        {workspaceObject.detail}
-                      </div>
-                      <div className="mt-2">
+                      {isEditing ? (
+                        <div className="space-y-2">
+                          <label className="flex flex-col gap-1 text-[10px] uppercase tracking-[0.14em] text-primary/72">
+                            Workspace card title
+                            <input
+                              aria-label="Workspace card title"
+                              value={editingTitle}
+                              onChange={(event) => setEditingTitle(event.target.value)}
+                              className="rounded-[0.65rem] border border-primary/18 bg-black/40 px-2 py-1.5 text-xs normal-case tracking-normal text-foreground outline-none focus:border-primary/50"
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1 text-[10px] uppercase tracking-[0.14em] text-primary/72">
+                            Workspace card detail
+                            <textarea
+                              aria-label="Workspace card detail"
+                              value={editingDetail}
+                              onChange={(event) => setEditingDetail(event.target.value)}
+                              rows={4}
+                              className="rounded-[0.65rem] border border-primary/18 bg-black/40 px-2 py-1.5 text-xs normal-case leading-5 tracking-normal text-foreground outline-none focus:border-primary/50"
+                            />
+                          </label>
+                          <div className="flex flex-wrap gap-1.5">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={saveCardEdit}
+                              className={WORKSPACE_CARD_BUTTON_CLASS}
+                            >
+                              Save Workspace Card
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              onClick={cancelCardEdit}
+                              className={WORKSPACE_CARD_BUTTON_CLASS}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <>
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="text-sm text-foreground">
+                              {workspaceObject.title}
+                            </div>
+                            {isHidden ? (
+                              <Badge
+                                variant="outline"
+                                className="shrink-0 rounded-full border-primary/18 px-2 py-0.5 text-[8px] uppercase tracking-[0.14em] text-foreground/58"
+                              >
+                                Hidden
+                              </Badge>
+                            ) : null}
+                          </div>
+                          <div className="mt-1 text-xs leading-5 text-foreground/62">
+                            {workspaceObject.detail}
+                          </div>
+                        </>
+                      )}
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() =>
+                            patchWorkspaceState(workspaceObject, {
+                              tutorContext: !isTutorContext,
+                            })
+                          }
+                          aria-label={
+                            isTutorContext
+                              ? `Remove ${workspaceObject.title} from Tutor context`
+                              : `Include ${workspaceObject.title} in Tutor context`
+                          }
+                          className={WORKSPACE_CARD_BUTTON_CLASS}
+                        >
+                          {isTutorContext ? "Tutor On" : "Tutor"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() =>
+                            patchWorkspaceState(workspaceObject, {
+                              obsidianHandoff: !isObsidianHandoff,
+                            })
+                          }
+                          aria-label={
+                            isObsidianHandoff
+                              ? `Remove ${workspaceObject.title} from Obsidian handoff`
+                              : `Include ${workspaceObject.title} in Obsidian handoff`
+                          }
+                          className={WORKSPACE_CARD_BUTTON_CLASS}
+                        >
+                          {isObsidianHandoff ? "Obsidian On" : "Obsidian"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => beginCardEdit(workspaceObject)}
+                          aria-label={`Edit Workspace card: ${workspaceObject.title}`}
+                          className={WORKSPACE_CARD_BUTTON_CLASS}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() =>
+                            patchWorkspaceState(workspaceObject, {
+                              hidden: !isHidden,
+                            })
+                          }
+                          aria-label={
+                            isHidden
+                              ? `Show Workspace card: ${workspaceObject.title}`
+                              : `Hide Workspace card: ${workspaceObject.title}`
+                          }
+                          className={WORKSPACE_CARD_BUTTON_CLASS}
+                        >
+                          {isHidden ? "Show" : "Hide"}
+                        </Button>
                         <Button
                           type="button"
                           variant="outline"
@@ -336,6 +583,15 @@ export function StudioTldrawWorkspace({
                           className="h-8 rounded-full border-primary/20 bg-black/20 px-3 font-mono text-[10px] uppercase tracking-[0.18em] text-primary/84 hover:bg-black/30 disabled:cursor-default disabled:opacity-100 disabled:text-foreground/60"
                         >
                           {isPromoted ? "In Prime Packet" : "Promote to Prime Packet"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => onDeleteWorkspaceObject?.(workspaceObject.id)}
+                          aria-label={`Delete Workspace card: ${workspaceObject.title}`}
+                          className={WORKSPACE_CARD_BUTTON_CLASS}
+                        >
+                          Delete
                         </Button>
                       </div>
                     </div>

--- a/dashboard_rebuild/client/src/components/studio/StudioWorkspaceMaterialSidebar.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioWorkspaceMaterialSidebar.tsx
@@ -24,6 +24,7 @@ import type {
   SessionMaterialBundle,
   PrimePromotedWorkspaceObject,
 } from "@/lib/sessionMaterialBundle";
+import type { StudioWorkspaceObject } from "@/lib/studioWorkspaceObjects";
 import type { StudioPolishPromotedNote } from "@/lib/studioPacketSections";
 
 // ── Section model ────────────────────────────────────────────────────
@@ -132,11 +133,68 @@ function buildPolishItem(
   };
 }
 
+function readWorkspaceObjectSource(workspaceObject: StudioWorkspaceObject): string | null {
+  if (workspaceObject.kind !== "text_note") return null;
+  if (workspaceObject.provenance.sourceType === "priming_result") {
+    return workspaceObject.provenance.sourceLabel;
+  }
+  return workspaceObject.provenance.sourceLabel;
+}
+
+function buildWorkspaceItem(workspaceObject: StudioWorkspaceObject): MaterialItem {
+  return {
+    id: `workspace-${workspaceObject.id}`,
+    title: workspaceObject.title,
+    snippet: snippet(workspaceObject.detail),
+    source: readWorkspaceObjectSource(workspaceObject),
+    copyText: joinTitleAndBody(workspaceObject.title, workspaceObject.detail),
+  };
+}
+
+function getWorkspaceSectionId(workspaceObject: StudioWorkspaceObject): string {
+  const label = `${workspaceObject.badge} ${workspaceObject.title}`.toLowerCase();
+  if (label.includes("objective")) return "objectives";
+  if (label.includes("concept")) return "concepts";
+  if (label.includes("term")) return "terms";
+  if (label.includes("summar")) return "summaries";
+  if (label.includes("root")) return "root-explanations";
+  if (
+    label.includes("gap") ||
+    label.includes("question") ||
+    label.includes("unsupported")
+  ) {
+    return "gaps";
+  }
+  return "prime-packet";
+}
+
+function appendWorkspaceObjectsToSections(
+  sections: MaterialSection[],
+  workspaceObjects: StudioWorkspaceObject[],
+): MaterialSection[] {
+  if (workspaceObjects.length === 0) return sections;
+
+  const nextSections = sections.map((section) => ({
+    ...section,
+    items: [...section.items],
+  }));
+  const sectionById = new Map(nextSections.map((section) => [section.id, section]));
+
+  for (const workspaceObject of workspaceObjects) {
+    const targetSection = sectionById.get(getWorkspaceSectionId(workspaceObject));
+    if (!targetSection) continue;
+    targetSection.items.push(buildWorkspaceItem(workspaceObject));
+  }
+
+  return nextSections;
+}
+
 function buildSections(
   bundle: SessionMaterialBundle | undefined,
+  workspaceObjects: StudioWorkspaceObject[] = [],
 ): MaterialSection[] {
   if (!bundle) {
-    return [];
+    return appendWorkspaceObjectsToSections([], workspaceObjects);
   }
 
   const concepts: MaterialItem[] = bundle.concepts.map((c, i) => ({
@@ -205,7 +263,7 @@ function buildSections(
     copyText: n.content,
   }));
 
-  return [
+  return appendWorkspaceObjectsToSections([
     {
       id: "objectives",
       label: "Learning objectives",
@@ -286,7 +344,7 @@ function buildSections(
       emptyHint: "No notes captured yet.",
       items: noteItems,
     },
-  ];
+  ], workspaceObjects);
 }
 
 // ── Component ────────────────────────────────────────────────────────
@@ -298,6 +356,7 @@ export type StudioWorkspaceMaterialActiveTab =
 
 export interface StudioWorkspaceMaterialSidebarProps {
   bundle: SessionMaterialBundle | undefined;
+  workspaceObjects?: StudioWorkspaceObject[];
   className?: string;
   activeTabId?: StudioWorkspaceMaterialActiveTab;
   onAddToCanvas?: (label: string) => void;
@@ -305,13 +364,17 @@ export interface StudioWorkspaceMaterialSidebarProps {
 
 export function StudioWorkspaceMaterialSidebar({
   bundle,
+  workspaceObjects = [],
   className,
   activeTabId,
   onAddToCanvas,
 }: StudioWorkspaceMaterialSidebarProps) {
   const canAddToCanvas =
     activeTabId === "mind-map" || activeTabId === "concept-map";
-  const sections = useMemo(() => buildSections(bundle), [bundle]);
+  const sections = useMemo(
+    () => buildSections(bundle, workspaceObjects),
+    [bundle, workspaceObjects],
+  );
   const [query, setQuery] = useState("");
   const [stageFilter, setStageFilter] = useState<StageFilter>("all");
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});

--- a/dashboard_rebuild/client/src/components/studio/StudioWorkspaceUnified.tsx
+++ b/dashboard_rebuild/client/src/components/studio/StudioWorkspaceUnified.tsx
@@ -192,6 +192,7 @@ export function StudioWorkspaceUnified({
       {materialSidebarOpen ? (
         <StudioWorkspaceMaterialSidebar
           bundle={sessionMaterialBundle}
+          workspaceObjects={canvasProps.canvasObjects}
           activeTabId={activeTab}
           onAddToCanvas={handleAddItemToCanvas}
         />

--- a/dashboard_rebuild/client/src/components/studio/__tests__/StudioTldrawWorkspace.test.tsx
+++ b/dashboard_rebuild/client/src/components/studio/__tests__/StudioTldrawWorkspace.test.tsx
@@ -1,0 +1,211 @@
+import { useEffect } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StudioTldrawWorkspace } from "@/components/studio/StudioTldrawWorkspace";
+import type { StudioWorkspaceObject } from "@/lib/studioWorkspaceObjects";
+
+const mockTldrawEditor = {
+  createShapes: vi.fn().mockReturnThis(),
+  updateShapes: vi.fn().mockReturnThis(),
+  deleteShapes: vi.fn().mockReturnThis(),
+  getCurrentPageShapeIds: vi.fn().mockReturnValue(new Set()),
+};
+let writeTextMock: ReturnType<typeof vi.fn>;
+
+vi.mock("tldraw", () => ({
+  Tldraw: ({
+    onMount,
+    hideUi,
+  }: {
+    onMount?: (editor: typeof mockTldrawEditor) => void;
+    hideUi?: boolean;
+  }) => {
+    useEffect(() => {
+      onMount?.(mockTldrawEditor);
+    }, [onMount]);
+
+    return (
+      <div data-testid="mock-tldraw-canvas" data-hide-ui={hideUi ? "true" : "false"}>
+        tldraw canvas
+      </div>
+    );
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function buildPrimingNote(
+  overrides: Partial<Extract<StudioWorkspaceObject, { kind: "text_note" }>> = {},
+): Extract<StudioWorkspaceObject, { kind: "text_note" }> {
+  return {
+    id: "priming-note-1",
+    kind: "text_note",
+    title: "Learning Objectives · Cardiac Output",
+    detail: "Explain preload, afterload, stroke volume, and heart rate.",
+    badge: "OBJECTIVES",
+    provenance: {
+      sourceType: "priming_result",
+      resultKey: "learning-objectives",
+      sourceLabel: "Learning Objectives Primer",
+    },
+    ...overrides,
+  };
+}
+
+describe("StudioTldrawWorkspace", () => {
+  beforeEach(() => {
+    mockTldrawEditor.createShapes.mockReset().mockReturnThis();
+    mockTldrawEditor.updateShapes.mockReset().mockReturnThis();
+    mockTldrawEditor.deleteShapes.mockReset().mockReturnThis();
+    mockTldrawEditor.getCurrentPageShapeIds.mockReset().mockReturnValue(new Set());
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: {
+        writeText: async () => undefined,
+      },
+    });
+    writeTextMock = vi.spyOn(window.navigator.clipboard, "writeText").mockResolvedValue(undefined) as unknown as ReturnType<typeof vi.fn>;
+  });
+
+  it("lets Workspace priming cards be edited, selected for Tutor and Obsidian, hidden, and deleted", async () => {
+    const user = userEvent.setup();
+    const onUpdateWorkspaceObject = vi.fn();
+    const onDeleteWorkspaceObject = vi.fn();
+
+    render(
+      <StudioTldrawWorkspace
+        courseName="Cardiovascular Pulmonary"
+        canvasObjects={[buildPrimingNote()]}
+        currentRunObjects={[]}
+        selectedMaterialCount={1}
+        promotedPrimeObjectIds={[]}
+        onUpdateWorkspaceObject={onUpdateWorkspaceObject}
+        onDeleteWorkspaceObject={onDeleteWorkspaceObject}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /include learning objectives .* in tutor context/i,
+      }),
+    );
+    expect(onUpdateWorkspaceObject).toHaveBeenLastCalledWith(
+      "priming-note-1",
+      expect.objectContaining({
+        workspace: expect.objectContaining({ tutorContext: true }),
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /include learning objectives .* in obsidian handoff/i,
+      }),
+    );
+    expect(onUpdateWorkspaceObject).toHaveBeenLastCalledWith(
+      "priming-note-1",
+      expect.objectContaining({
+        workspace: expect.objectContaining({ obsidianHandoff: true }),
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /edit workspace card: learning objectives/i,
+      }),
+    );
+    await user.clear(screen.getByLabelText(/workspace card title/i));
+    await user.type(screen.getByLabelText(/workspace card title/i), "Updated Objectives");
+    await user.clear(screen.getByLabelText(/workspace card detail/i));
+    await user.type(screen.getByLabelText(/workspace card detail/i), "Updated detail");
+    await user.click(screen.getByRole("button", { name: /save workspace card/i }));
+    expect(onUpdateWorkspaceObject).toHaveBeenLastCalledWith(
+      "priming-note-1",
+      expect.objectContaining({
+        title: "Updated Objectives",
+        detail: "Updated detail",
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /hide workspace card: learning objectives/i,
+      }),
+    );
+    expect(onUpdateWorkspaceObject).toHaveBeenLastCalledWith(
+      "priming-note-1",
+      expect.objectContaining({
+        workspace: expect.objectContaining({ hidden: true }),
+      }),
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /delete workspace card: learning objectives/i,
+      }),
+    );
+    expect(onDeleteWorkspaceObject).toHaveBeenCalledWith("priming-note-1");
+  });
+
+  it("keeps hidden Workspace cards out of the tldraw canvas sync", async () => {
+    render(
+      <StudioTldrawWorkspace
+        courseName="Cardiovascular Pulmonary"
+        canvasObjects={[
+          buildPrimingNote({
+            workspace: {
+              hidden: true,
+              tutorContext: true,
+              obsidianHandoff: true,
+            },
+          }),
+        ]}
+        currentRunObjects={[]}
+        selectedMaterialCount={1}
+        promotedPrimeObjectIds={[]}
+      />,
+    );
+
+    expect(screen.getByText("Learning Objectives · Cardiac Output")).toBeInTheDocument();
+    await waitFor(() => expect(mockTldrawEditor.createShapes).not.toHaveBeenCalled());
+  });
+
+  it("copies selected Obsidian Workspace cards as a markdown handoff packet", async () => {
+    render(
+      <StudioTldrawWorkspace
+        courseName="Cardiovascular Pulmonary"
+        canvasObjects={[
+          buildPrimingNote({
+            workspace: {
+              obsidianHandoff: true,
+              tutorContext: true,
+            },
+          }),
+        ]}
+        currentRunObjects={[]}
+        selectedMaterialCount={1}
+        promotedPrimeObjectIds={[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /copy obsidian markdown handoff/i }),
+    );
+
+    await waitFor(() =>
+      expect(writeTextMock).toHaveBeenCalledWith(
+        expect.stringContaining("# Obsidian Handoff - Cardiovascular Pulmonary"),
+      ),
+    );
+    expect(writeTextMock).toHaveBeenCalledWith(
+      expect.stringContaining("Learning Objectives · Cardiac Output"),
+    );
+  });
+});

--- a/dashboard_rebuild/client/src/components/studio/__tests__/StudioWorkspaceMaterialSidebar.test.tsx
+++ b/dashboard_rebuild/client/src/components/studio/__tests__/StudioWorkspaceMaterialSidebar.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { StudioWorkspaceMaterialSidebar } from "@/components/studio/StudioWorkspaceMaterialSidebar";
 import type { SessionMaterialBundle } from "@/lib/sessionMaterialBundle";
+import type { StudioWorkspaceObject } from "@/lib/studioWorkspaceObjects";
 
 function buildBundle(
   overrides: Partial<SessionMaterialBundle> = {},
@@ -130,5 +131,34 @@ describe("StudioWorkspaceMaterialSidebar", () => {
     expect(
       screen.getByTestId("studio-workspace-material-item-concept-0"),
     ).toBeInTheDocument();
+  });
+
+  it("buckets priming Workspace cards by their artifact type", () => {
+    const workspaceObjects: StudioWorkspaceObject[] = [
+      {
+        id: "priming-result-objectives",
+        kind: "text_note",
+        title: "Learning Objectives · Cardiac Output Lecture",
+        detail: "## Learning Objectives\n- LO-1 — Explain cardiac output regulation",
+        badge: "OBJECTIVES",
+        provenance: {
+          sourceType: "priming_result",
+          resultKey: "learning-objectives",
+          sourceLabel: "Learning Objectives Primer",
+        },
+      },
+    ];
+
+    render(
+      <StudioWorkspaceMaterialSidebar
+        bundle={buildBundle()}
+        workspaceObjects={workspaceObjects}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /learning objectives\s*1/i })).toBeInTheDocument();
+    expect(
+      screen.getByTestId("studio-workspace-material-item-workspace-priming-result-objectives"),
+    ).toHaveTextContent("Learning Objectives · Cardiac Output Lecture");
   });
 });

--- a/dashboard_rebuild/client/src/hooks/__tests__/useTutorSession.test.tsx
+++ b/dashboard_rebuild/client/src/hooks/__tests__/useTutorSession.test.tsx
@@ -107,7 +107,7 @@ describe("useTutorSession", () => {
     createSessionMock.mockResolvedValue({ session_id: "sess-started" });
   });
 
-  it("uses carried-forward priming objectives in Tutor preflight when no approved objectives are loaded", () => {
+  it("uses carried-forward priming objectives in the Tutor Workspace context payload when no approved objectives are loaded", () => {
     const wrapper = createWrapper();
     const hub = createHubMock();
     const activeWorkflowDetail: TutorWorkflowDetailResponse = {
@@ -570,12 +570,12 @@ describe("useTutorSession", () => {
 
     expect(createSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        content_filter: {
+        content_filter: expect.objectContaining({
           session_rules: [
             "Always force a function confirmation before L4 precision.",
             "Stay inside the assigned provenance boundary.",
           ],
-        },
+        }),
       }),
     );
   });
@@ -639,20 +639,16 @@ describe("useTutorSession", () => {
       await result.current.startSession();
     });
 
-    expect(preflightSessionMock).toHaveBeenCalledWith(
+    expect(preflightSessionMock).not.toHaveBeenCalled();
+    expect(createSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        course_id: 1,
         topic: "Cardiovascular",
-        study_unit: "Cardiovascular",
         module_name: "Cardiovascular",
         content_filter: expect.objectContaining({
           material_ids: [561],
           vault_folder: "Courses/Exercise Physiology/Cardiovascular",
         }),
-      }),
-    );
-    expect(createSessionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        preflight_id: "preflight-1",
       }),
     );
   });

--- a/dashboard_rebuild/client/src/hooks/useStudioRun.ts
+++ b/dashboard_rebuild/client/src/hooks/useStudioRun.ts
@@ -33,6 +33,7 @@ export interface UseStudioRunParams {
   pendingLaunchHandoff: {
     fromLibraryHandoff: boolean;
     brainLaunchContext: TutorBrainLaunchContext | null;
+    courseSetupPrimingHandoff?: unknown;
   };
   persistStartState?: boolean;
   persistShellQuery?: boolean;

--- a/dashboard_rebuild/client/src/hooks/useTutorSession.ts
+++ b/dashboard_rebuild/client/src/hooks/useTutorSession.ts
@@ -9,7 +9,6 @@ import type {
   TutorProjectShellResponse,
   TutorScholarStrategy,
   TutorSessionEndResult,
-  TutorSessionPreflightResponse,
   TutorSessionWithTurns,
   TutorStrategyFeedback,
   TutorTurn,
@@ -199,7 +198,7 @@ export function useTutorSession({
   const [stageTimerDisplaySeconds, setStageTimerDisplaySeconds] = useState(0);
   const stageTimerSessionRef = useRef<string | null>(null);
 
-  // ─── Preflight ───
+  // ─── Workspace Context ───
   const preflightPayload = useMemo(() => {
     if (typeof hub.courseId !== "number") return null;
     const learningObjectives =
@@ -245,26 +244,9 @@ export function useTutorSession({
     workflowPrimingObjectives,
   ]);
 
-  const {
-    data: preflight,
-    isFetching: preflightLoading,
-    error: preflightError,
-  } = useQuery<TutorSessionPreflightResponse>({
-    queryKey: [
-      "tutor-session-preflight",
-      JSON.stringify(preflightPayload || {}),
-    ],
-    queryFn: () => api.tutor.preflightSession(preflightPayload!),
-    enabled: !!preflightPayload && hub.selectedMaterials.length > 0,
-    staleTime: 30 * 1000,
-  });
-
-  const preflightErrorMessage =
-    preflightError instanceof Error
-      ? preflightError.message
-      : preflightError
-        ? String(preflightError)
-        : null;
+  const preflight = null;
+  const preflightLoading = false;
+  const preflightErrorMessage = null;
 
   // ─── Config check ───
   const { data: configStatus } = useQuery<TutorConfigCheck>({
@@ -568,27 +550,27 @@ export function useTutorSession({
         resolvedChainId = customChain.id;
         setTutorChainId(customChain.id);
       }
-      const preflightResult = await api.tutor.preflightSession(preflightPayload);
-      if (preflightResult.blockers.length > 0) {
-        toast.error(preflightResult.blockers[0].message);
-        return null;
-      }
+      const contentFilter = {
+        ...preflightPayload.content_filter,
+        ...(opts?.session_rules && opts.session_rules.length > 0
+          ? { session_rules: opts.session_rules }
+          : {}),
+      };
 
       const session = await api.tutor.createSession({
-        preflight_id: preflightResult.preflight_id,
+        course_id: preflightPayload.course_id,
+        topic: preflightPayload.topic,
+        module_name: preflightPayload.module_name,
+        objective_scope: preflightPayload.objective_scope,
+        focus_objective_id: preflightPayload.focus_objective_id,
+        learning_objectives: preflightPayload.learning_objectives,
         phase: "first_pass",
         mode: "Core",
         method_chain_id: resolvedChainId,
+        content_filter: contentFilter,
         ...(opts?.packet_context ? { packet_context: opts.packet_context } : {}),
         ...(opts?.memory_capsule_context
           ? { memory_capsule_context: opts.memory_capsule_context }
-          : {}),
-        ...(opts?.session_rules && opts.session_rules.length > 0
-          ? {
-              content_filter: {
-                session_rules: opts.session_rules,
-              },
-            }
           : {}),
       });
       const full = await api.tutor.getSession(session.session_id);

--- a/dashboard_rebuild/client/src/index.css
+++ b/dashboard_rebuild/client/src/index.css
@@ -860,132 +860,178 @@
   .library-page-hero {
     height: auto;
     min-height: 0;
-    padding-block: 0.95rem 0.85rem;
+    padding-block: 0.42rem 0.4rem;
   }
 
   .library-page-hero.page-shell__hero {
-    border-color: rgba(255, 74, 104, 0.18);
+    border-color: rgba(120, 142, 156, 0.18);
     background:
-      linear-gradient(180deg, rgba(6, 2, 4, 0.97), rgba(1, 1, 2, 0.98) 62%, rgba(0, 0, 0, 0.99)),
-      linear-gradient(90deg, rgba(255, 74, 104, 0.04), transparent 42%, rgba(255, 74, 104, 0.025));
+      linear-gradient(180deg, rgba(7, 9, 12, 0.98), rgba(3, 4, 6, 0.99) 62%, rgba(0, 0, 0, 0.99)),
+      linear-gradient(90deg, rgba(53, 92, 110, 0.08), transparent 44%, rgba(255, 74, 104, 0.025));
     box-shadow:
-      0 12px 32px rgba(0, 0, 0, 0.5),
-      inset 0 1px 0 rgba(255, 170, 188, 0.035);
+      0 10px 26px rgba(0, 0, 0, 0.44),
+      inset 0 1px 0 rgba(210, 232, 242, 0.04);
   }
 
   .library-page-hero.page-shell__hero::before {
-    height: 2.6rem;
-    background: linear-gradient(180deg, rgba(255, 48, 78, 0.055), transparent);
+    height: 1.4rem;
+    background: linear-gradient(180deg, rgba(62, 118, 138, 0.055), transparent);
   }
 
   .library-page-hero.page-shell__hero::after {
-    background: linear-gradient(90deg, rgba(255, 52, 82, 0.34), rgba(255, 52, 82, 0.09) 44%, transparent 76%);
+    background: linear-gradient(90deg, rgba(255, 72, 104, 0.26), rgba(48, 135, 150, 0.12) 48%, transparent 78%);
   }
 
   .library-page-hero .page-shell__header {
-    gap: 0.75rem;
+    gap: 0.55rem;
+  }
+
+  .library-page-hero .page-shell__eyebrow {
+    font-size: 0.64rem;
+    letter-spacing: 0.2em;
+    color: rgba(255, 126, 150, 0.78);
+  }
+
+  .library-page-hero .page-shell__title {
+    font-size: clamp(1.25rem, 1.9vw, 1.95rem);
+    line-height: 1;
+    letter-spacing: 0.05em;
+  }
+
+  .library-page-hero .page-shell__dipline {
+    opacity: 0.78;
+    transform: scaleY(0.7);
+    transform-origin: center;
   }
 
   .library-page-hero .page-shell__subtitle {
-    margin-top: 0.45rem;
-    max-width: min(56ch, 100%);
-    font-size: clamp(0.92rem, 1.3vw, 1.05rem);
-    line-height: 1.45;
+    display: none;
   }
 
   .library-page-hero .page-shell__meta {
-    flex-basis: 38rem;
-    width: min(100%, 38rem);
-    gap: 0.5rem;
+    flex-basis: 37rem;
+    width: min(100%, 37rem);
+    gap: 0.45rem;
   }
 
   .library-page-hero .page-shell__stat {
-    min-height: 3.6rem;
-    padding: 0.55rem 0.7rem;
-    border-color: rgba(255, 84, 116, 0.14);
-    border-top-color: rgba(255, 84, 116, 0.26);
+    min-height: 2.55rem;
+    padding: 0.38rem 0.58rem;
+    border-color: rgba(126, 150, 164, 0.14);
+    border-top-color: rgba(255, 84, 116, 0.18);
     background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(0, 0, 0, 0.12) 24%, rgba(0, 0, 0, 0.42) 100%),
-      rgba(3, 2, 3, 0.72);
+      linear-gradient(180deg, rgba(255, 255, 255, 0.024), rgba(0, 0, 0, 0.08) 24%, rgba(0, 0, 0, 0.36) 100%),
+      rgba(5, 8, 10, 0.76);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.035),
-      0 8px 18px rgba(0, 0, 0, 0.22);
+      inset 0 1px 0 rgba(255, 255, 255, 0.03),
+      0 6px 16px rgba(0, 0, 0, 0.2);
   }
 
   .library-page-hero .page-shell__stat-label {
-    font-size: 0.68rem;
-    letter-spacing: 0.12em;
+    font-size: 0.64rem;
+    letter-spacing: 0.1em;
+    color: rgba(197, 214, 222, 0.62);
   }
 
   .library-page-hero .page-shell__stat-value {
     overflow-wrap: anywhere;
-    font-size: clamp(0.88rem, 1.45vw, 1rem);
+    font-size: clamp(0.82rem, 1.05vw, 0.94rem);
     line-height: 1.22;
   }
 
   .library-ops-workspace.app-workspace-shell {
-    border-color: rgba(255, 74, 104, 0.14);
+    border-color: rgba(125, 147, 160, 0.16);
     background:
-      linear-gradient(180deg, rgba(5, 3, 4, 0.99), rgba(2, 2, 3, 0.99) 42%, rgba(0, 0, 0, 0.99) 100%),
-      linear-gradient(135deg, rgba(255, 46, 80, 0.018), rgba(0, 0, 0, 0.22) 44%, rgba(0, 0, 0, 0.58) 100%);
+      linear-gradient(180deg, rgba(7, 9, 11, 0.99), rgba(3, 5, 7, 0.99) 44%, rgba(0, 0, 0, 0.99) 100%),
+      linear-gradient(135deg, rgba(50, 115, 132, 0.035), rgba(0, 0, 0, 0.18) 44%, rgba(0, 0, 0, 0.52) 100%);
     box-shadow:
-      0 18px 44px rgba(0, 0, 0, 0.5),
-      inset 0 1px 0 rgba(255, 128, 152, 0.04);
-    font-size: 1rem;
+      0 14px 36px rgba(0, 0, 0, 0.44),
+      inset 0 1px 0 rgba(216, 238, 246, 0.035);
+    font-size: 1.04rem;
   }
 
   .library-ops-workspace.app-workspace-shell::before {
-    opacity: 0.2;
+    opacity: 0.11;
     background:
-      linear-gradient(180deg, rgba(255, 46, 82, 0.03), transparent 22%),
+      linear-gradient(180deg, rgba(64, 132, 148, 0.035), transparent 22%),
       linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.014), transparent);
   }
 
   .library-rail-panel,
   .library-main-panel {
-    border-color: rgba(255, 84, 116, 0.11) !important;
+    border-color: rgba(130, 153, 166, 0.14) !important;
     background:
-      linear-gradient(180deg, rgba(7, 5, 6, 0.9), rgba(2, 2, 3, 0.96)) !important;
+      linear-gradient(180deg, rgba(10, 13, 16, 0.92), rgba(3, 5, 7, 0.97)) !important;
     box-shadow:
-      inset 0 1px 0 rgba(255, 180, 196, 0.025),
-      0 12px 28px rgba(0, 0, 0, 0.42) !important;
+      inset 0 1px 0 rgba(220, 240, 248, 0.035),
+      0 10px 24px rgba(0, 0, 0, 0.38) !important;
     backdrop-filter: blur(10px);
   }
 
   .library-panel-surface {
-    border-radius: 0.9rem;
-    border: 1px solid rgba(255, 84, 116, 0.11);
+    border-radius: 0.75rem;
+    border: 1px solid rgba(132, 154, 166, 0.14);
     background:
-      linear-gradient(180deg, rgba(12, 9, 10, 0.74), rgba(4, 4, 5, 0.9) 40%, rgba(0, 0, 0, 0.92) 100%);
+      linear-gradient(180deg, rgba(15, 18, 21, 0.82), rgba(6, 8, 10, 0.92) 46%, rgba(1, 2, 3, 0.94) 100%);
     box-shadow:
-      inset 0 1px 0 rgba(255, 190, 202, 0.025),
-      0 12px 24px rgba(0, 0, 0, 0.34);
+      inset 0 1px 0 rgba(225, 242, 248, 0.03),
+      0 8px 20px rgba(0, 0, 0, 0.3);
     backdrop-filter: blur(10px);
   }
 
   .library-panel-inset,
   .library-step-card {
-    border: 1px solid rgba(255, 84, 116, 0.09);
-    background: rgba(0, 0, 0, 0.58);
+    border: 1px solid rgba(132, 154, 166, 0.11);
+    background: rgba(4, 7, 9, 0.68);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
   }
 
   .library-segmented-control {
-    border-radius: 0.85rem;
-    border: 1px solid rgba(255, 84, 116, 0.1);
-    background: rgba(0, 0, 0, 0.64);
+    border-radius: 0.65rem;
+    border: 1px solid rgba(132, 154, 166, 0.12);
+    background: rgba(3, 6, 8, 0.72);
+  }
+
+  .library-workflow-tabs {
+    gap: 0.45rem;
+    padding: 0.42rem;
+  }
+
+  .library-workflow-tabs [role="tab"] {
+    min-height: 2.65rem !important;
+    border-radius: 0.55rem !important;
+    border-color: rgba(126, 150, 164, 0.16) !important;
+    background: rgba(7, 10, 12, 0.74) !important;
+    color: rgba(219, 230, 235, 0.72) !important;
+    font-family: var(--font-mono) !important;
+    font-size: 0.96rem !important;
+    letter-spacing: 0.08em !important;
+    text-transform: uppercase;
+    box-shadow: none !important;
+  }
+
+  .library-workflow-tabs [role="tab"][aria-selected="true"] {
+    border-color: rgba(255, 104, 132, 0.42) !important;
+    background:
+      linear-gradient(180deg, rgba(255, 78, 110, 0.17), rgba(18, 12, 15, 0.9)) !important;
+    color: #ffe5ec !important;
+  }
+
+  .library-workflow-tabs [role="tab"]:hover {
+    border-color: rgba(255, 126, 152, 0.32) !important;
+    color: #fff4f7 !important;
   }
 
   .library-action-button {
-    border-color: rgba(255, 84, 116, 0.2) !important;
+    border-color: rgba(255, 104, 132, 0.24) !important;
     background:
-      linear-gradient(180deg, rgba(255, 74, 104, 0.055), rgba(6, 4, 5, 0.94) 52%, rgba(0, 0, 0, 0.96)) !important;
+      linear-gradient(180deg, rgba(255, 74, 104, 0.065), rgba(8, 9, 11, 0.94) 52%, rgba(0, 0, 0, 0.96)) !important;
     box-shadow:
       inset 0 1px 0 rgba(255, 210, 220, 0.035),
       0 8px 18px rgba(0, 0, 0, 0.3) !important;
-    color: #ffd8e2;
-    font-size: 0.84rem !important;
-    letter-spacing: 0.11em !important;
+    color: #ffe0e7;
+    font-size: 0.9rem !important;
+    letter-spacing: 0.09em !important;
   }
 
   .library-action-button:hover {
@@ -1022,38 +1068,38 @@
 
   .library-section-label {
     font-family: var(--font-mono);
-    font-size: 0.9rem;
+    font-size: 0.92rem;
     line-height: 1.35;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: rgba(255, 226, 232, 0.68);
+    color: rgba(220, 232, 238, 0.68);
   }
 
   .library-panel-title {
     font-family: var(--font-arcade);
-    font-size: 1.2rem;
+    font-size: 1.25rem;
     line-height: 1.2;
-    letter-spacing: 0.13em;
+    letter-spacing: 0.11em;
     text-transform: uppercase;
-    color: rgba(255, 82, 112, 0.86);
+    color: rgba(255, 92, 122, 0.88);
   }
 
   .library-help-text {
     font-family: var(--font-mono);
-    font-size: 1rem;
-    line-height: 1.6;
-    color: hsl(var(--muted-foreground) / 0.94);
+    font-size: 1.04rem;
+    line-height: 1.55;
+    color: hsl(var(--foreground) / 0.66);
   }
 
   .library-field {
-    border-color: rgba(255, 84, 116, 0.15) !important;
-    background: rgba(0, 0, 0, 0.7) !important;
-    font-size: 1rem !important;
+    border-color: rgba(135, 158, 170, 0.18) !important;
+    background: rgba(3, 6, 8, 0.78) !important;
+    font-size: 1.04rem !important;
   }
 
   .library-course-nav-row {
-    font-size: 1.02rem;
-    line-height: 1.4;
+    font-size: 1.05rem;
+    line-height: 1.45;
   }
 
   .library-ops-workspace .text-ui-3xs {

--- a/dashboard_rebuild/client/src/index.css
+++ b/dashboard_rebuild/client/src/index.css
@@ -847,6 +847,312 @@
     color: hsl(var(--foreground) / 0.96);
   }
 
+  .tutor-page-hero {
+    min-height: clamp(11rem, 14vw, 15.2rem);
+  }
+
+  .library-page-hero {
+    height: auto;
+    min-height: 0;
+    padding-block: 0.95rem 0.85rem;
+  }
+
+  .library-page-hero.page-shell__hero {
+    border-color: rgba(255, 74, 104, 0.18);
+    background:
+      linear-gradient(180deg, rgba(6, 2, 4, 0.97), rgba(1, 1, 2, 0.98) 62%, rgba(0, 0, 0, 0.99)),
+      linear-gradient(90deg, rgba(255, 74, 104, 0.04), transparent 42%, rgba(255, 74, 104, 0.025));
+    box-shadow:
+      0 12px 32px rgba(0, 0, 0, 0.5),
+      inset 0 1px 0 rgba(255, 170, 188, 0.035);
+  }
+
+  .library-page-hero.page-shell__hero::before {
+    height: 2.6rem;
+    background: linear-gradient(180deg, rgba(255, 48, 78, 0.055), transparent);
+  }
+
+  .library-page-hero.page-shell__hero::after {
+    background: linear-gradient(90deg, rgba(255, 52, 82, 0.34), rgba(255, 52, 82, 0.09) 44%, transparent 76%);
+  }
+
+  .library-page-hero .page-shell__header {
+    gap: 0.75rem;
+  }
+
+  .library-page-hero .page-shell__subtitle {
+    margin-top: 0.45rem;
+    max-width: min(56ch, 100%);
+    font-size: clamp(0.92rem, 1.3vw, 1.05rem);
+    line-height: 1.45;
+  }
+
+  .library-page-hero .page-shell__meta {
+    flex-basis: 38rem;
+    width: min(100%, 38rem);
+    gap: 0.5rem;
+  }
+
+  .library-page-hero .page-shell__stat {
+    min-height: 3.6rem;
+    padding: 0.55rem 0.7rem;
+    border-color: rgba(255, 84, 116, 0.14);
+    border-top-color: rgba(255, 84, 116, 0.26);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(0, 0, 0, 0.12) 24%, rgba(0, 0, 0, 0.42) 100%),
+      rgba(3, 2, 3, 0.72);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.035),
+      0 8px 18px rgba(0, 0, 0, 0.22);
+  }
+
+  .library-page-hero .page-shell__stat-label {
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+  }
+
+  .library-page-hero .page-shell__stat-value {
+    overflow-wrap: anywhere;
+    font-size: clamp(0.88rem, 1.45vw, 1rem);
+    line-height: 1.22;
+  }
+
+  .library-ops-workspace.app-workspace-shell {
+    border-color: rgba(255, 74, 104, 0.14);
+    background:
+      linear-gradient(180deg, rgba(5, 3, 4, 0.99), rgba(2, 2, 3, 0.99) 42%, rgba(0, 0, 0, 0.99) 100%),
+      linear-gradient(135deg, rgba(255, 46, 80, 0.018), rgba(0, 0, 0, 0.22) 44%, rgba(0, 0, 0, 0.58) 100%);
+    box-shadow:
+      0 18px 44px rgba(0, 0, 0, 0.5),
+      inset 0 1px 0 rgba(255, 128, 152, 0.04);
+    font-size: 1rem;
+  }
+
+  .library-ops-workspace.app-workspace-shell::before {
+    opacity: 0.2;
+    background:
+      linear-gradient(180deg, rgba(255, 46, 82, 0.03), transparent 22%),
+      linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.014), transparent);
+  }
+
+  .library-rail-panel,
+  .library-main-panel {
+    border-color: rgba(255, 84, 116, 0.11) !important;
+    background:
+      linear-gradient(180deg, rgba(7, 5, 6, 0.9), rgba(2, 2, 3, 0.96)) !important;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 180, 196, 0.025),
+      0 12px 28px rgba(0, 0, 0, 0.42) !important;
+    backdrop-filter: blur(10px);
+  }
+
+  .library-panel-surface {
+    border-radius: 0.9rem;
+    border: 1px solid rgba(255, 84, 116, 0.11);
+    background:
+      linear-gradient(180deg, rgba(12, 9, 10, 0.74), rgba(4, 4, 5, 0.9) 40%, rgba(0, 0, 0, 0.92) 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 190, 202, 0.025),
+      0 12px 24px rgba(0, 0, 0, 0.34);
+    backdrop-filter: blur(10px);
+  }
+
+  .library-panel-inset,
+  .library-step-card {
+    border: 1px solid rgba(255, 84, 116, 0.09);
+    background: rgba(0, 0, 0, 0.58);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+  }
+
+  .library-segmented-control {
+    border-radius: 0.85rem;
+    border: 1px solid rgba(255, 84, 116, 0.1);
+    background: rgba(0, 0, 0, 0.64);
+  }
+
+  .library-action-button {
+    border-color: rgba(255, 84, 116, 0.2) !important;
+    background:
+      linear-gradient(180deg, rgba(255, 74, 104, 0.055), rgba(6, 4, 5, 0.94) 52%, rgba(0, 0, 0, 0.96)) !important;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 210, 220, 0.035),
+      0 8px 18px rgba(0, 0, 0, 0.3) !important;
+    color: #ffd8e2;
+    font-size: 0.84rem !important;
+    letter-spacing: 0.11em !important;
+  }
+
+  .library-action-button:hover {
+    border-color: rgba(255, 138, 162, 0.28) !important;
+    background:
+      linear-gradient(180deg, rgba(255, 88, 118, 0.08), rgba(8, 5, 6, 0.95) 52%, rgba(0, 0, 0, 0.96)) !important;
+  }
+
+  .library-action-button--inline {
+    font-size: 0.78rem !important;
+  }
+
+  .library-icon-button {
+    display: inline-flex;
+    min-height: 2rem;
+    min-width: 2rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.65rem;
+    border: 1px solid rgba(255, 84, 116, 0.26);
+    background: rgba(0, 0, 0, 0.38);
+    color: rgba(255, 198, 210, 0.82);
+    transition:
+      border-color 0.18s ease,
+      background 0.18s ease,
+      color 0.18s ease;
+  }
+
+  .library-icon-button:hover {
+    border-color: rgba(255, 130, 154, 0.46);
+    background: rgba(255, 84, 116, 0.08);
+    color: #ffe8ee;
+  }
+
+  .library-section-label {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    line-height: 1.35;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255, 226, 232, 0.68);
+  }
+
+  .library-panel-title {
+    font-family: var(--font-arcade);
+    font-size: 1.2rem;
+    line-height: 1.2;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: rgba(255, 82, 112, 0.86);
+  }
+
+  .library-help-text {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    line-height: 1.6;
+    color: hsl(var(--muted-foreground) / 0.94);
+  }
+
+  .library-field {
+    border-color: rgba(255, 84, 116, 0.15) !important;
+    background: rgba(0, 0, 0, 0.7) !important;
+    font-size: 1rem !important;
+  }
+
+  .library-course-nav-row {
+    font-size: 1.02rem;
+    line-height: 1.4;
+  }
+
+  .library-ops-workspace .text-ui-3xs {
+    font-size: 0.82rem;
+    line-height: 1.1rem;
+  }
+
+  .library-ops-workspace .text-ui-2xs {
+    font-size: 0.88rem;
+    line-height: 1.2rem;
+  }
+
+  .library-ops-workspace .text-ui-xs {
+    font-size: 0.96rem;
+    line-height: 1.35rem;
+  }
+
+  .tutor-page-hero .page-shell__meta {
+    flex-basis: 45rem;
+    width: min(100%, 45rem);
+  }
+
+  @media (max-width: 1279px) {
+    .library-page-hero {
+      padding-block: 0.8rem 0.7rem;
+    }
+
+    .library-page-hero .page-shell__header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .library-page-hero .page-shell__meta {
+      flex-basis: auto;
+      width: 100%;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .tutor-page-hero {
+      min-height: auto;
+      padding-block: 1rem 0.875rem;
+    }
+
+    .tutor-page-hero .page-shell__header {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.875rem;
+    }
+
+    .tutor-page-hero .page-shell__subtitle {
+      margin-top: 0.55rem;
+      max-width: min(64ch, 100%);
+      font-size: clamp(0.92rem, 1.6vw, 1.05rem);
+      line-height: 1.45;
+    }
+
+    .tutor-page-hero .page-shell__meta {
+      flex-basis: auto;
+      width: 100%;
+      gap: 0.5rem;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .tutor-page-hero .page-shell__stat {
+      min-height: 4.5rem;
+      padding: 0.65rem 0.75rem;
+    }
+
+    .tutor-page-hero .page-shell__stat-label {
+      font-size: 0.7rem;
+      letter-spacing: 0.12em;
+    }
+
+    .tutor-page-hero .page-shell__stat-value {
+      overflow-wrap: break-word;
+      font-size: clamp(0.9rem, 1.8vw, 1rem);
+      line-height: 1.22;
+    }
+
+    .page-shell__actions > .tutor-hero-action {
+      min-height: 2.75rem;
+      padding-inline: 0.75rem;
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+    }
+  }
+
+  @media (max-width: 767px) {
+    .library-page-hero .page-shell__meta {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .library-page-hero .page-shell__title {
+      font-size: 1.15rem;
+    }
+
+    .tutor-page-hero .page-shell__meta {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .page-shell__actions > .tutor-hero-action {
+      min-height: 2.5rem;
+    }
+  }
+
   .page-shell__stat--info {
     border-color: rgba(59, 130, 246, 0.36);
   }

--- a/dashboard_rebuild/client/src/index.css
+++ b/dashboard_rebuild/client/src/index.css
@@ -310,6 +310,54 @@
 }
 
 @layer components {
+  .library-material-dialog-title {
+    margin: 0;
+    font-family:
+      ui-sans-serif,
+      system-ui,
+      sans-serif,
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      "Noto Color Emoji" !important;
+    font-size: var(--text-lg) !important;
+    font-weight: 650;
+    letter-spacing: normal !important;
+    line-height: var(--text-lg--line-height) !important;
+    text-shadow: none !important;
+    text-transform: none !important;
+  }
+
+  .library-material-dialog-title * {
+    font-family:
+      ui-sans-serif,
+      system-ui,
+      sans-serif,
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      "Noto Color Emoji" !important;
+    letter-spacing: normal !important;
+    text-transform: none !important;
+  }
+
+  .library-material-reader-shell {
+    scrollbar-gutter: stable;
+  }
+
+  .library-material-markdown {
+    text-rendering: optimizeLegibility;
+  }
+
+  .library-material-markdown > :first-child {
+    margin-top: 0;
+  }
+
+  .library-material-markdown p {
+    margin-block: 1rem;
+    line-height: 1.85;
+  }
+
   .library-material-markdown :is(h1, h2, h3, h4, h5, h6) {
     font-family:
       ui-sans-serif,
@@ -322,6 +370,8 @@
     font-weight: 600;
     letter-spacing: normal;
     line-height: 1.35;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
     text-shadow: none;
     text-transform: none;
   }

--- a/dashboard_rebuild/client/src/index.css
+++ b/dashboard_rebuild/client/src/index.css
@@ -309,6 +309,42 @@
   }
 }
 
+@layer components {
+  .library-material-markdown :is(h1, h2, h3, h4, h5, h6) {
+    font-family:
+      ui-sans-serif,
+      system-ui,
+      sans-serif,
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      "Noto Color Emoji";
+    font-weight: 600;
+    letter-spacing: normal;
+    line-height: 1.35;
+    text-shadow: none;
+    text-transform: none;
+  }
+
+  .library-material-markdown h1 {
+    font-size: var(--text-2xl);
+    line-height: var(--text-2xl--line-height);
+  }
+
+  .library-material-markdown h2 {
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+  }
+
+  .library-material-markdown h3,
+  .library-material-markdown h4,
+  .library-material-markdown h5,
+  .library-material-markdown h6 {
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+  }
+}
+
 @layer utilities {
   .inline-flex {
     display: inline-flex;

--- a/dashboard_rebuild/client/src/index.css
+++ b/dashboard_rebuild/client/src/index.css
@@ -248,6 +248,12 @@
   * {
     @apply border-border;
   }
+  html,
+  body,
+  #root {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
   /* Force VT323 on form elements that don't inherit */
   button,
   input,
@@ -1070,7 +1076,7 @@
     width: min(100%, 45rem);
   }
 
-  @media (max-width: 1279px) {
+  @media (max-width: 1535px) {
     .library-page-hero {
       padding-block: 0.8rem 0.7rem;
     }
@@ -1085,6 +1091,9 @@
       width: 100%;
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
+  }
+
+  @media (max-width: 1279px) {
 
     .tutor-page-hero {
       min-height: auto;

--- a/dashboard_rebuild/client/src/index.css
+++ b/dashboard_rebuild/client/src/index.css
@@ -343,6 +343,35 @@
     font-size: var(--text-lg);
     line-height: var(--text-lg--line-height);
   }
+
+  .library-material-table-scroll {
+    margin-block: 1.25rem;
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1px solid hsl(var(--primary) / 0.24);
+    background: rgba(0, 0, 0, 0.28);
+  }
+
+  .library-material-table-scroll table {
+    margin: 0;
+    min-width: 100%;
+    width: max-content;
+    border-collapse: collapse;
+    table-layout: auto;
+  }
+
+  .library-material-table-scroll :is(th, td) {
+    min-width: 9rem;
+    max-width: 28rem;
+    vertical-align: top;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .library-material-table-scroll th {
+    font-weight: 700;
+  }
 }
 
 @layer utilities {

--- a/dashboard_rebuild/client/src/lib/__tests__/obsidianHandoffPacket.test.ts
+++ b/dashboard_rebuild/client/src/lib/__tests__/obsidianHandoffPacket.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { buildObsidianHandoffMarkdown } from "@/lib/obsidianHandoffPacket";
+import type { StudioWorkspaceObject } from "@/lib/studioWorkspaceObjects";
+
+describe("buildObsidianHandoffMarkdown", () => {
+  it("serializes selected Workspace cards into a structured Obsidian handoff packet", () => {
+    const workspaceObjects: StudioWorkspaceObject[] = [
+      {
+        id: "objective-1",
+        kind: "text_note",
+        title: "Learning Objectives · Cardiac Output",
+        detail: "- Explain preload\n- Contrast afterload and stroke volume",
+        badge: "OBJECTIVES",
+        workspace: {
+          obsidianHandoff: true,
+          tutorContext: true,
+        },
+        provenance: {
+          sourceType: "priming_result",
+          resultKey: "learning-objectives",
+          sourceLabel: "Learning Objectives Primer",
+        },
+      },
+      {
+        id: "hidden-from-obsidian",
+        kind: "text_note",
+        title: "Draft scratch",
+        detail: "Do not export this.",
+        badge: "NOTE",
+        workspace: {
+          obsidianHandoff: false,
+        },
+        provenance: {
+          sourceType: "priming_result",
+          resultKey: "scratch",
+          sourceLabel: "Scratch",
+        },
+      },
+    ];
+
+    const markdown = buildObsidianHandoffMarkdown({
+      courseName: "Cardiovascular Pulmonary",
+      sessionGoal: "Module 1 safe patient care",
+      materialTitles: ["Cardiac Output Lecture"],
+      workspaceObjects,
+    });
+
+    expect(markdown).toContain("# Obsidian Handoff - Cardiovascular Pulmonary");
+    expect(markdown).toContain("Session goal: Module 1 safe patient care");
+    expect(markdown).toContain("Materials: Cardiac Output Lecture");
+    expect(markdown).toContain("## Learning Objectives");
+    expect(markdown).toContain("Learning Objectives · Cardiac Output");
+    expect(markdown).toContain("Source: Learning Objectives Primer");
+    expect(markdown).toContain("Contrast afterload and stroke volume");
+    expect(markdown).not.toContain("Draft scratch");
+  });
+});

--- a/dashboard_rebuild/client/src/lib/obsidianHandoffPacket.ts
+++ b/dashboard_rebuild/client/src/lib/obsidianHandoffPacket.ts
@@ -1,0 +1,145 @@
+import type { StudioWorkspaceObject } from "@/lib/studioWorkspaceObjects";
+
+export interface BuildObsidianHandoffMarkdownParams {
+  courseName: string | null;
+  sessionGoal?: string | null;
+  materialTitles?: string[];
+  workspaceObjects: StudioWorkspaceObject[];
+}
+
+type HandoffBucket =
+  | "learningObjectives"
+  | "concepts"
+  | "terms"
+  | "summaries"
+  | "rootExplanations"
+  | "gaps"
+  | "visuals"
+  | "excerpts"
+  | "other";
+
+const BUCKET_HEADINGS: Record<HandoffBucket, string> = {
+  learningObjectives: "Learning Objectives",
+  concepts: "Concepts",
+  terms: "Terms",
+  summaries: "Summaries",
+  rootExplanations: "Root Explanations",
+  gaps: "Gaps / Questions",
+  visuals: "Visual Map Outline / Images",
+  excerpts: "Source Excerpts",
+  other: "Other Workspace Notes",
+};
+
+function normalizeLine(value: string | null | undefined): string | null {
+  const trimmed = String(value || "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readSourceLabel(workspaceObject: StudioWorkspaceObject): string | null {
+  if (workspaceObject.kind === "excerpt") {
+    return workspaceObject.provenance.sourceTitle;
+  }
+  if (workspaceObject.kind === "text_note") {
+    return workspaceObject.provenance.sourceLabel;
+  }
+  if (workspaceObject.kind === "material") {
+    return workspaceObject.detail;
+  }
+  if (workspaceObject.kind === "vault_path") {
+    return workspaceObject.title;
+  }
+  if (workspaceObject.kind === "image") {
+    return workspaceObject.asset.url;
+  }
+  if (workspaceObject.kind === "link_reference") {
+    return workspaceObject.href;
+  }
+  return null;
+}
+
+function getBucket(workspaceObject: StudioWorkspaceObject): HandoffBucket {
+  if (workspaceObject.kind === "image" || workspaceObject.kind === "diagram_sketch") {
+    return "visuals";
+  }
+  if (workspaceObject.kind === "excerpt") {
+    return "excerpts";
+  }
+
+  const label = `${workspaceObject.badge} ${workspaceObject.title}`.toLowerCase();
+  if (label.includes("objective")) return "learningObjectives";
+  if (label.includes("concept")) return "concepts";
+  if (label.includes("term")) return "terms";
+  if (label.includes("summar")) return "summaries";
+  if (label.includes("root")) return "rootExplanations";
+  if (
+    label.includes("gap") ||
+    label.includes("question") ||
+    label.includes("unsupported")
+  ) {
+    return "gaps";
+  }
+  return "other";
+}
+
+function formatWorkspaceObject(workspaceObject: StudioWorkspaceObject): string {
+  const lines = [`### ${workspaceObject.title}`, ""];
+  const sourceLabel = normalizeLine(readSourceLabel(workspaceObject));
+  if (sourceLabel) {
+    lines.push(`Source: ${sourceLabel}`, "");
+  }
+  lines.push(workspaceObject.detail.trim() || "_No detail captured._");
+
+  if (workspaceObject.kind === "image") {
+    lines.push("", `Image: ${workspaceObject.asset.url}`);
+  }
+  if (workspaceObject.kind === "link_reference") {
+    lines.push("", `Link: ${workspaceObject.href}`);
+  }
+
+  return lines.join("\n").trim();
+}
+
+export function buildObsidianHandoffMarkdown({
+  courseName,
+  sessionGoal = null,
+  materialTitles = [],
+  workspaceObjects,
+}: BuildObsidianHandoffMarkdownParams): string {
+  const selectedObjects = workspaceObjects.filter(
+    (workspaceObject) => workspaceObject.workspace?.obsidianHandoff === true,
+  );
+  const lines = [
+    `# Obsidian Handoff - ${normalizeLine(courseName) || "Unassigned Course"}`,
+    "",
+    `Course: ${normalizeLine(courseName) || "Unassigned Course"}`,
+    `Session goal: ${normalizeLine(sessionGoal) || "Not specified"}`,
+  ];
+
+  const normalizedMaterials = materialTitles
+    .map((title) => normalizeLine(title))
+    .filter((title): title is string => Boolean(title));
+  lines.push(
+    `Materials: ${
+      normalizedMaterials.length > 0 ? normalizedMaterials.join(", ") : "No material titles captured"
+    }`,
+    "",
+  );
+
+  const grouped = new Map<HandoffBucket, StudioWorkspaceObject[]>();
+  for (const workspaceObject of selectedObjects) {
+    const bucket = getBucket(workspaceObject);
+    grouped.set(bucket, [...(grouped.get(bucket) || []), workspaceObject]);
+  }
+
+  for (const bucket of Object.keys(BUCKET_HEADINGS) as HandoffBucket[]) {
+    const objects = grouped.get(bucket) || [];
+    lines.push(`## ${BUCKET_HEADINGS[bucket]}`);
+    if (objects.length === 0) {
+      lines.push("_None selected._", "");
+      continue;
+    }
+    lines.push(objects.map(formatWorkspaceObject).join("\n\n"), "");
+  }
+
+  return lines.join("\n").trimEnd() + "\n";
+}

--- a/dashboard_rebuild/client/src/lib/studioWorkspaceObjects.ts
+++ b/dashboard_rebuild/client/src/lib/studioWorkspaceObjects.ts
@@ -9,7 +9,10 @@ interface RepairWorkspaceCandidate {
 }
 
 export type StudioWorkspaceObject =
-  | {
+  {
+    workspace?: StudioWorkspaceCardState;
+  } & (
+    | {
       id: string;
       kind: "material";
       title: string;
@@ -84,7 +87,21 @@ export type StudioWorkspaceObject =
             resultKey: string;
             sourceLabel: string;
           };
-    };
+    }
+  );
+
+export interface StudioWorkspaceCardState {
+  hidden?: boolean;
+  tutorContext?: boolean;
+  obsidianHandoff?: boolean;
+}
+
+export type StudioWorkspaceObjectUpdate = {
+  title?: string;
+  detail?: string;
+  badge?: string;
+  workspace?: StudioWorkspaceCardState;
+};
 
 function formatFileType(value: string | null | undefined): string {
   const normalized = String(value || "").trim();
@@ -240,6 +257,10 @@ export function createStudioPrimingResultWorkspaceObject({
     title: normalizedTitle,
     detail: normalizedDetail,
     badge: badge.trim() || "PRIMING",
+    workspace: {
+      tutorContext: true,
+      obsidianHandoff: true,
+    },
     provenance: {
       sourceType: "priming_result",
       resultKey: resultKey.trim(),
@@ -301,6 +322,21 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isStudioWorkspaceCardState(
+  value: unknown,
+): value is StudioWorkspaceCardState | undefined {
+  if (typeof value === "undefined") return true;
+  if (!isPlainRecord(value)) return false;
+  return (
+    (typeof value.hidden === "undefined" ||
+      typeof value.hidden === "boolean") &&
+    (typeof value.tutorContext === "undefined" ||
+      typeof value.tutorContext === "boolean") &&
+    (typeof value.obsidianHandoff === "undefined" ||
+      typeof value.obsidianHandoff === "boolean")
+  );
+}
+
 export function isStudioWorkspaceObject(value: unknown): value is StudioWorkspaceObject {
   if (!isPlainRecord(value)) return false;
   if (
@@ -310,6 +346,9 @@ export function isStudioWorkspaceObject(value: unknown): value is StudioWorkspac
     typeof value.detail !== "string" ||
     typeof value.badge !== "string"
   ) {
+    return false;
+  }
+  if (!isStudioWorkspaceCardState(value.workspace)) {
     return false;
   }
 

--- a/dashboard_rebuild/client/src/lib/tutorClientState.ts
+++ b/dashboard_rebuild/client/src/lib/tutorClientState.ts
@@ -14,6 +14,8 @@ export const TUTOR_LIBRARY_HANDOFF_KEY = "tutor.open_from_library.v1";
 export const TUTOR_BRAIN_HANDOFF_KEY = "tutor.open_from_brain.v1";
 export const TUTOR_VAULT_FOLDER_KEY = "tutor.vault_folder.v1";
 export const LIBRARY_TUTOR_HANDOFF_KEY = "library.open_from_tutor.v1";
+export const TUTOR_COURSE_SETUP_PRIMING_HANDOFF_KEY =
+  "tutor.course_setup_priming_handoff.v1";
 
 export type TutorBrainLaunchContext = {
   source?: string;
@@ -33,6 +35,15 @@ export type LibraryTutorLaunchContext = {
   courseEventId?: number;
   eventType?: string | null;
   target?: "load_materials";
+};
+
+export type TutorCourseSetupPrimingHandoff = {
+  courseId?: number;
+  courseName?: string;
+  materialId: number;
+  materialTitle: string;
+  setupKind?: string;
+  sourcePath?: string | null;
 };
 
 export type TutorPersistedStartState = {
@@ -199,6 +210,41 @@ function normalizeTutorStartState(
         : "",
     selectedPaths: normalizeStringArray(record.selectedPaths),
   };
+}
+
+function normalizeTutorCourseSetupPrimingHandoff(
+  value: unknown,
+): TutorCourseSetupPrimingHandoff | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const materialId =
+    typeof record.materialId === "number" &&
+    Number.isInteger(record.materialId) &&
+    record.materialId > 0
+      ? record.materialId
+      : null;
+  const materialTitle =
+    typeof record.materialTitle === "string" && record.materialTitle.trim()
+      ? record.materialTitle.trim()
+      : "";
+  if (!materialId || !materialTitle) return null;
+  const next: TutorCourseSetupPrimingHandoff = {
+    materialId,
+    materialTitle,
+  };
+  if (
+    typeof record.courseId === "number" &&
+    Number.isInteger(record.courseId) &&
+    record.courseId > 0
+  ) {
+    next.courseId = record.courseId;
+  }
+  if (typeof record.courseName === "string") next.courseName = record.courseName;
+  if (typeof record.setupKind === "string") next.setupKind = record.setupKind;
+  if (typeof record.sourcePath === "string" || record.sourcePath === null) {
+    next.sourcePath = record.sourcePath;
+  }
+  return next;
 }
 
 export function readTutorSelectedMaterialIds(
@@ -450,6 +496,7 @@ export function consumeTutorLaunchHandoff(
 ): {
   fromLibraryHandoff: boolean;
   brainLaunchContext: TutorBrainLaunchContext | null;
+  courseSetupPrimingHandoff: TutorCourseSetupPrimingHandoff | null;
 } {
   const fromLibraryHandoff = storage.getItem(TUTOR_LIBRARY_HANDOFF_KEY) === "1";
   if (fromLibraryHandoff) {
@@ -477,7 +524,24 @@ export function consumeTutorLaunchHandoff(
     }
   }
 
-  return { fromLibraryHandoff, brainLaunchContext };
+  const rawSetupHandoff = storage.getItem(TUTOR_COURSE_SETUP_PRIMING_HANDOFF_KEY);
+  let courseSetupPrimingHandoff: TutorCourseSetupPrimingHandoff | null = null;
+  if (rawSetupHandoff !== null) {
+    try {
+      courseSetupPrimingHandoff = normalizeTutorCourseSetupPrimingHandoff(
+        JSON.parse(rawSetupHandoff),
+      );
+    } catch {
+      courseSetupPrimingHandoff = null;
+    }
+    try {
+      storage.removeItem(TUTOR_COURSE_SETUP_PRIMING_HANDOFF_KEY);
+    } catch {
+      // Ignore storage failures.
+    }
+  }
+
+  return { fromLibraryHandoff, brainLaunchContext, courseSetupPrimingHandoff };
 }
 
 export function peekTutorLaunchHandoff(
@@ -485,6 +549,7 @@ export function peekTutorLaunchHandoff(
 ): {
   fromLibraryHandoff: boolean;
   brainLaunchContext: TutorBrainLaunchContext | null;
+  courseSetupPrimingHandoff: TutorCourseSetupPrimingHandoff | null;
 } {
   const fromLibraryHandoff = storage.getItem(TUTOR_LIBRARY_HANDOFF_KEY) === "1";
   const rawBrainHandoff = storage.getItem(TUTOR_BRAIN_HANDOFF_KEY);
@@ -498,7 +563,33 @@ export function peekTutorLaunchHandoff(
       brainLaunchContext = null;
     }
   }
-  return { fromLibraryHandoff, brainLaunchContext };
+  const rawSetupHandoff = storage.getItem(TUTOR_COURSE_SETUP_PRIMING_HANDOFF_KEY);
+  let courseSetupPrimingHandoff: TutorCourseSetupPrimingHandoff | null = null;
+  if (rawSetupHandoff !== null) {
+    try {
+      courseSetupPrimingHandoff = normalizeTutorCourseSetupPrimingHandoff(
+        JSON.parse(rawSetupHandoff),
+      );
+    } catch {
+      courseSetupPrimingHandoff = null;
+    }
+  }
+  return { fromLibraryHandoff, brainLaunchContext, courseSetupPrimingHandoff };
+}
+
+export function writeTutorCourseSetupPrimingHandoff(
+  value: TutorCourseSetupPrimingHandoff,
+  storage: Pick<Storage, "setItem"> = window.sessionStorage,
+): TutorCourseSetupPrimingHandoff {
+  const normalized = normalizeTutorCourseSetupPrimingHandoff(value);
+  if (!normalized) {
+    throw new Error("A setup material id and title are required.");
+  }
+  storage.setItem(
+    TUTOR_COURSE_SETUP_PRIMING_HANDOFF_KEY,
+    JSON.stringify(normalized),
+  );
+  return normalized;
 }
 
 export function writeLibraryLaunchFromTutor(

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
@@ -11,6 +11,8 @@ const {
   getContentSourcesMock,
   getMaterialContentMock,
   previewSyncMaterialsFolderMock,
+  startSyncMaterialsFolderMock,
+  getSyncMaterialsStatusMock,
   getEmbedStatusMock,
   updateMaterialMock,
   deleteMaterialMock,
@@ -23,6 +25,8 @@ const {
   getContentSourcesMock: vi.fn(),
   getMaterialContentMock: vi.fn(),
   previewSyncMaterialsFolderMock: vi.fn(),
+  startSyncMaterialsFolderMock: vi.fn(),
+  getSyncMaterialsStatusMock: vi.fn(),
   getEmbedStatusMock: vi.fn(),
   updateMaterialMock: vi.fn(),
   deleteMaterialMock: vi.fn(),
@@ -60,6 +64,8 @@ vi.mock("@/lib/api", () => ({
       getContentSources: getContentSourcesMock,
       getMaterialContent: getMaterialContentMock,
       previewSyncMaterialsFolder: previewSyncMaterialsFolderMock,
+      startSyncMaterialsFolder: startSyncMaterialsFolderMock,
+      getSyncMaterialsStatus: getSyncMaterialsStatusMock,
       embedStatus: getEmbedStatusMock,
       updateMaterial: updateMaterialMock,
       deleteMaterial: deleteMaterialMock,
@@ -132,6 +138,28 @@ describe("Library catalog", () => {
       allowed_exts: [".pdf", ".docx", ".pptx", ".txt", ".md", ".mp4"],
       truncated: false,
       max_files: 5000,
+    });
+    startSyncMaterialsFolderMock.mockResolvedValue({
+      ok: true,
+      job_id: "source-upload-job",
+      selected_count: 1,
+      setup_count: 0,
+      course_id: null,
+    });
+    getSyncMaterialsStatusMock.mockResolvedValue({
+      job_id: "source-upload-job",
+      status: "completed",
+      phase: "done",
+      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
+      processed: 1,
+      total: 1,
+      index: 1,
+      current_file: null,
+      errors: 0,
+      sync_result: { ok: true, processed: 1, total: 1, doc_ids: [901] },
+      embed_result: null,
+      started_at: new Date("2026-05-15T12:00:00Z").toISOString(),
+      finished_at: new Date("2026-05-15T12:00:02Z").toISOString(),
     });
     getEmbedStatusMock.mockResolvedValue({
       materials: [
@@ -503,5 +531,115 @@ describe("Library catalog", () => {
       screen.getByRole("button", { name: /refresh source folders/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/2 source files detected/i)).toBeInTheDocument();
+  });
+
+  it("opens the Upload tab with checkbox candidates for unuploaded source-folder files", async () => {
+    const root =
+      "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School";
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 401,
+        title: "Already Loaded",
+        source_path: `${root}/10_Dx Mgmt Integumentary/10_Week 1/already-loaded.pdf`,
+        folder_path: "10_Dx Mgmt Integumentary/10_Week 1",
+        file_type: "pdf",
+        file_size: 100,
+        course_id: null,
+        enabled: true,
+        extraction_error: null,
+        checksum: "existing-401",
+        created_at: new Date("2026-05-15T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-05-15T12:00:00Z").toISOString(),
+      },
+    ]);
+    previewSyncMaterialsFolderMock.mockResolvedValue({
+      ok: true,
+      folder: root,
+      tree: {
+        type: "folder",
+        name: "PT School",
+        path: "",
+        children: [
+          {
+            type: "folder",
+            name: "10_Dx Mgmt Integumentary",
+            path: "10_Dx Mgmt Integumentary",
+            children: [
+              {
+                type: "folder",
+                name: "10_Week 1",
+                path: "10_Dx Mgmt Integumentary/10_Week 1",
+                children: [
+                  {
+                    type: "file",
+                    name: "already-loaded.pdf",
+                    path: "10_Dx Mgmt Integumentary/10_Week 1/already-loaded.pdf",
+                    size: 100,
+                  },
+                  {
+                    type: "file",
+                    name: "Wound Healing Lecture.pptx",
+                    path: "10_Dx Mgmt Integumentary/10_Week 1/Wound Healing Lecture.pptx",
+                    size: 2200,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      counts: { folders: 2, files: 2 },
+      allowed_exts: [".pdf", ".pptx"],
+      truncated: false,
+      max_files: 5000,
+    });
+
+    renderLibrary();
+
+    fireEvent.click(await screen.findByRole("button", { name: /folders/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /10_Dx Mgmt Integumentary/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "UPLOAD" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+    const candidatePanel = await screen.findByTestId(
+      "library-source-upload-candidates",
+    );
+    expect(
+      within(candidatePanel).getByRole("checkbox", {
+        name: /upload wound healing lecture\.pptx/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(candidatePanel).queryByRole("checkbox", {
+        name: /upload already-loaded\.pdf/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(candidatePanel).getByRole("checkbox", {
+        name: /upload wound healing lecture\.pptx/i,
+      }),
+    );
+    fireEvent.click(
+      within(candidatePanel).getByRole("button", {
+        name: /upload selected \(1\)/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(startSyncMaterialsFolderMock).toHaveBeenCalledWith({
+        folder_path: root,
+        selected_files: [
+          "10_Dx Mgmt Integumentary/10_Week 1/Wound Healing Lecture.pptx",
+        ],
+        course_id: null,
+      }),
+    );
   });
 });

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -263,7 +263,10 @@ describe("Library catalog", () => {
       source_path: "Uploaded Files/intro-notes.pdf",
       file_type: "pdf",
       char_count: 12000,
-      content: "# Intro Notes\n\n" + "Readable paragraph.\n\n".repeat(80),
+      content:
+        "# Intro Notes\n\n" +
+        "| Phase | What to check |\n|---|---|\n| Intake | Confirm the file renders clearly. |\n\n" +
+        "Readable paragraph.\n\n".repeat(80),
       assets: [],
     });
 
@@ -278,6 +281,8 @@ describe("Library catalog", () => {
     expect(markdownReader.className).toContain("library-material-markdown");
     expect(markdownReader.className).toContain("prose-headings:font-sans");
     expect(markdownReader.className).not.toContain("prose-headings:font-arcade");
+    expect(screen.getByTestId("library-material-table-scroll")).toBeInTheDocument();
+    expect(screen.getByRole("table")).toHaveTextContent("What to check");
     expect(screen.getByRole("dialog", { name: "Intro Notes" })).toBeInTheDocument();
     expect(screen.getAllByText(/readable paragraph/i).length).toBeGreaterThan(1);
   });

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -274,6 +274,10 @@ describe("Library catalog", () => {
     expect(await screen.findByTestId("library-material-reader")).toHaveClass(
       "overflow-y-auto",
     );
+    const markdownReader = screen.getByTestId("library-material-markdown");
+    expect(markdownReader.className).toContain("library-material-markdown");
+    expect(markdownReader.className).toContain("prose-headings:font-sans");
+    expect(markdownReader.className).not.toContain("prose-headings:font-arcade");
     expect(screen.getByRole("dialog", { name: "Intro Notes" })).toBeInTheDocument();
     expect(screen.getAllByText(/readable paragraph/i).length).toBeGreaterThan(1);
   });

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -256,6 +256,28 @@ describe("Library catalog", () => {
     expect(screen.queryByText(/study run/i)).not.toBeInTheDocument();
   });
 
+  it("opens extracted material content in a readable scroll container", async () => {
+    getMaterialContentMock.mockResolvedValue({
+      id: 1,
+      title: "Intro Notes",
+      source_path: "Uploaded Files/intro-notes.pdf",
+      file_type: "pdf",
+      char_count: 12000,
+      content: "# Intro Notes\n\n" + "Readable paragraph.\n\n".repeat(80),
+      assets: [],
+    });
+
+    renderLibrary();
+
+    fireEvent.click(await screen.findByRole("button", { name: "View content" }));
+
+    expect(await screen.findByTestId("library-material-reader")).toHaveClass(
+      "overflow-y-auto",
+    );
+    expect(screen.getByRole("dialog", { name: "Intro Notes" })).toBeInTheDocument();
+    expect(screen.getAllByText(/readable paragraph/i).length).toBeGreaterThan(1);
+  });
+
   it("uploads files into the Library without setup/intake choices", async () => {
     getActiveCoursesMock.mockResolvedValue([
       { id: 9, name: "Dx Mgmt Integumentary", code: "PHYT 6262" },

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -421,6 +421,101 @@ describe("Library catalog", () => {
     expect(screen.getByText("Professional Writing")).toBeInTheDocument();
   });
 
+  it("filters catalog rows from basic file-column filter buttons", async () => {
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 201,
+        title: "Movement Objectives",
+        source_path: "11_Movement Science II/objectives.pdf",
+        folder_path: "11_Movement Science II",
+        file_type: "pdf",
+        file_size: 1024,
+        course_id: null,
+        enabled: true,
+        extraction_error: null,
+        checksum: "filter-201",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+      {
+        id: 202,
+        title: "Task Analysis Slides",
+        source_path: "11_Movement Science II/task-analysis.pptx",
+        folder_path: "11_Movement Science II",
+        file_type: "pptx",
+        file_size: 2048,
+        course_id: null,
+        enabled: true,
+        extraction_error: null,
+        checksum: "filter-202",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+    ]);
+
+    renderLibrary();
+
+    expect(await screen.findByText("Movement Objectives")).toBeInTheDocument();
+    expect(screen.getByText("Task Analysis Slides")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /filter type column/i }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "PDF" }));
+
+    expect(screen.getByText("Movement Objectives")).toBeInTheDocument();
+    expect(screen.queryByText("Task Analysis Slides")).not.toBeInTheDocument();
+  });
+
+  it("supports basic file-explorer column resize, autofit, and drag ordering", async () => {
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 301,
+        title: "MSII Topic 1 - Control of Human Movement With A Long Name",
+        source_path:
+          "11_Movement Science II/10_Intro/MSII Topic 1 - Control of Human Movement.pptx",
+        folder_path: "11_Movement Science II/10_Intro",
+        file_type: "pptx",
+        file_size: 4096,
+        course_id: null,
+        enabled: true,
+        extraction_error: null,
+        checksum: "explorer-301",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+    ]);
+
+    renderLibrary();
+
+    expect(await screen.findByText(/MSII Topic 1/)).toBeInTheDocument();
+    const headerRow = screen.getByTestId("library-material-table-header");
+    const initialTemplate = headerRow.style.gridTemplateColumns;
+
+    fireEvent.doubleClick(
+      screen.getByRole("separator", { name: /resize title column/i }),
+    );
+    expect(headerRow.style.gridTemplateColumns).not.toBe(initialTemplate);
+
+    const titleResize = screen.getByRole("separator", {
+      name: /resize title column/i,
+    });
+    const beforeDragTemplate = headerRow.style.gridTemplateColumns;
+    fireEvent.mouseDown(titleResize, { clientX: 100 });
+    fireEvent.mouseMove(window, { clientX: 150 });
+    fireEvent.mouseUp(window);
+    expect(headerRow.style.gridTemplateColumns).not.toBe(beforeDragTemplate);
+
+    const titleHeader = screen.getByTestId("library-table-header-title");
+    const folderHeader = screen.getByTestId("library-table-header-folder");
+    fireEvent.dragStart(folderHeader);
+    fireEvent.dragOver(titleHeader);
+    fireEvent.drop(titleHeader);
+
+    const orderedColumns = Array.from(
+      headerRow.querySelectorAll("[data-library-column-id]"),
+    ).map((node) => node.getAttribute("data-library-column-id"));
+    expect(orderedColumns.slice(0, 2)).toEqual(["folder", "title"]);
+  });
+
   it("consumes Tutor Page 1 handoff and preselects the upload course target", async () => {
     getActiveCoursesMock.mockResolvedValue([
       { id: 9, name: "Neuro", code: "NEU-9" },

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
@@ -13,16 +13,7 @@ const {
   getEmbedStatusMock,
   updateMaterialMock,
   deleteMaterialMock,
-  previewSyncMaterialsFolderMock,
-  startSyncMaterialsFolderMock,
-  getSyncMaterialsStatusMock,
   reextractMaterialMock,
-  semesterIntakePreviewMock,
-  semesterIntakeApplyMock,
-  readTutorSelectedMaterialIdsMock,
-  writeTutorSelectedMaterialIdsMock,
-  writeTutorStoredStartStateMock,
-  setLocationMock,
 } = vi.hoisted(() => ({
   consumeLibraryLaunchFromTutorMock: vi.fn(),
   getMaterialsMock: vi.fn(),
@@ -33,16 +24,7 @@ const {
   getEmbedStatusMock: vi.fn(),
   updateMaterialMock: vi.fn(),
   deleteMaterialMock: vi.fn(),
-  previewSyncMaterialsFolderMock: vi.fn(),
-  startSyncMaterialsFolderMock: vi.fn(),
-  getSyncMaterialsStatusMock: vi.fn(),
   reextractMaterialMock: vi.fn(),
-  semesterIntakePreviewMock: vi.fn(),
-  semesterIntakeApplyMock: vi.fn(),
-  readTutorSelectedMaterialIdsMock: vi.fn(),
-  writeTutorSelectedMaterialIdsMock: vi.fn(),
-  writeTutorStoredStartStateMock: vi.fn(),
-  setLocationMock: vi.fn(),
 }));
 
 vi.mock("@/components/layout", () => ({
@@ -50,18 +32,23 @@ vi.mock("@/components/layout", () => ({
 }));
 
 vi.mock("@/components/MaterialUploader", () => ({
-  MaterialUploader: () => <div data-testid="material-uploader" />,
+  MaterialUploader: ({
+    courseId,
+    role,
+    setupKind,
+  }: {
+    courseId?: number;
+    role?: string;
+    setupKind?: string;
+  }) => (
+    <div data-testid={`material-uploader-${role || "study"}`}>
+      {role || "study"}:{setupKind || "none"}:{courseId || "none"}
+    </div>
+  ),
 }));
 
 vi.mock("@/lib/tutorClientState", () => ({
   consumeLibraryLaunchFromTutor: consumeLibraryLaunchFromTutorMock,
-  readTutorSelectedMaterialIds: readTutorSelectedMaterialIdsMock,
-  writeTutorSelectedMaterialIds: writeTutorSelectedMaterialIdsMock,
-  writeTutorStoredStartState: writeTutorStoredStartStateMock,
-}));
-
-vi.mock("wouter", () => ({
-  useLocation: () => ["/library", setLocationMock],
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -73,18 +60,11 @@ vi.mock("@/lib/api", () => ({
       embedStatus: getEmbedStatusMock,
       updateMaterial: updateMaterialMock,
       deleteMaterial: deleteMaterialMock,
-      previewSyncMaterialsFolder: previewSyncMaterialsFolderMock,
-      startSyncMaterialsFolder: startSyncMaterialsFolderMock,
-      getSyncMaterialsStatus: getSyncMaterialsStatusMock,
       reextractMaterial: reextractMaterialMock,
     },
     courses: {
       getActive: getActiveCoursesMock,
       getEvery: getEveryCoursesMock,
-    },
-    semesterIntake: {
-      preview: semesterIntakePreviewMock,
-      apply: semesterIntakeApplyMock,
     },
   },
 }));
@@ -102,15 +82,13 @@ function renderLibrary() {
   );
 }
 
-describe("Library tutor handoff", () => {
+describe("Library catalog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
 
     consumeLibraryLaunchFromTutorMock.mockReturnValue(null);
-    readTutorSelectedMaterialIdsMock.mockReturnValue([]);
-    writeTutorSelectedMaterialIdsMock.mockImplementation(() => {});
 
     getMaterialsMock.mockResolvedValue([
       {
@@ -159,36 +137,9 @@ describe("Library tutor handoff", () => {
       collection: "tutor_materials_gemini_gemini-embedding-2-preview",
       auto_selected_provider: false,
     });
-    semesterIntakePreviewMock.mockResolvedValue({
-      ok: true,
-      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
-      courses: [],
-      global_schedule_files: [],
-      unassigned_material_files: [],
-      ignored_files: [],
-      counts: {
-        courses: 0,
-        syllabus_files: 0,
-        schedule_files: 0,
-        material_files: 0,
-        ignored_files: 0,
-      },
-    });
-    semesterIntakeApplyMock.mockResolvedValue({
-      ok: true,
-      coursesCreated: 0,
-      coursesUpdated: 0,
-      modulesCreated: 0,
-      objectivesCreated: 0,
-      eventsCreated: 0,
-      setupFilesParsed: 0,
-      setupParseErrors: [],
-      materialSyncJobs: [],
-      courses: [],
-    });
   });
 
-  it("renders the course-first Library operations workflow", async () => {
+  it("renders Library as a catalog with upload, not intake or Tutor handoff", async () => {
     getActiveCoursesMock.mockResolvedValue([
       { id: 11, name: "Movement Science II", code: "PHYT 6242" },
     ]);
@@ -206,213 +157,134 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     expect(await screen.findByText("COURSE RAIL")).toBeInTheDocument();
+    expect(getMaterialsMock).toHaveBeenCalledWith({ include_setup: true });
     expect(screen.getByText("Movement Science II")).toBeInTheDocument();
     expect(screen.getByText("PHYT 6242")).toBeInTheDocument();
-    expect(screen.getByText("ADD COURSEWORK")).toBeInTheDocument();
-    expect(screen.getByText("COURSE SETUP")).toBeInTheDocument();
-    expect(screen.getByText("STUDY MATERIALS")).toBeInTheDocument();
-    expect(screen.getByText("CURRENT RUN")).toBeInTheDocument();
-    expect(screen.getByText("STUDY READINESS")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /choose files/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /folder sync/i })).toBeInTheDocument();
-    expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
-    expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
-    expect(screen.getByText("YOUR MATERIALS")).toBeInTheDocument();
-    expect(screen.getByText(/build the Current Run/i)).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("option", {
-        name: /Movement Science II \(PHYT 6242\)/i,
-      }).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByRole("tab", { name: /all files/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /upload/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /all files/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByPlaceholderText(/search library files/i)).toBeInTheDocument();
+    expect(screen.getByText("LIBRARY FILES")).toBeInTheDocument();
+    expect(screen.getByText("Intro Notes")).toBeInTheDocument();
+
+    expect(screen.queryByText(/selected for tutor/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/study run/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /use visible/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add visible/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /open tutor/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /semester intake/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /folder sync/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /refresh pt school/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /upload/i }));
+    expect(screen.getAllByText("UPLOAD FILES").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("material-uploader-study")).toBeInTheDocument();
+    expect(screen.queryByTestId("material-uploader-setup")).not.toBeInTheDocument();
+    expect(screen.queryByText(/course setup upload/i)).not.toBeInTheDocument();
   });
 
-  it("switches Add Coursework modes without losing selected-file safety", async () => {
+  it("uses a compact visual shell with catalog tabs as the primary navigation", async () => {
+    const { container } = renderLibrary();
+
+    expect(await screen.findByText("COURSE RAIL")).toBeInTheDocument();
+    expect(
+      container.querySelector(".library-ops-workspace--calm"),
+    ).toBeInTheDocument();
+
+    const workflowTabs = screen.getByRole("tablist", {
+      name: /library workflow/i,
+    });
+    expect(workflowTabs).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "ALL FILES" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "UPLOAD" }));
+    expect(screen.getByRole("tab", { name: "UPLOAD" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("shows setup files as ordinary catalog rows without study controls", async () => {
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 11,
+        title: "Dx Mgmt Syllabus and Schedule",
+        source_path: "Uploaded Files/dx-syllabus-schedule.docx",
+        folder_path: "Uploaded Files",
+        file_type: "docx",
+        doc_type: "course_setup",
+        material_role: "setup",
+        setup_kind: "syllabus_schedule",
+        file_size: 70122,
+        course_id: null,
+        enabled: true,
+        extraction_error: null,
+        checksum: "setup-11",
+        created_at: new Date("2026-05-14T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-05-14T12:00:00Z").toISOString(),
+      },
+      {
+        id: 12,
+        title: "Dx Week 1 Wound Lecture",
+        source_path: "Uploaded Files/dx-week-1.pptx",
+        folder_path: "Uploaded Files",
+        file_type: "pptx",
+        doc_type: "upload",
+        material_role: "study",
+        file_size: 99000,
+        course_id: null,
+        enabled: true,
+        extraction_error: null,
+        checksum: "study-12",
+        created_at: new Date("2026-05-14T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-05-14T12:00:00Z").toISOString(),
+      },
+    ]);
+
+    renderLibrary();
+
+    expect(await screen.findByText("Dx Mgmt Syllabus and Schedule")).toBeInTheDocument();
+    expect(screen.getByText("Dx Week 1 Wound Lecture")).toBeInTheDocument();
+    expect(screen.getByText("SETUP")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /open tutor/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/study run/i)).not.toBeInTheDocument();
+  });
+
+  it("uploads files into the Library without setup/intake choices", async () => {
     getActiveCoursesMock.mockResolvedValue([
-      { id: 11, name: "Movement Science II", code: "PHYT 6242" },
+      { id: 9, name: "Dx Mgmt Integumentary", code: "PHYT 6262" },
     ]);
     getContentSourcesMock.mockResolvedValue({
       courses: [
         {
-          id: 11,
-          name: "Movement Science II",
-          code: "PHYT 6242",
-          doc_count: 2,
+          id: 9,
+          name: "Dx Mgmt Integumentary",
+          code: "PHYT 6262",
+          doc_count: 0,
         },
       ],
     });
 
     renderLibrary();
 
-    expect(await screen.findByText("ADD COURSEWORK")).toBeInTheDocument();
-    expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
-    expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
-
-    expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /semester intake/i }));
-
-    expect(
-      screen.getByRole("button", { name: /apply setup \+ selected files/i }),
-    ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: /folder sync/i }));
-
-    expect(screen.getByText("SYNC STUDY FOLDER")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /sync selected files/i })).toBeDisabled();
-    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: /choose files/i }));
-
-    expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
-    expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
-  });
-
-  it("shows Movement Science II intake as a reviewable course row", async () => {
-    semesterIntakePreviewMock.mockResolvedValue({
-      ok: true,
-      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
-      courses: [
-        {
-          name: "Movement Science II",
-          code: "PHYT 6242",
-          folder_path: "11_Movement Science II",
-          syllabus_files: [
-            {
-              path: "11_Movement Science II/syllabus.docx",
-              name: "syllabus.docx",
-              roles: ["syllabus"],
-              size: 100,
-              modified_at: "2026-05-13T12:00:00",
-            },
-          ],
-          schedule_files: [
-            {
-              path: "11_Movement Science II/schedule.pdf",
-              name: "schedule.pdf",
-              roles: ["schedule"],
-              size: 120,
-              modified_at: "2026-05-13T12:00:00",
-            },
-          ],
-          material_files: [
-            {
-              path: "11_Movement Science II/Topic 1/objectives.docx",
-              name: "objectives.docx",
-              roles: ["material"],
-              size: 90,
-              modified_at: "2026-05-13T12:00:00",
-            },
-            {
-              path: "11_Movement Science II/Topic 1/intro-movement.pptx",
-              name: "intro-movement.pptx",
-              roles: ["material"],
-              size: 200,
-              modified_at: "2026-05-13T12:00:00",
-            },
-          ],
-          readiness: {
-            course: "missing",
-            syllabus: "found",
-            schedule: "found",
-            materials: "found",
-            embeddings: "pending",
-            readyForTutor: false,
-          },
-        },
-      ],
-      global_schedule_files: [],
-      unassigned_material_files: [],
-      ignored_files: [],
-      counts: {
-        courses: 1,
-        syllabus_files: 1,
-        schedule_files: 1,
-        material_files: 2,
-        ignored_files: 0,
-      },
+    fireEvent.click(await screen.findByRole("tab", { name: /upload/i }));
+    expect((await screen.findAllByText("UPLOAD FILES")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("COURSE SETUP UPLOAD")).not.toBeInTheDocument();
+    expect(screen.queryByText("STUDY MATERIAL UPLOAD")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByRole("combobox", { name: /upload course/i }), {
+      target: { value: "9" },
     });
-
-    renderLibrary();
-
-    fireEvent.click(await screen.findByRole("button", { name: /semester intake/i }));
-    fireEvent.click(await screen.findByRole("button", { name: /scan intake/i }));
-
-    expect(await screen.findByText("Movement Science II")).toBeInTheDocument();
-    expect(
-      screen.getByText(/1 syllabus \/ 1 schedule \/ 2 material/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/0 selected for Library/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", {
-        name: /load objectives\.docx from movement science ii/i,
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", {
-        name: /load intro-movement\.pptx from movement science ii/i,
-      }),
-    ).toBeInTheDocument();
+    expect(screen.queryByTestId("material-uploader-setup")).not.toBeInTheDocument();
+    expect(screen.getByTestId("material-uploader-study")).toHaveTextContent("study:none:9");
   });
 
-  it("writes selected tutor materials and clears stale wizard progress on open", async () => {
-    getMaterialsMock.mockResolvedValue([
-      {
-        id: 1,
-        title: "Intro Notes",
-        source_path: "Uploaded Files/intro-notes.pdf",
-        folder_path: "Uploaded Files",
-        file_type: "pdf",
-        file_size: 1024,
-        course_id: 9,
-        enabled: true,
-        extraction_error: null,
-        checksum: "abc123",
-        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
-        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
-      },
-    ]);
-    localStorage.setItem(
-      "tutor.wizard.progress.v1",
-      JSON.stringify({ step: 2, chainMode: "template" }),
-    );
-
-    renderLibrary();
-
-    await screen.findByText("Intro Notes");
-    expect(screen.getByText("COURSE RAIL")).toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /select intro notes for tutor/i }),
-    );
-
-    await waitFor(() => {
-      expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([1]);
-    });
-
-    writeTutorSelectedMaterialIdsMock.mockClear();
-
-    fireEvent.click(screen.getByRole("button", { name: /open tutor/i }));
-
-    expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([1]);
-    expect(writeTutorStoredStartStateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        courseId: 9,
-        selectedMaterials: [1],
-        chainId: undefined,
-        customBlockIds: [],
-        accuracyProfile: "strict",
-        objectiveScope: "module_all",
-        selectedObjectiveId: "",
-        selectedObjectiveGroup: "",
-        selectedPaths: [],
-      }),
-    );
-    expect(localStorage.getItem("tutor.wizard.progress.v1")).toBeNull();
-    expect(localStorage.getItem("tutor-studio-last-tab")).toBe("workspace");
-    expect(sessionStorage.getItem("tutor.open_from_library.v1")).toBe("1");
-    expect(setLocationMock).toHaveBeenCalledWith("/tutor?course_id=9");
-  });
-
-  it("keeps textbook references visible but out of default Current Run bulk actions", async () => {
+  it("searches uploaded materials by title, folder, type, and source path", async () => {
     getMaterialsMock.mockResolvedValue([
       {
         id: 101,
@@ -422,7 +294,7 @@ describe("Library tutor handoff", () => {
         folder_path: "11_Movement Science II/10_Intro",
         file_type: "pdf",
         file_size: 1024,
-        course_id: 9,
+        course_id: null,
         enabled: true,
         extraction_error: null,
         checksum: "study-101",
@@ -431,16 +303,15 @@ describe("Library tutor handoff", () => {
       },
       {
         id: 102,
-        title: "Observational Gait Analysis",
-        source_path:
-          "11_Movement Science II/01_Textbook/Observational Gait Analysis.pdf",
-        folder_path: "11_Movement Science II/01_Textbook",
+        title: "Professional Writing",
+        source_path: "13_Professionalism/Professional Writing.pdf",
+        folder_path: "13_Professionalism",
         file_type: "pdf",
         file_size: 4096,
-        course_id: 9,
+        course_id: null,
         enabled: true,
         extraction_error: null,
-        checksum: "reference-102",
+        checksum: "study-102",
         created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
         updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
       },
@@ -449,68 +320,24 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     expect(await screen.findByText("MSII Topic 1 Objectives")).toBeInTheDocument();
-    expect(screen.getByText("Observational Gait Analysis")).toBeInTheDocument();
-    expect(screen.getByText("COURSE REF")).toBeInTheDocument();
+    expect(screen.getByText("Professional Writing")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /replace run/i }));
-
-    await waitFor(() => {
-      expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([101]);
+    fireEvent.change(screen.getByPlaceholderText(/search library files/i), {
+      target: { value: "professionalism" },
     });
-    expect(screen.getByText(/Current Run: 1 file total/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /open tutor \(1\)/i })).toBeEnabled();
+
+    expect(screen.queryByText("MSII Topic 1 Objectives")).not.toBeInTheDocument();
+    expect(screen.getByText("Professional Writing")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/search library files/i), {
+      target: { value: "pdf" },
+    });
+
+    expect(screen.getByText("MSII Topic 1 Objectives")).toBeInTheDocument();
+    expect(screen.getByText("Professional Writing")).toBeInTheDocument();
   });
 
-  it("launches Tutor with only the row file when Study this file is used", async () => {
-    getMaterialsMock.mockResolvedValue([
-      {
-        id: 1,
-        title: "Intro Notes",
-        source_path: "Uploaded Files/intro-notes.pdf",
-        folder_path: "Uploaded Files",
-        file_type: "pdf",
-        file_size: 1024,
-        course_id: 9,
-        enabled: true,
-        extraction_error: null,
-        checksum: "abc123",
-        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
-        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
-      },
-      {
-        id: 2,
-        title: "Reference Chapter",
-        source_path: "Uploaded Files/reference-chapter.pdf",
-        folder_path: "Uploaded Files/01_Textbook",
-        file_type: "pdf",
-        file_size: 2048,
-        course_id: 9,
-        enabled: true,
-        extraction_error: null,
-        checksum: "def456",
-        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
-        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
-      },
-    ]);
-
-    renderLibrary();
-
-    await screen.findByText("Intro Notes");
-    fireEvent.click(
-      screen.getByRole("button", { name: /study intro notes in tutor/i }),
-    );
-
-    expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([1]);
-    expect(writeTutorStoredStartStateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        courseId: 9,
-        selectedMaterials: [1],
-      }),
-    );
-    expect(setLocationMock).toHaveBeenCalledWith("/tutor?course_id=9");
-  });
-
-  it("consumes Tutor Page 1 handoff and preselects the course intake target", async () => {
+  it("consumes Tutor Page 1 handoff and preselects the upload course target", async () => {
     getActiveCoursesMock.mockResolvedValue([
       { id: 9, name: "Neuro", code: "NEU-9" },
     ]);
@@ -527,205 +354,36 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     expect(await screen.findByText("NEU-9")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /choose files/i }));
-    expect(
-      screen.getByRole("combobox", { name: /upload course/i }),
-    ).toHaveValue("9");
-    fireEvent.click(screen.getByRole("button", { name: /folder sync/i }));
-    expect(screen.getByRole("combobox", { name: /sync course/i })).toHaveValue(
+    fireEvent.click(screen.getByRole("tab", { name: /upload/i }));
+    expect(screen.getByRole("combobox", { name: /upload course/i })).toHaveValue(
       "9",
     );
   });
 
-  it("scans a semester folder and applies course setup from Library", async () => {
-    semesterIntakePreviewMock.mockResolvedValue({
-      ok: true,
-      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
-      courses: [
-        {
-          name: "Dx Mgmt Integumentary",
-          code: "PHYT 6262",
-          folder_path: "10_Dx_Mgmt_Integumentary",
-          syllabus_files: [
-            {
-              path: "10_Dx_Mgmt_Integumentary/syllabus.docx",
-              name: "syllabus.docx",
-              roles: ["syllabus"],
-              size: 100,
-              modified_at: "2026-05-11T12:00:00",
-            },
-          ],
-          schedule_files: [],
-          material_files: [
-            {
-              path: "10_Dx_Mgmt_Integumentary/week-1.pdf",
-              name: "week-1.pdf",
-              roles: ["material"],
-              size: 200,
-              modified_at: "2026-05-11T12:00:00",
-            },
-            {
-              path: "10_Dx_Mgmt_Integumentary/week-1-extra.pptx",
-              name: "week-1-extra.pptx",
-              roles: ["material"],
-              size: 250,
-              modified_at: "2026-05-11T12:00:00",
-            },
-          ],
-          readiness: {
-            course: "missing",
-            syllabus: "found",
-            schedule: "missing",
-            materials: "found",
-            embeddings: "pending",
-            readyForTutor: false,
-          },
-        },
-      ],
-      global_schedule_files: [
-        {
-          path: "00_Class_Schedules/semester-schedule.pdf",
-          name: "semester-schedule.pdf",
-          roles: ["schedule"],
-          size: 300,
-          modified_at: "2026-05-11T12:00:00",
-        },
-      ],
-      unassigned_material_files: [],
-      ignored_files: [],
-      counts: {
-        courses: 1,
-        syllabus_files: 1,
-        schedule_files: 1,
-        material_files: 2,
-        ignored_files: 0,
-      },
-    });
-    semesterIntakeApplyMock.mockResolvedValue({
-      ok: true,
-      coursesCreated: 1,
-      coursesUpdated: 0,
-      modulesCreated: 0,
-      objectivesCreated: 0,
-      eventsCreated: 0,
-      setupFilesParsed: 1,
-      setupParseErrors: [],
-      materialSyncJobs: [{ courseId: 1, jobId: "semester-sync-job" }],
-      courses: [{ id: 1, name: "Dx Mgmt Integumentary" }],
-    });
-
-    renderLibrary();
-
-    expect(
-      await screen.findByRole("button", { name: /semester intake/i }),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /semester intake/i }));
-    fireEvent.click(screen.getByRole("button", { name: /scan intake/i }));
-
-    expect(await screen.findByText("Dx Mgmt Integumentary")).toBeInTheDocument();
-    expect(screen.getByText(/0 selected for Library/i)).toBeInTheDocument();
-    fireEvent.click(
-      screen.getByRole("checkbox", {
-        name: /load week-1\.pdf from dx mgmt integumentary/i,
-      }),
-    );
-    fireEvent.click(
-      screen.getByRole("button", { name: /apply setup \+ selected files/i }),
-    );
-
-    await waitFor(() => {
-      expect(semesterIntakeApplyMock).toHaveBeenCalledWith({
-        folder_path:
-          "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
-        courses: [
-          {
-            name: "Dx Mgmt Integumentary",
-            code: "PHYT 6262",
-            folder_path: "10_Dx_Mgmt_Integumentary",
-            syllabus_files: ["10_Dx_Mgmt_Integumentary/syllabus.docx"],
-            schedule_files: [],
-            material_files: ["10_Dx_Mgmt_Integumentary/week-1.pdf"],
-            syllabus: { modules: [] },
-            schedule: { events: [] },
-          },
-        ],
-      });
-    });
-  });
-
-  it("scans a folder without auto-selecting every file for sync", async () => {
-    previewSyncMaterialsFolderMock.mockResolvedValue({
-      ok: true,
-      type: "folder",
-      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
-      counts: { folders: 1, files: 2 },
-      tree: {
-        type: "folder",
-        name: "Movement Science II",
-        path: "",
-        children: [
-          {
-            type: "folder",
-            name: "Topic 1",
-            path: "Topic 1",
-            children: [
-              {
-                type: "file",
-                name: "objectives.docx",
-                path: "Topic 1/objectives.docx",
-                size: 100,
-                modified_at: "2026-05-13T12:00:00",
-              },
-              {
-                type: "file",
-                name: "intro-movement.pptx",
-                path: "Topic 1/intro-movement.pptx",
-                size: 200,
-                modified_at: "2026-05-13T12:00:00",
-              },
-            ],
-          },
-        ],
-      },
-      allowed_exts: [".docx", ".pptx"],
-      truncated: false,
-    });
-    startSyncMaterialsFolderMock.mockResolvedValue({
-      ok: true,
-      job_id: "sync-selected-only",
-      folder:
-        "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
-      selected_count: 1,
-      course_id: null,
-    });
-
-    renderLibrary();
-
-    fireEvent.click(await screen.findByRole("button", { name: /folder sync/i }));
-    fireEvent.change(screen.getByPlaceholderText(/paste the local pt school folder path/i), {
-      target: {
-        value:
-          "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
-      },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /scan folder tree/i }));
-
-    expect(await screen.findByText(/2 files found/i)).toBeInTheDocument();
-    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /sync selected files/i })).toBeDisabled();
-
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /sync objectives\.docx/i }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: /sync selected files/i }));
-
-    await waitFor(() => {
-      expect(startSyncMaterialsFolderMock).toHaveBeenCalledWith({
-        folder_path:
-          "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
-        selected_files: ["Topic 1/objectives.docx"],
+  it("folder rail shows folders from uploaded Library materials only", async () => {
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 301,
+        title: "Topic 1 objectives",
+        source_path:
+          "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II/Topic 1/objectives.pdf",
+        folder_path: "Movement Science II/Topic 1",
+        file_type: "pdf",
+        file_size: 200,
         course_id: null,
-      });
-    });
+        enabled: true,
+        extraction_error: null,
+        checksum: "existing-301",
+        created_at: new Date("2026-05-14T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-05-14T12:00:00Z").toISOString(),
+      },
+    ]);
+
+    renderLibrary();
+
+    fireEvent.click(await screen.findByRole("button", { name: /folders/i }));
+    expect(await screen.findByText("Movement Science II")).toBeInTheDocument();
+    expect(screen.getByText("Topic 1")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /refresh pt school/i })).not.toBeInTheDocument();
   });
 });

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
@@ -279,11 +279,19 @@ describe("Library catalog", () => {
     );
     const markdownReader = screen.getByTestId("library-material-markdown");
     expect(markdownReader.className).toContain("library-material-markdown");
+    expect(markdownReader.className).toContain("max-w-[86ch]");
     expect(markdownReader.className).toContain("prose-headings:font-sans");
     expect(markdownReader.className).not.toContain("prose-headings:font-arcade");
     expect(screen.getByTestId("library-material-table-scroll")).toBeInTheDocument();
     expect(screen.getByRole("table")).toHaveTextContent("What to check");
-    expect(screen.getByRole("dialog", { name: "Intro Notes" })).toBeInTheDocument();
+    const contentDialog = screen.getByRole("dialog", { name: "Intro Notes" });
+    expect(contentDialog).toBeInTheDocument();
+    expect(
+      within(contentDialog).getByRole("heading", {
+        level: 2,
+        name: "Intro Notes",
+      }),
+    ).toHaveClass("library-material-dialog-title");
     expect(screen.getAllByText(/readable paragraph/i).length).toBeGreaterThan(1);
   });
 

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -7,6 +7,7 @@ const {
   consumeLibraryLaunchFromTutorMock,
   getMaterialsMock,
   getActiveCoursesMock,
+  getEveryCoursesMock,
   getContentSourcesMock,
   getMaterialContentMock,
   getEmbedStatusMock,
@@ -26,6 +27,7 @@ const {
   consumeLibraryLaunchFromTutorMock: vi.fn(),
   getMaterialsMock: vi.fn(),
   getActiveCoursesMock: vi.fn(),
+  getEveryCoursesMock: vi.fn(),
   getContentSourcesMock: vi.fn(),
   getMaterialContentMock: vi.fn(),
   getEmbedStatusMock: vi.fn(),
@@ -78,6 +80,7 @@ vi.mock("@/lib/api", () => ({
     },
     courses: {
       getActive: getActiveCoursesMock,
+      getEvery: getEveryCoursesMock,
     },
     semesterIntake: {
       preview: semesterIntakePreviewMock,
@@ -126,6 +129,7 @@ describe("Library tutor handoff", () => {
       },
     ]);
     getActiveCoursesMock.mockResolvedValue([]);
+    getEveryCoursesMock.mockResolvedValue([]);
     getContentSourcesMock.mockResolvedValue({ courses: [] });
     getMaterialContentMock.mockResolvedValue({
       id: 1,
@@ -184,6 +188,164 @@ describe("Library tutor handoff", () => {
     });
   });
 
+  it("renders the course-first Library operations workflow", async () => {
+    getActiveCoursesMock.mockResolvedValue([
+      { id: 11, name: "Movement Science II", code: "PHYT 6242" },
+    ]);
+    getContentSourcesMock.mockResolvedValue({
+      courses: [
+        {
+          id: 11,
+          name: "Movement Science II",
+          code: "PHYT 6242",
+          doc_count: 2,
+        },
+      ],
+    });
+
+    renderLibrary();
+
+    expect(await screen.findByText("COURSE RAIL")).toBeInTheDocument();
+    expect(screen.getByText("Movement Science II")).toBeInTheDocument();
+    expect(screen.getByText("PHYT 6242")).toBeInTheDocument();
+    expect(screen.getByText("ADD COURSEWORK")).toBeInTheDocument();
+    expect(screen.getByText("SOURCE")).toBeInTheDocument();
+    expect(screen.getByText("REVIEW")).toBeInTheDocument();
+    expect(screen.getByText("STUDY")).toBeInTheDocument();
+    expect(screen.getByText("STUDY READINESS")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /folder sync/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /direct upload/i })).toBeInTheDocument();
+    expect(screen.getByText("YOUR MATERIALS")).toBeInTheDocument();
+    expect(screen.getByText(/ready for tutor handoff/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("option", {
+        name: /Movement Science II \(PHYT 6242\)/i,
+      }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("switches Add Coursework modes without losing selected-file safety", async () => {
+    getActiveCoursesMock.mockResolvedValue([
+      { id: 11, name: "Movement Science II", code: "PHYT 6242" },
+    ]);
+    getContentSourcesMock.mockResolvedValue({
+      courses: [
+        {
+          id: 11,
+          name: "Movement Science II",
+          code: "PHYT 6242",
+          doc_count: 2,
+        },
+      ],
+    });
+
+    renderLibrary();
+
+    expect(await screen.findByText("ADD COURSEWORK")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /apply setup \+ selected files/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /folder sync/i }));
+
+    expect(screen.getByText("SYNC STUDY FOLDER")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sync selected files/i })).toBeDisabled();
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /direct upload/i }));
+
+    expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
+    expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
+  });
+
+  it("shows Movement Science II intake as a reviewable course row", async () => {
+    semesterIntakePreviewMock.mockResolvedValue({
+      ok: true,
+      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
+      courses: [
+        {
+          name: "Movement Science II",
+          code: "PHYT 6242",
+          folder_path: "11_Movement Science II",
+          syllabus_files: [
+            {
+              path: "11_Movement Science II/syllabus.docx",
+              name: "syllabus.docx",
+              roles: ["syllabus"],
+              size: 100,
+              modified_at: "2026-05-13T12:00:00",
+            },
+          ],
+          schedule_files: [
+            {
+              path: "11_Movement Science II/schedule.pdf",
+              name: "schedule.pdf",
+              roles: ["schedule"],
+              size: 120,
+              modified_at: "2026-05-13T12:00:00",
+            },
+          ],
+          material_files: [
+            {
+              path: "11_Movement Science II/Topic 1/objectives.docx",
+              name: "objectives.docx",
+              roles: ["material"],
+              size: 90,
+              modified_at: "2026-05-13T12:00:00",
+            },
+            {
+              path: "11_Movement Science II/Topic 1/intro-movement.pptx",
+              name: "intro-movement.pptx",
+              roles: ["material"],
+              size: 200,
+              modified_at: "2026-05-13T12:00:00",
+            },
+          ],
+          readiness: {
+            course: "missing",
+            syllabus: "found",
+            schedule: "found",
+            materials: "found",
+            embeddings: "pending",
+            readyForTutor: false,
+          },
+        },
+      ],
+      global_schedule_files: [],
+      unassigned_material_files: [],
+      ignored_files: [],
+      counts: {
+        courses: 1,
+        syllabus_files: 1,
+        schedule_files: 1,
+        material_files: 2,
+        ignored_files: 0,
+      },
+    });
+
+    renderLibrary();
+
+    fireEvent.click(await screen.findByRole("button", { name: /scan intake/i }));
+
+    expect(await screen.findByText("Movement Science II")).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 syllabus \/ 1 schedule \/ 2 material/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/0 selected for Library/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", {
+        name: /load objectives\.docx from movement science ii/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", {
+        name: /load intro-movement\.pptx from movement science ii/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("writes selected tutor materials and clears stale wizard progress on open", async () => {
     getMaterialsMock.mockResolvedValue([
       {
@@ -209,11 +371,10 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     await screen.findByText("Intro Notes");
-    expect(
-      screen.getByText("Mirror your Obsidian-style folder tree."),
-    ).toBeInTheDocument();
-    const checkboxes = screen.getAllByRole("checkbox");
-    fireEvent.click(checkboxes[1]);
+    expect(screen.getByText("COURSE RAIL")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /select intro notes for tutor/i }),
+    );
 
     await waitFor(() => {
       expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([1]);
@@ -260,9 +421,11 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     expect(await screen.findByText("NEU-9")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /direct upload/i }));
     expect(
       screen.getByRole("combobox", { name: /upload course/i }),
     ).toHaveValue("9");
+    fireEvent.click(screen.getByRole("button", { name: /folder sync/i }));
     expect(screen.getByRole("combobox", { name: /sync course/i })).toHaveValue(
       "9",
     );
@@ -275,6 +438,7 @@ describe("Library tutor handoff", () => {
       courses: [
         {
           name: "Dx Mgmt Integumentary",
+          code: "PHYT 6262",
           folder_path: "10_Dx_Mgmt_Integumentary",
           syllabus_files: [
             {
@@ -292,6 +456,13 @@ describe("Library tutor handoff", () => {
               name: "week-1.pdf",
               roles: ["material"],
               size: 200,
+              modified_at: "2026-05-11T12:00:00",
+            },
+            {
+              path: "10_Dx_Mgmt_Integumentary/week-1-extra.pptx",
+              name: "week-1-extra.pptx",
+              roles: ["material"],
+              size: 250,
               modified_at: "2026-05-11T12:00:00",
             },
           ],
@@ -320,7 +491,7 @@ describe("Library tutor handoff", () => {
         courses: 1,
         syllabus_files: 1,
         schedule_files: 1,
-        material_files: 1,
+        material_files: 2,
         ignored_files: 0,
       },
     });
@@ -339,12 +510,20 @@ describe("Library tutor handoff", () => {
 
     renderLibrary();
 
-    expect(await screen.findByText("SEMESTER INTAKE")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /semester intake/i }),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /scan intake/i }));
 
     expect(await screen.findByText("Dx Mgmt Integumentary")).toBeInTheDocument();
+    expect(screen.getByText(/0 selected for Library/i)).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: /apply course setup/i }),
+      screen.getByRole("checkbox", {
+        name: /load week-1\.pdf from dx mgmt integumentary/i,
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply setup \+ selected files/i }),
     );
 
     await waitFor(() => {
@@ -354,6 +533,7 @@ describe("Library tutor handoff", () => {
         courses: [
           {
             name: "Dx Mgmt Integumentary",
+            code: "PHYT 6262",
             folder_path: "10_Dx_Mgmt_Integumentary",
             syllabus_files: ["10_Dx_Mgmt_Integumentary/syllabus.docx"],
             schedule_files: [],
@@ -362,6 +542,82 @@ describe("Library tutor handoff", () => {
             schedule: { events: [] },
           },
         ],
+      });
+    });
+  });
+
+  it("scans a folder without auto-selecting every file for sync", async () => {
+    previewSyncMaterialsFolderMock.mockResolvedValue({
+      ok: true,
+      type: "folder",
+      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
+      counts: { folders: 1, files: 2 },
+      tree: {
+        type: "folder",
+        name: "Movement Science II",
+        path: "",
+        children: [
+          {
+            type: "folder",
+            name: "Topic 1",
+            path: "Topic 1",
+            children: [
+              {
+                type: "file",
+                name: "objectives.docx",
+                path: "Topic 1/objectives.docx",
+                size: 100,
+                modified_at: "2026-05-13T12:00:00",
+              },
+              {
+                type: "file",
+                name: "intro-movement.pptx",
+                path: "Topic 1/intro-movement.pptx",
+                size: 200,
+                modified_at: "2026-05-13T12:00:00",
+              },
+            ],
+          },
+        ],
+      },
+      allowed_exts: [".docx", ".pptx"],
+      truncated: false,
+    });
+    startSyncMaterialsFolderMock.mockResolvedValue({
+      ok: true,
+      job_id: "sync-selected-only",
+      folder:
+        "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
+      selected_count: 1,
+      course_id: null,
+    });
+
+    renderLibrary();
+
+    fireEvent.click(await screen.findByRole("button", { name: /folder sync/i }));
+    fireEvent.change(screen.getByPlaceholderText(/paste the local pt school folder path/i), {
+      target: {
+        value:
+          "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /scan folder tree/i }));
+
+    expect(await screen.findByText(/2 files found/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sync selected files/i })).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /sync objectives\.docx/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /sync selected files/i }));
+
+    await waitFor(() => {
+      expect(startSyncMaterialsFolderMock).toHaveBeenCalledWith({
+        folder_path:
+          "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School/Movement Science II",
+        selected_files: ["Topic 1/objectives.docx"],
+        course_id: null,
       });
     });
   });

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -10,6 +10,7 @@ const {
   getEveryCoursesMock,
   getContentSourcesMock,
   getMaterialContentMock,
+  previewSyncMaterialsFolderMock,
   getEmbedStatusMock,
   updateMaterialMock,
   deleteMaterialMock,
@@ -21,6 +22,7 @@ const {
   getEveryCoursesMock: vi.fn(),
   getContentSourcesMock: vi.fn(),
   getMaterialContentMock: vi.fn(),
+  previewSyncMaterialsFolderMock: vi.fn(),
   getEmbedStatusMock: vi.fn(),
   updateMaterialMock: vi.fn(),
   deleteMaterialMock: vi.fn(),
@@ -57,6 +59,7 @@ vi.mock("@/lib/api", () => ({
       getMaterials: getMaterialsMock,
       getContentSources: getContentSourcesMock,
       getMaterialContent: getMaterialContentMock,
+      previewSyncMaterialsFolder: previewSyncMaterialsFolderMock,
       embedStatus: getEmbedStatusMock,
       updateMaterial: updateMaterialMock,
       deleteMaterial: deleteMaterialMock,
@@ -115,6 +118,20 @@ describe("Library catalog", () => {
       source_path: "Uploaded Files/intro-notes.pdf",
       content: "notes",
       assets: [],
+    });
+    previewSyncMaterialsFolderMock.mockResolvedValue({
+      ok: true,
+      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
+      tree: {
+        type: "folder",
+        name: "PT School",
+        path: "",
+        children: [],
+      },
+      counts: { folders: 0, files: 0 },
+      allowed_exts: [".pdf", ".docx", ".pptx", ".txt", ".md", ".mp4"],
+      truncated: false,
+      max_files: 5000,
     });
     getEmbedStatusMock.mockResolvedValue({
       materials: [
@@ -399,7 +416,7 @@ describe("Library catalog", () => {
     );
   });
 
-  it("folder rail shows folders from uploaded Library materials only", async () => {
+  it("folder rail refreshes from the live PT School source tree", async () => {
     getMaterialsMock.mockResolvedValue([
       {
         id: 301,
@@ -417,12 +434,74 @@ describe("Library catalog", () => {
         updated_at: new Date("2026-05-14T12:00:00Z").toISOString(),
       },
     ]);
+    previewSyncMaterialsFolderMock.mockResolvedValue({
+      ok: true,
+      folder: "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School",
+      tree: {
+        type: "folder",
+        name: "PT School",
+        path: "",
+        children: [
+          {
+            type: "folder",
+            name: "10_Dx Mgmt Integumentary",
+            path: "10_Dx Mgmt Integumentary",
+            children: [
+              {
+                type: "folder",
+                name: "10_Week 1 Course Intro Skin Anatomy and Wound Healing",
+                path: "10_Dx Mgmt Integumentary/10_Week 1 Course Intro Skin Anatomy and Wound Healing",
+                children: [
+                  {
+                    type: "file",
+                    name: "PHYT 6262 - Skin Anatomy.pptx",
+                    path: "10_Dx Mgmt Integumentary/10_Week 1 Course Intro Skin Anatomy and Wound Healing/PHYT 6262 - Skin Anatomy.pptx",
+                    size: 400,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "folder",
+            name: "11_Movement Science II",
+            path: "11_Movement Science II",
+            children: [
+              {
+                type: "folder",
+                name: "10_Intro and Perspective of Human Movement",
+                path: "11_Movement Science II/10_Intro and Perspective of Human Movement",
+                children: [
+                  {
+                    type: "file",
+                    name: "objectives.pdf",
+                    path: "11_Movement Science II/10_Intro and Perspective of Human Movement/objectives.pdf",
+                    size: 200,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      counts: { folders: 4, files: 2 },
+      allowed_exts: [".pdf", ".pptx"],
+      truncated: false,
+      max_files: 5000,
+    });
 
     renderLibrary();
 
     fireEvent.click(await screen.findByRole("button", { name: /folders/i }));
-    expect(await screen.findByText("Movement Science II")).toBeInTheDocument();
-    expect(screen.getByText("Topic 1")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /refresh pt school/i })).not.toBeInTheDocument();
+    expect(previewSyncMaterialsFolderMock).toHaveBeenCalledWith({});
+    expect(await screen.findByText("10_Dx Mgmt Integumentary")).toBeInTheDocument();
+    expect(screen.getByText("11_Movement Science II")).toBeInTheDocument();
+    expect(
+      screen.getByText("10_Intro and Perspective of Human Movement"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /refresh source folders/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2 source files detected/i)).toBeInTheDocument();
   });
 });

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -213,9 +213,11 @@ describe("Library tutor handoff", () => {
     expect(screen.getByText("STUDY MATERIALS")).toBeInTheDocument();
     expect(screen.getByText("CURRENT RUN")).toBeInTheDocument();
     expect(screen.getByText("STUDY READINESS")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /choose files/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /folder sync/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /direct upload/i })).toBeInTheDocument();
+    expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
+    expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
     expect(screen.getByText("YOUR MATERIALS")).toBeInTheDocument();
     expect(screen.getByText(/build the Current Run/i)).toBeInTheDocument();
     expect(
@@ -243,7 +245,12 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     expect(await screen.findByText("ADD COURSEWORK")).toBeInTheDocument();
+    expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
+    expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
+
     expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /semester intake/i }));
+
     expect(
       screen.getByRole("button", { name: /apply setup \+ selected files/i }),
     ).toBeInTheDocument();
@@ -254,7 +261,7 @@ describe("Library tutor handoff", () => {
     expect(screen.getByRole("button", { name: /sync selected files/i })).toBeDisabled();
     expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /direct upload/i }));
+    fireEvent.click(screen.getByRole("button", { name: /choose files/i }));
 
     expect(screen.getByText("UPLOAD MATERIALS")).toBeInTheDocument();
     expect(screen.getByTestId("material-uploader")).toBeInTheDocument();
@@ -327,6 +334,7 @@ describe("Library tutor handoff", () => {
 
     renderLibrary();
 
+    fireEvent.click(await screen.findByRole("button", { name: /semester intake/i }));
     fireEvent.click(await screen.findByRole("button", { name: /scan intake/i }));
 
     expect(await screen.findByText("Movement Science II")).toBeInTheDocument();
@@ -519,7 +527,7 @@ describe("Library tutor handoff", () => {
     renderLibrary();
 
     expect(await screen.findByText("NEU-9")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /direct upload/i }));
+    fireEvent.click(screen.getByRole("button", { name: /choose files/i }));
     expect(
       screen.getByRole("combobox", { name: /upload course/i }),
     ).toHaveValue("9");
@@ -611,6 +619,7 @@ describe("Library tutor handoff", () => {
     expect(
       await screen.findByRole("button", { name: /semester intake/i }),
     ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /semester intake/i }));
     fireEvent.click(screen.getByRole("button", { name: /scan intake/i }));
 
     expect(await screen.findByText("Dx Mgmt Integumentary")).toBeInTheDocument();

--- a/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/library.test.tsx
@@ -209,15 +209,15 @@ describe("Library tutor handoff", () => {
     expect(screen.getByText("Movement Science II")).toBeInTheDocument();
     expect(screen.getByText("PHYT 6242")).toBeInTheDocument();
     expect(screen.getByText("ADD COURSEWORK")).toBeInTheDocument();
-    expect(screen.getByText("SOURCE")).toBeInTheDocument();
-    expect(screen.getByText("REVIEW")).toBeInTheDocument();
-    expect(screen.getByText("STUDY")).toBeInTheDocument();
+    expect(screen.getByText("COURSE SETUP")).toBeInTheDocument();
+    expect(screen.getByText("STUDY MATERIALS")).toBeInTheDocument();
+    expect(screen.getByText("CURRENT RUN")).toBeInTheDocument();
     expect(screen.getByText("STUDY READINESS")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /semester intake/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /folder sync/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /direct upload/i })).toBeInTheDocument();
     expect(screen.getByText("YOUR MATERIALS")).toBeInTheDocument();
-    expect(screen.getByText(/ready for tutor handoff/i)).toBeInTheDocument();
+    expect(screen.getByText(/build the Current Run/i)).toBeInTheDocument();
     expect(
       screen.getAllByRole("option", {
         name: /Movement Science II \(PHYT 6242\)/i,
@@ -401,6 +401,104 @@ describe("Library tutor handoff", () => {
     expect(localStorage.getItem("tutor.wizard.progress.v1")).toBeNull();
     expect(localStorage.getItem("tutor-studio-last-tab")).toBe("workspace");
     expect(sessionStorage.getItem("tutor.open_from_library.v1")).toBe("1");
+    expect(setLocationMock).toHaveBeenCalledWith("/tutor?course_id=9");
+  });
+
+  it("keeps textbook references visible but out of default Current Run bulk actions", async () => {
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 101,
+        title: "MSII Topic 1 Objectives",
+        source_path:
+          "11_Movement Science II/10_Intro/MSII Topic 1 Objectives.pdf",
+        folder_path: "11_Movement Science II/10_Intro",
+        file_type: "pdf",
+        file_size: 1024,
+        course_id: 9,
+        enabled: true,
+        extraction_error: null,
+        checksum: "study-101",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+      {
+        id: 102,
+        title: "Observational Gait Analysis",
+        source_path:
+          "11_Movement Science II/01_Textbook/Observational Gait Analysis.pdf",
+        folder_path: "11_Movement Science II/01_Textbook",
+        file_type: "pdf",
+        file_size: 4096,
+        course_id: 9,
+        enabled: true,
+        extraction_error: null,
+        checksum: "reference-102",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+    ]);
+
+    renderLibrary();
+
+    expect(await screen.findByText("MSII Topic 1 Objectives")).toBeInTheDocument();
+    expect(screen.getByText("Observational Gait Analysis")).toBeInTheDocument();
+    expect(screen.getByText("COURSE REF")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /replace run/i }));
+
+    await waitFor(() => {
+      expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([101]);
+    });
+    expect(screen.getByText(/Current Run: 1 file total/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /open tutor \(1\)/i })).toBeEnabled();
+  });
+
+  it("launches Tutor with only the row file when Study this file is used", async () => {
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 1,
+        title: "Intro Notes",
+        source_path: "Uploaded Files/intro-notes.pdf",
+        folder_path: "Uploaded Files",
+        file_type: "pdf",
+        file_size: 1024,
+        course_id: 9,
+        enabled: true,
+        extraction_error: null,
+        checksum: "abc123",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+      {
+        id: 2,
+        title: "Reference Chapter",
+        source_path: "Uploaded Files/reference-chapter.pdf",
+        folder_path: "Uploaded Files/01_Textbook",
+        file_type: "pdf",
+        file_size: 2048,
+        course_id: 9,
+        enabled: true,
+        extraction_error: null,
+        checksum: "def456",
+        created_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+        updated_at: new Date("2026-03-05T12:00:00Z").toISOString(),
+      },
+    ]);
+
+    renderLibrary();
+
+    await screen.findByText("Intro Notes");
+    fireEvent.click(
+      screen.getByRole("button", { name: /study intro notes in tutor/i }),
+    );
+
+    expect(writeTutorSelectedMaterialIdsMock).toHaveBeenCalledWith([1]);
+    expect(writeTutorStoredStartStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        courseId: 9,
+        selectedMaterials: [1],
+      }),
+    );
     expect(setLocationMock).toHaveBeenCalledWith("/tutor?course_id=9");
   });
 

--- a/dashboard_rebuild/client/src/pages/__tests__/tutor.test.tsx
+++ b/dashboard_rebuild/client/src/pages/__tests__/tutor.test.tsx
@@ -1215,6 +1215,99 @@ describe("Tutor page restore", () => {
     expect(sourceShelf).toHaveTextContent("Brainstem Walkthrough");
   });
 
+  it("keeps a Library one-file handoff as the Current Run instead of auto-selecting the whole course", async () => {
+    const user = userEvent.setup();
+
+    window.history.replaceState({}, "", "/tutor?course_id=1");
+    localStorage.setItem("tutor.selected_material_ids.v2", JSON.stringify([101]));
+    localStorage.setItem(
+      "tutor.start.state.v2",
+      JSON.stringify({
+        courseId: 1,
+        topic: "",
+        selectedMaterials: [101],
+        customBlockIds: [],
+        accuracyProfile: "strict",
+        objectiveScope: "module_all",
+        selectedObjectiveId: "",
+        selectedObjectiveGroup: "",
+        selectedPaths: [],
+      }),
+    );
+    sessionStorage.setItem("tutor.open_from_library.v1", "1");
+    getContentSourcesMock.mockResolvedValue({
+      courses: [{ id: 1, name: "Movement Science II" }],
+    });
+    getMaterialsMock.mockResolvedValue([
+      {
+        id: 101,
+        title: "MSII Topic 1 Objectives",
+        source_path: "11_Movement Science II/10_Intro/MSII Topic 1 Objectives.pdf",
+        folder_path: "11_Movement Science II/10_Intro",
+        file_type: "pdf",
+        file_size: 1024,
+        course_id: 1,
+        enabled: true,
+        extraction_error: null,
+        checksum: null,
+        created_at: new Date("2026-03-10T00:00:00Z").toISOString(),
+        updated_at: null,
+      },
+      {
+        id: 102,
+        title: "Control of Human Movement",
+        source_path: "11_Movement Science II/10_Intro/Control of Human Movement.pptx",
+        folder_path: "11_Movement Science II/10_Intro",
+        file_type: "pptx",
+        file_size: 2048,
+        course_id: 1,
+        enabled: true,
+        extraction_error: null,
+        checksum: null,
+        created_at: new Date("2026-03-10T00:00:00Z").toISOString(),
+        updated_at: null,
+      },
+      {
+        id: 103,
+        title: "Observational Gait Analysis",
+        source_path: "11_Movement Science II/01_Textbook/Observational Gait Analysis.pdf",
+        folder_path: "11_Movement Science II/01_Textbook",
+        file_type: "pdf",
+        file_size: 4096,
+        course_id: 1,
+        enabled: true,
+        extraction_error: null,
+        checksum: null,
+        created_at: new Date("2026-03-10T00:00:00Z").toISOString(),
+        updated_at: null,
+      },
+    ]);
+    getProjectShellMock.mockResolvedValue(
+      makeProjectShell(1, { selected_material_ids: [102, 103] }),
+    );
+
+    renderTutor();
+
+    expect(await screen.findByTestId("studio-entry-state")).toBeInTheDocument();
+    expect(await screen.findByText("1 of 3 materials selected")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: /msii topic 1 objectives/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /control of human movement/i }),
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /observational gait analysis/i }),
+    ).not.toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /start session/i }));
+
+    const sourceShelf = await screen.findByTestId("studio-source-shelf");
+    expect(sourceShelf).toHaveTextContent("1 material loaded");
+    expect(sourceShelf).toHaveTextContent("1 materials in run");
+    expect(sourceShelf).toHaveTextContent("MSII Topic 1 Objectives");
+  });
+
   it("uploads entry-card materials into the selected course and refreshes the checklist", async () => {
     const user = userEvent.setup();
     let materialRequestCount = 0;
@@ -1854,10 +1947,10 @@ describe("Tutor page restore", () => {
     fireEvent.click(screen.getByRole("button", { name: /^start session$/i }));
 
     await waitFor(() => {
-      expect(preflightSessionMock).toHaveBeenCalledWith(
+      expect(createSessionMock).toHaveBeenCalledWith(
         expect.objectContaining({
+          course_id: 1,
           topic: "Cardiovascular",
-          study_unit: "Cardiovascular",
           module_name: "Cardiovascular",
           content_filter: expect.objectContaining({
             material_ids: [561],

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -2055,7 +2055,7 @@ function useLibraryPageController() {
                     variant="b"
                     className={`${LIBRARY_PANEL_SURFACE} p-3`}
                   >
-                    <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                    <div className="flex flex-col gap-3 2xl:flex-row 2xl:items-center 2xl:justify-between">
                       <div className="min-w-0">
                         <div className={LIBRARY_SECTION_LABEL}>ADD COURSEWORK</div>
                         <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
@@ -2111,7 +2111,7 @@ function useLibraryPageController() {
                     </div>
                   </HudPanel>
 
-                  <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.42fr)]">
+                  <div className="grid gap-3 2xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.42fr)]">
                   {addCourseworkMode === "intake" ? (
                   <HudPanel
                     variant="b"

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -1,5 +1,11 @@
 import { PageScaffold } from "@/components/PageScaffold";
-import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  type ComponentPropsWithoutRef,
+} from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import {
@@ -130,6 +136,39 @@ function resolveMaterialAssetUrl(
     .join("/");
   if (!encodedPath) return "";
   return `/api/tutor/materials/${materialId}/asset/${encodedPath}`;
+}
+
+function getMaterialMarkdownComponents(materialId: number) {
+  return {
+    table: ({
+      node: _node,
+      children,
+      ...props
+    }: ComponentPropsWithoutRef<"table"> & { node?: unknown }) => (
+      <div
+        className="library-material-table-scroll"
+        data-testid="library-material-table-scroll"
+      >
+        <table {...props}>{children}</table>
+      </div>
+    ),
+    img: ({
+      node: _node,
+      src,
+      alt,
+    }: ComponentPropsWithoutRef<"img"> & { node?: unknown }) => {
+      const resolvedSrc = resolveMaterialAssetUrl(src, materialId);
+      if (!resolvedSrc) return null;
+      return (
+        <img
+          src={resolvedSrc}
+          alt={alt || "Extracted figure"}
+          loading="lazy"
+          className="max-w-full h-auto border border-primary/30 bg-black/20"
+        />
+      );
+    },
+  };
 }
 
 function getMaterialTitle(mat: Material): string {
@@ -1768,29 +1807,9 @@ function useLibraryPageController() {
                     >
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
-                        components={{
-                          img: ({
-                            src,
-                            alt,
-                          }: {
-                            src?: string;
-                            alt?: string;
-                          }) => {
-                            const resolvedSrc = resolveMaterialAssetUrl(
-                              src,
-                              materialContent.id,
-                            );
-                            if (!resolvedSrc) return null;
-                            return (
-                              <img
-                                src={resolvedSrc}
-                                alt={alt || "Extracted figure"}
-                                loading="lazy"
-                                className="max-w-full h-auto border border-primary/30 bg-black/20"
-                              />
-                            );
-                          },
-                        }}
+                        components={getMaterialMarkdownComponents(
+                          materialContent.id,
+                        )}
                       >
                         {materialContent.content}
                       </ReactMarkdown>
@@ -1808,23 +1827,7 @@ function useLibraryPageController() {
                 >
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
-                    components={{
-                      img: ({ src, alt }: { src?: string; alt?: string }) => {
-                        const resolvedSrc = resolveMaterialAssetUrl(
-                          src,
-                          materialContent.id,
-                        );
-                        if (!resolvedSrc) return null;
-                        return (
-                          <img
-                            src={resolvedSrc}
-                            alt={alt || "Extracted figure"}
-                            loading="lazy"
-                            className="max-w-full h-auto border border-primary/30 bg-black/20"
-                          />
-                        );
-                      },
-                    }}
+                    components={getMaterialMarkdownComponents(materialContent.id)}
                   >
                     {materialContent.content}
                   </ReactMarkdown>

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useCallback,
   type ComponentPropsWithoutRef,
+  type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
@@ -57,6 +58,7 @@ import {
   ArchiveRestore,
   ChevronDown,
   Plus,
+  ListFilter,
 } from "lucide-react";
 import {
   Dialog,
@@ -87,8 +89,8 @@ const LIBRARY_MAIN_TITLE =
   "font-arcade text-base uppercase tracking-[0.16em] text-white";
 const LIBRARY_PANEL_TITLE = "library-panel-title";
 const LIBRARY_HELP_TEXT = "library-help-text";
-const MATERIAL_TABLE_GRID_TEMPLATE =
-  "40px minmax(340px,1.35fr) minmax(220px,0.9fr) minmax(240px,0.85fr) 92px 96px 132px";
+const MATERIAL_TABLE_ICON_WIDTH = 40;
+const LIBRARY_TABLE_STORAGE_KEY = "pt-study.library.table.v1";
 const MATERIAL_READER_MARKDOWN_CLASS = `
   library-material-markdown prose prose-invert prose-base mx-auto max-w-[86ch] font-sans text-[16px] leading-8 tracking-normal sm:text-[17px]
   prose-headings:font-sans prose-headings:font-semibold prose-headings:tracking-normal prose-headings:normal-case prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-2
@@ -103,6 +105,92 @@ const MATERIAL_READER_MARKDOWN_CLASS = `
 `;
 type LibraryWorkflowTab = "upload" | "materials";
 type MaterialRole = "study" | "reference" | "setup";
+type LibraryTableColumnId =
+  | "title"
+  | "folder"
+  | "type"
+  | "size"
+  | "status"
+  | "actions";
+type LibraryTableFilterKey = "title" | "folder" | "type" | "status";
+type LibraryStatusFilter = "on" | "off";
+type LibraryTableColumnWidths = Record<LibraryTableColumnId, number>;
+
+interface LibraryTableColumnConfig {
+  id: LibraryTableColumnId;
+  label: string;
+  defaultWidth: number;
+  minWidth: number;
+  maxWidth: number;
+  align?: "left" | "right";
+  filter?: LibraryTableFilterKey;
+}
+
+interface LibraryTableFilters {
+  title: string;
+  folder: string;
+  types: string[];
+  statuses: LibraryStatusFilter[];
+}
+
+const LIBRARY_TABLE_COLUMNS: LibraryTableColumnConfig[] = [
+  {
+    id: "title",
+    label: "Title",
+    defaultWidth: 430,
+    minWidth: 220,
+    maxWidth: 720,
+    filter: "title",
+  },
+  {
+    id: "folder",
+    label: "Folder",
+    defaultWidth: 330,
+    minWidth: 170,
+    maxWidth: 620,
+    filter: "folder",
+  },
+  {
+    id: "type",
+    label: "Type",
+    defaultWidth: 250,
+    minWidth: 150,
+    maxWidth: 420,
+    filter: "type",
+  },
+  {
+    id: "size",
+    label: "Size",
+    defaultWidth: 100,
+    minWidth: 78,
+    maxWidth: 180,
+  },
+  {
+    id: "status",
+    label: "Status",
+    defaultWidth: 112,
+    minWidth: 90,
+    maxWidth: 170,
+    filter: "status",
+  },
+  {
+    id: "actions",
+    label: "Actions",
+    defaultWidth: 140,
+    minWidth: 118,
+    maxWidth: 220,
+    align: "right",
+  },
+];
+const DEFAULT_LIBRARY_TABLE_COLUMN_ORDER = LIBRARY_TABLE_COLUMNS.map(
+  (column) => column.id,
+);
+const DEFAULT_LIBRARY_TABLE_FILTERS: LibraryTableFilters = {
+  title: "",
+  folder: "",
+  types: [],
+  statuses: [],
+};
 
 function getFileTypeLabel(fileType: string | null | undefined): string {
   const normalizedRaw = (fileType || "").toLowerCase().trim();
@@ -113,6 +201,121 @@ function getFileTypeLabel(fileType: string | null | undefined): string {
     FILE_TYPE_LABEL[normalized] ||
     (normalized ? normalized.toUpperCase() : "FILE")
   );
+}
+
+function getLibraryTableColumnConfig(
+  columnId: LibraryTableColumnId,
+): LibraryTableColumnConfig {
+  return (
+    LIBRARY_TABLE_COLUMNS.find((column) => column.id === columnId) ||
+    LIBRARY_TABLE_COLUMNS[0]
+  );
+}
+
+function isLibraryTableColumnId(value: unknown): value is LibraryTableColumnId {
+  return (
+    typeof value === "string" &&
+    LIBRARY_TABLE_COLUMNS.some((column) => column.id === value)
+  );
+}
+
+function getDefaultLibraryColumnWidths(): LibraryTableColumnWidths {
+  return LIBRARY_TABLE_COLUMNS.reduce((widths, column) => {
+    widths[column.id] = column.defaultWidth;
+    return widths;
+  }, {} as LibraryTableColumnWidths);
+}
+
+function normalizeLibraryColumnOrder(value: unknown): LibraryTableColumnId[] {
+  const requested = Array.isArray(value)
+    ? value.filter(isLibraryTableColumnId)
+    : [];
+  return [
+    ...requested,
+    ...DEFAULT_LIBRARY_TABLE_COLUMN_ORDER.filter(
+      (columnId) => !requested.includes(columnId),
+    ),
+  ];
+}
+
+function clampLibraryColumnWidth(
+  columnId: LibraryTableColumnId,
+  width: number,
+): number {
+  const config = getLibraryTableColumnConfig(columnId);
+  if (!Number.isFinite(width)) return config.defaultWidth;
+  return Math.max(config.minWidth, Math.min(config.maxWidth, Math.round(width)));
+}
+
+function normalizeLibraryColumnWidths(
+  value: unknown,
+): LibraryTableColumnWidths {
+  const defaults = getDefaultLibraryColumnWidths();
+  if (!value || typeof value !== "object") return defaults;
+  const rawWidths = value as Partial<Record<LibraryTableColumnId, unknown>>;
+  return LIBRARY_TABLE_COLUMNS.reduce((widths, column) => {
+    const rawWidth = Number(rawWidths[column.id]);
+    widths[column.id] = clampLibraryColumnWidth(
+      column.id,
+      Number.isFinite(rawWidth) ? rawWidth : column.defaultWidth,
+    );
+    return widths;
+  }, {} as LibraryTableColumnWidths);
+}
+
+function readLibraryTableState(): {
+  columnOrder: LibraryTableColumnId[];
+  columnWidths: LibraryTableColumnWidths;
+} {
+  if (typeof window === "undefined") {
+    return {
+      columnOrder: DEFAULT_LIBRARY_TABLE_COLUMN_ORDER,
+      columnWidths: getDefaultLibraryColumnWidths(),
+    };
+  }
+  try {
+    const rawState = window.localStorage.getItem(LIBRARY_TABLE_STORAGE_KEY);
+    const parsedState = rawState ? JSON.parse(rawState) : {};
+    const storedState =
+      parsedState && typeof parsedState === "object" ? parsedState : {};
+    return {
+      columnOrder: normalizeLibraryColumnOrder(
+        (storedState as { columnOrder?: unknown }).columnOrder,
+      ),
+      columnWidths: normalizeLibraryColumnWidths(
+        (storedState as { columnWidths?: unknown }).columnWidths,
+      ),
+    };
+  } catch {
+    return {
+      columnOrder: DEFAULT_LIBRARY_TABLE_COLUMN_ORDER,
+      columnWidths: getDefaultLibraryColumnWidths(),
+    };
+  }
+}
+
+function buildLibraryTableGridTemplate(
+  columnOrder: LibraryTableColumnId[],
+  columnWidths: LibraryTableColumnWidths,
+): string {
+  return [
+    `${MATERIAL_TABLE_ICON_WIDTH}px`,
+    ...columnOrder.map(
+      (columnId) => `${clampLibraryColumnWidth(columnId, columnWidths[columnId])}px`,
+    ),
+  ].join(" ");
+}
+
+function getLibraryTableMinWidth(
+  columnOrder: LibraryTableColumnId[],
+  columnWidths: LibraryTableColumnWidths,
+): number {
+  const columnsWidth = columnOrder.reduce(
+    (total, columnId) =>
+      total + clampLibraryColumnWidth(columnId, columnWidths[columnId]),
+    MATERIAL_TABLE_ICON_WIDTH,
+  );
+  return Math.max(920, columnsWidth);
 }
 
 function formatSize(bytes: number | null | undefined): string {
@@ -360,6 +563,102 @@ function getMaterialRole(mat: Material): MaterialRole {
   }
 
   return "study";
+}
+
+function getMaterialColumnText(
+  mat: Material,
+  columnId: LibraryTableColumnId,
+): string {
+  const role = getMaterialRole(mat);
+  const normalizedType = String(mat.file_type || "").toLowerCase();
+  const supportsDocling = ["pdf", "docx", "pptx", "powerpoint"].includes(
+    normalizedType,
+  );
+  switch (columnId) {
+    case "title":
+      return getMaterialTitle(mat);
+    case "folder":
+      return getMaterialFolder(mat);
+    case "type":
+      return [
+        getFileTypeLabel(mat.file_type),
+        role === "reference" ? "Course reference" : "",
+        role === "setup" ? "Setup" : "",
+        supportsDocling ? `D:${Number(mat.docling_asset_count || 0)}` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+    case "size":
+      return formatSize(getMaterialSize(mat));
+    case "status":
+      return mat.enabled ? "On" : "Off";
+    case "actions":
+      return "View Re-extract Edit Delete";
+    default:
+      return "";
+  }
+}
+
+function getAutoFitWidthForColumn(
+  columnId: LibraryTableColumnId,
+  materials: Material[],
+): number {
+  const column = getLibraryTableColumnConfig(columnId);
+  const longestTextLength = Math.max(
+    column.label.length,
+    ...materials.map((material) =>
+      getMaterialColumnText(material, columnId).length,
+    ),
+  );
+  const charWidth = columnId === "title" || columnId === "folder" ? 9 : 10;
+  return clampLibraryColumnWidth(columnId, longestTextLength * charWidth + 58);
+}
+
+function tableFilterIsActive(
+  filters: LibraryTableFilters,
+  filterKey: LibraryTableFilterKey | undefined,
+): boolean {
+  if (!filterKey) return false;
+  if (filterKey === "title") return Boolean(filters.title.trim());
+  if (filterKey === "folder") return Boolean(filters.folder.trim());
+  if (filterKey === "type") return filters.types.length > 0;
+  if (filterKey === "status") return filters.statuses.length > 0;
+  return false;
+}
+
+function materialMatchesLibraryTableFilters(
+  mat: Material,
+  filters: LibraryTableFilters,
+): boolean {
+  const titleFilter = filters.title.trim().toLowerCase();
+  if (
+    titleFilter &&
+    !getMaterialTitle(mat).toLowerCase().includes(titleFilter)
+  ) {
+    return false;
+  }
+
+  const folderFilter = filters.folder.trim().toLowerCase();
+  if (
+    folderFilter &&
+    !getMaterialFolder(mat).toLowerCase().includes(folderFilter)
+  ) {
+    return false;
+  }
+
+  if (
+    filters.types.length > 0 &&
+    !filters.types.includes(getFileTypeLabel(mat.file_type))
+  ) {
+    return false;
+  }
+
+  if (filters.statuses.length > 0) {
+    const status: LibraryStatusFilter = mat.enabled ? "on" : "off";
+    if (!filters.statuses.includes(status)) return false;
+  }
+
+  return true;
 }
 
 function buildFolderTree(materials: Material[]): FolderNode {
@@ -622,6 +921,8 @@ function renderMaterialRow(
   viewContent: (id: number) => void,
   reextractContent: (id: number) => void,
   isReextracting: boolean,
+  columnOrder: LibraryTableColumnId[],
+  gridTemplateColumns: string,
 ) {
   const displayTitle = getMaterialTitle(mat);
   const folderLabel = getMaterialFolder(mat);
@@ -633,193 +934,220 @@ function renderMaterialRow(
   const hasDoclingAssets = Boolean(mat.has_docling_assets);
   const doclingAssetCount = Number(mat.docling_asset_count || 0);
 
+  const renderCell = (columnId: LibraryTableColumnId) => {
+    switch (columnId) {
+      case "title":
+        return (
+          <div key={columnId} className="min-w-0">
+            {editingId === mat.id ? (
+              <div className="flex items-center gap-1">
+                <input
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  className={`${INPUT_BASE} flex-1 h-9 py-1 text-base`}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveEdit();
+                    if (e.key === "Escape") setEditingId(null);
+                  }}
+                />
+                <button
+                  onClick={saveEdit}
+                  className="text-primary hover:text-primary/80"
+                >
+                  <Check className={ICON_SM} />
+                </button>
+                <button
+                  onClick={() => setEditingId(null)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <X className={ICON_SM} />
+                </button>
+              </div>
+            ) : (
+              <div className={`${TEXT_BODY} truncate`} title={displayTitle}>
+                {displayTitle}
+                {mat.extraction_error && (
+                  <span
+                    className="text-red-400 ml-1"
+                    title={mat.extraction_error}
+                  >
+                    [ERR]
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      case "folder":
+        return (
+          <div
+            key={columnId}
+            className={`${TEXT_MUTED} min-w-0 truncate`}
+            title={folderLabel}
+          >
+            {folderLabel}
+          </div>
+        );
+      case "type":
+        return (
+          <div
+            key={columnId}
+            className="flex min-w-0 flex-wrap items-center gap-1.5 overflow-visible"
+          >
+            {isDuplicate ? (
+              <Badge
+                variant="outline"
+                className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-yellow-500/50 text-yellow-400`}
+              >
+                DUPE
+              </Badge>
+            ) : null}
+            <Badge
+              variant="outline"
+              className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit`}
+            >
+              {getFileTypeLabel(mat.file_type)}
+            </Badge>
+            {materialRole === "reference" ? (
+              <Badge
+                variant="outline"
+                className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-sky-500/50 text-sky-300`}
+                title="Course reference; manually selectable for Tutor"
+              >
+                COURSE REF
+              </Badge>
+            ) : null}
+            {materialRole === "setup" ? (
+              <Badge
+                variant="outline"
+                className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-emerald-500/50 text-emerald-300`}
+                title="Course setup file"
+              >
+                SETUP
+              </Badge>
+            ) : null}
+            {canReextract ? (
+              <Badge
+                variant="outline"
+                className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit ${hasDoclingAssets ? "border-green-500/60 text-green-300" : "border-yellow-500/60 text-yellow-300"}`}
+                title={
+                  hasDoclingAssets
+                    ? `${doclingAssetCount} Docling asset${doclingAssetCount === 1 ? "" : "s"} detected`
+                    : "No Docling image assets detected"
+                }
+              >
+                D:{doclingAssetCount}
+              </Badge>
+            ) : null}
+          </div>
+        );
+      case "size":
+        return (
+          <div key={columnId} className={TEXT_MUTED}>
+            {formatSize(getMaterialSize(mat))}
+          </div>
+        );
+      case "status":
+        return (
+          <button
+            key={columnId}
+            onClick={() => toggleEnabled(mat)}
+            className={`flex items-center gap-1 ${TEXT_MUTED} hover:text-foreground transition-colors`}
+          >
+            {mat.enabled ? (
+              <>
+                <ToggleRight className={`${ICON_SM} text-primary`} />
+                <span>On</span>
+              </>
+            ) : (
+              <>
+                <ToggleLeft className={ICON_SM} />
+                <span>Off</span>
+              </>
+            )}
+          </button>
+        );
+      case "actions":
+        return (
+          <div key={columnId} className="flex items-center gap-1 justify-end">
+            <button
+              onClick={() => viewContent(mat.id)}
+              className="text-muted-foreground hover:text-primary transition-colors p-0.5"
+              title="View content"
+              aria-label="View content"
+            >
+              <Eye className={ICON_SM} />
+            </button>
+            {canReextract ? (
+              <button
+                onClick={() => reextractContent(mat.id)}
+                disabled={isReextracting}
+                className="text-muted-foreground hover:text-primary transition-colors p-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                title="Re-extract with Docling"
+                aria-label="Re-extract with Docling"
+              >
+                <RefreshCw
+                  className={`${ICON_SM} ${isReextracting ? "animate-spin" : ""}`}
+                />
+              </button>
+            ) : null}
+            <button
+              onClick={() => startEdit(mat)}
+              className="text-muted-foreground hover:text-primary transition-colors p-0.5"
+              title="Edit title"
+              aria-label="Edit title"
+            >
+              <Pencil className={ICON_SM} />
+            </button>
+
+            {deleteConfirm === mat.id ? (
+              <div className="flex items-center gap-0.5">
+                <button
+                  onClick={() => deleteMutation.mutate(mat.id)}
+                  className="text-red-400 hover:text-red-300 p-0.5"
+                  title="Confirm delete"
+                  aria-label="Confirm delete"
+                >
+                  <Check className={ICON_SM} />
+                </button>
+                <button
+                  onClick={() => setDeleteConfirm(null)}
+                  className="text-muted-foreground hover:text-foreground p-0.5"
+                  title="Cancel"
+                  aria-label="Cancel delete"
+                >
+                  <X className={ICON_SM} />
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setDeleteConfirm(mat.id)}
+                className="text-muted-foreground hover:text-red-400 transition-colors p-0.5"
+                title="Delete"
+                aria-label="Delete"
+              >
+                <Trash2 className={ICON_SM} />
+              </button>
+            )}
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <div
       key={mat.id}
       className={`grid gap-3 px-3 py-2.5 items-center border-b border-primary/10 hover:bg-primary/5 transition-colors ${!mat.enabled ? "opacity-50" : ""}`}
       style={{
-        gridTemplateColumns: MATERIAL_TABLE_GRID_TEMPLATE,
+        gridTemplateColumns,
       }}
     >
       <div className="flex items-center justify-center">
         <FileText className={`${ICON_SM} text-primary/70`} />
       </div>
-
-      {/* Title */}
-      <div className="min-w-0">
-        {editingId === mat.id ? (
-          <div className="flex items-center gap-1">
-            <input
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              className={`${INPUT_BASE} flex-1 h-9 py-1 text-base`}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") saveEdit();
-                if (e.key === "Escape") setEditingId(null);
-              }}
-            />
-            <button
-              onClick={saveEdit}
-              className="text-primary hover:text-primary/80"
-            >
-              <Check className={ICON_SM} />
-            </button>
-            <button
-              onClick={() => setEditingId(null)}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <X className={ICON_SM} />
-            </button>
-          </div>
-        ) : (
-          <div className={`${TEXT_BODY} truncate`} title={displayTitle}>
-            {displayTitle}
-            {mat.extraction_error && (
-              <span className="text-red-400 ml-1" title={mat.extraction_error}>
-                [ERR]
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Folder */}
-      <div className={`${TEXT_MUTED} truncate`} title={folderLabel}>
-        {folderLabel}
-      </div>
-
-      {/* Type */}
-      <div className="flex min-w-0 flex-wrap items-center gap-1.5 overflow-visible">
-        {isDuplicate ? (
-          <Badge
-            variant="outline"
-            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-yellow-500/50 text-yellow-400`}
-          >
-            DUPE
-          </Badge>
-        ) : null}
-        <Badge
-          variant="outline"
-          className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit`}
-        >
-          {getFileTypeLabel(mat.file_type)}
-        </Badge>
-        {materialRole === "reference" ? (
-          <Badge
-            variant="outline"
-            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-sky-500/50 text-sky-300`}
-            title="Course reference; manually selectable for Tutor"
-          >
-            COURSE REF
-          </Badge>
-        ) : null}
-        {materialRole === "setup" ? (
-          <Badge
-            variant="outline"
-            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-emerald-500/50 text-emerald-300`}
-            title="Course setup file"
-          >
-            SETUP
-          </Badge>
-        ) : null}
-        {canReextract ? (
-          <Badge
-            variant="outline"
-            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit ${hasDoclingAssets ? "border-green-500/60 text-green-300" : "border-yellow-500/60 text-yellow-300"}`}
-            title={
-              hasDoclingAssets
-                ? `${doclingAssetCount} Docling asset${doclingAssetCount === 1 ? "" : "s"} detected`
-                : "No Docling image assets detected"
-            }
-          >
-            D:{doclingAssetCount}
-          </Badge>
-        ) : null}
-      </div>
-
-      {/* Size */}
-      <div className={TEXT_MUTED}>{formatSize(getMaterialSize(mat))}</div>
-
-      {/* Enabled toggle */}
-      <button
-        onClick={() => toggleEnabled(mat)}
-        className={`flex items-center gap-1 ${TEXT_MUTED} hover:text-foreground transition-colors`}
-      >
-        {mat.enabled ? (
-          <>
-            <ToggleRight className={`${ICON_SM} text-primary`} />
-            <span>On</span>
-          </>
-        ) : (
-          <>
-            <ToggleLeft className={ICON_SM} />
-            <span>Off</span>
-          </>
-        )}
-      </button>
-
-      {/* Actions */}
-      <div className="flex items-center gap-1 justify-end">
-        <button
-          onClick={() => viewContent(mat.id)}
-          className="text-muted-foreground hover:text-primary transition-colors p-0.5"
-          title="View content"
-          aria-label="View content"
-        >
-          <Eye className={ICON_SM} />
-        </button>
-        {canReextract ? (
-          <button
-            onClick={() => reextractContent(mat.id)}
-            disabled={isReextracting}
-            className="text-muted-foreground hover:text-primary transition-colors p-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
-            title="Re-extract with Docling"
-            aria-label="Re-extract with Docling"
-          >
-            <RefreshCw
-              className={`${ICON_SM} ${isReextracting ? "animate-spin" : ""}`}
-            />
-          </button>
-        ) : null}
-        <button
-          onClick={() => startEdit(mat)}
-          className="text-muted-foreground hover:text-primary transition-colors p-0.5"
-          title="Edit title"
-          aria-label="Edit title"
-        >
-          <Pencil className={ICON_SM} />
-        </button>
-
-        {deleteConfirm === mat.id ? (
-          <div className="flex items-center gap-0.5">
-            <button
-              onClick={() => deleteMutation.mutate(mat.id)}
-              className="text-red-400 hover:text-red-300 p-0.5"
-              title="Confirm delete"
-              aria-label="Confirm delete"
-            >
-              <Check className={ICON_SM} />
-            </button>
-            <button
-              onClick={() => setDeleteConfirm(null)}
-              className="text-muted-foreground hover:text-foreground p-0.5"
-              title="Cancel"
-              aria-label="Cancel delete"
-            >
-              <X className={ICON_SM} />
-            </button>
-          </div>
-        ) : (
-          <button
-            onClick={() => setDeleteConfirm(mat.id)}
-            className="text-muted-foreground hover:text-red-400 transition-colors p-0.5"
-            title="Delete"
-            aria-label="Delete"
-          >
-            <Trash2 className={ICON_SM} />
-          </button>
-        )}
-      </div>
+      {columnOrder.map((columnId) => renderCell(columnId))}
     </div>
   );
 }
@@ -827,12 +1155,24 @@ function renderMaterialRow(
 function useLibraryPageController() {
   const queryClient = useQueryClient();
   const initialLaunchState = useMemo(() => readInitialLibraryLaunchState(), []);
+  const initialTableState = useMemo(() => readLibraryTableState(), []);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editTitle, setEditTitle] = useState("");
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
   const [activeLibraryTab, setActiveLibraryTab] =
     useState<LibraryWorkflowTab>("materials");
   const [librarySearchQuery, setLibrarySearchQuery] = useState("");
+  const [libraryTableColumnOrder, setLibraryTableColumnOrder] = useState<
+    LibraryTableColumnId[]
+  >(initialTableState.columnOrder);
+  const [libraryTableColumnWidths, setLibraryTableColumnWidths] =
+    useState<LibraryTableColumnWidths>(initialTableState.columnWidths);
+  const [draggedLibraryColumnId, setDraggedLibraryColumnId] =
+    useState<LibraryTableColumnId | null>(null);
+  const [openLibraryTableFilter, setOpenLibraryTableFilter] =
+    useState<LibraryTableFilterKey | null>(null);
+  const [libraryTableFilters, setLibraryTableFilters] =
+    useState<LibraryTableFilters>(DEFAULT_LIBRARY_TABLE_FILTERS);
   const [uploadCourseTarget, setUploadCourseTarget] = useState<string>(
     initialLaunchState.uploadCourseTarget,
   );
@@ -1094,12 +1434,46 @@ function useLibraryPageController() {
     sidebarMode,
     materials,
   ]);
-  const visibleCatalogMaterials = useMemo(
+  const searchedCatalogMaterials = useMemo(
     () =>
       visibleMaterials.filter((material) =>
         materialMatchesLibrarySearch(material, librarySearchQuery),
       ),
     [librarySearchQuery, visibleMaterials],
+  );
+  const visibleCatalogMaterials = useMemo(
+    () =>
+      searchedCatalogMaterials.filter((material) =>
+        materialMatchesLibraryTableFilters(material, libraryTableFilters),
+      ),
+    [libraryTableFilters, searchedCatalogMaterials],
+  );
+  const libraryTableGridTemplate = useMemo(
+    () =>
+      buildLibraryTableGridTemplate(
+        libraryTableColumnOrder,
+        libraryTableColumnWidths,
+      ),
+    [libraryTableColumnOrder, libraryTableColumnWidths],
+  );
+  const libraryTableMinWidth = useMemo(
+    () =>
+      getLibraryTableMinWidth(
+        libraryTableColumnOrder,
+        libraryTableColumnWidths,
+      ),
+    [libraryTableColumnOrder, libraryTableColumnWidths],
+  );
+  const libraryTableTypeOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          searchedCatalogMaterials.map((material) =>
+            getFileTypeLabel(material.file_type),
+          ),
+        ),
+      ).sort((a, b) => a.localeCompare(b)),
+    [searchedCatalogMaterials],
   );
   const selectedFolderLabel = useMemo(() => {
     if (sidebarMode === "courses") {
@@ -1140,6 +1514,117 @@ function useLibraryPageController() {
     } else {
       selectFolderPath(ALL_FOLDERS_KEY);
     }
+  };
+
+  const setLibraryColumnWidth = useCallback(
+    (columnId: LibraryTableColumnId, width: number) => {
+      setLibraryTableColumnWidths((prev) => ({
+        ...prev,
+        [columnId]: clampLibraryColumnWidth(columnId, width),
+      }));
+    },
+    [],
+  );
+
+  const startLibraryColumnResize = useCallback(
+    (
+      event: ReactMouseEvent<HTMLButtonElement>,
+      columnId: LibraryTableColumnId,
+    ) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const startX = event.clientX;
+      const startWidth = libraryTableColumnWidths[columnId];
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        setLibraryColumnWidth(
+          columnId,
+          startWidth + moveEvent.clientX - startX,
+        );
+      };
+      const handleMouseUp = () => {
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    },
+    [libraryTableColumnWidths, setLibraryColumnWidth],
+  );
+
+  const autoFitLibraryColumn = useCallback(
+    (columnId: LibraryTableColumnId) => {
+      const fitMaterials = visibleCatalogMaterials.length
+        ? visibleCatalogMaterials
+        : searchedCatalogMaterials;
+      setLibraryColumnWidth(
+        columnId,
+        getAutoFitWidthForColumn(columnId, fitMaterials),
+      );
+    },
+    [searchedCatalogMaterials, setLibraryColumnWidth, visibleCatalogMaterials],
+  );
+
+  const dropLibraryColumn = (targetColumnId: LibraryTableColumnId) => {
+    if (!draggedLibraryColumnId || draggedLibraryColumnId === targetColumnId) {
+      setDraggedLibraryColumnId(null);
+      return;
+    }
+    setLibraryTableColumnOrder((prev) => {
+      const withoutDragged = prev.filter(
+        (columnId) => columnId !== draggedLibraryColumnId,
+      );
+      const targetIndex = withoutDragged.indexOf(targetColumnId);
+      const insertIndex = targetIndex < 0 ? withoutDragged.length : targetIndex;
+      const next = [...withoutDragged];
+      next.splice(insertIndex, 0, draggedLibraryColumnId);
+      return normalizeLibraryColumnOrder(next);
+    });
+    setDraggedLibraryColumnId(null);
+  };
+
+  const setTextTableFilter = (
+    filterKey: "title" | "folder",
+    value: string,
+  ) => {
+    setLibraryTableFilters((prev) => ({
+      ...prev,
+      [filterKey]: value,
+    }));
+  };
+
+  const toggleTypeTableFilter = (type: string) => {
+    setLibraryTableFilters((prev) => {
+      const active = prev.types.includes(type);
+      return {
+        ...prev,
+        types: active
+          ? prev.types.filter((value) => value !== type)
+          : [...prev.types, type],
+      };
+    });
+  };
+
+  const toggleStatusTableFilter = (status: LibraryStatusFilter) => {
+    setLibraryTableFilters((prev) => {
+      const active = prev.statuses.includes(status);
+      return {
+        ...prev,
+        statuses: active
+          ? prev.statuses.filter((value) => value !== status)
+          : [...prev.statuses, status],
+      };
+    });
+  };
+
+  const clearTableFilter = (filterKey: LibraryTableFilterKey) => {
+    setLibraryTableFilters((prev) => {
+      if (filterKey === "title") return { ...prev, title: "" };
+      if (filterKey === "folder") return { ...prev, folder: "" };
+      if (filterKey === "type") return { ...prev, types: [] };
+      return { ...prev, statuses: [] };
+    });
   };
 
   const dupeChecksums = useMemo(() => {
@@ -1210,6 +1695,21 @@ function useLibraryPageController() {
       new Set(sourceUploadCandidates.map((candidate) => candidate.path)),
     );
   };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
+        LIBRARY_TABLE_STORAGE_KEY,
+        JSON.stringify({
+          columnOrder: libraryTableColumnOrder,
+          columnWidths: libraryTableColumnWidths,
+        }),
+      );
+    } catch {
+      // Local storage is a convenience for column layout, not a workflow dependency.
+    }
+  }, [libraryTableColumnOrder, libraryTableColumnWidths]);
 
   useEffect(() => {
     if (isLoading) return;
@@ -1367,6 +1867,190 @@ function useLibraryPageController() {
   const visibleTabFileCount = visibleCatalogMaterials.length;
   const visibleTabFileLabel = "file";
   const selectedSourceUploadCount = selectedSourceUploadPaths.size;
+
+  const renderLibraryTableFilterMenu = (
+    filterKey: LibraryTableFilterKey,
+    alignRight = false,
+  ) => {
+    const stopFilterEvent = (
+      event: ReactMouseEvent<HTMLDivElement | HTMLButtonElement>,
+    ) => {
+      event.stopPropagation();
+    };
+    return (
+      <div
+        className={cn(
+          "absolute top-[calc(100%+6px)] z-30 w-64 rounded-[0.85rem] border border-primary/35 bg-black/95 p-3 shadow-[0_18px_40px_rgba(0,0,0,0.55)]",
+          alignRight ? "right-0" : "left-0",
+        )}
+        onClick={stopFilterEvent}
+        onMouseDown={stopFilterEvent}
+      >
+        {filterKey === "title" ? (
+          <label className="block space-y-1">
+            <span className={`${TEXT_BADGE} text-muted-foreground`}>
+              Title contains
+            </span>
+            <input
+              aria-label="Filter title text"
+              className={`${INPUT_BASE} h-9 py-1 text-sm`}
+              value={libraryTableFilters.title}
+              onChange={(event) =>
+                setTextTableFilter("title", event.target.value)
+              }
+            />
+          </label>
+        ) : null}
+
+        {filterKey === "folder" ? (
+          <label className="block space-y-1">
+            <span className={`${TEXT_BADGE} text-muted-foreground`}>
+              Folder contains
+            </span>
+            <input
+              aria-label="Filter folder text"
+              className={`${INPUT_BASE} h-9 py-1 text-sm`}
+              value={libraryTableFilters.folder}
+              onChange={(event) =>
+                setTextTableFilter("folder", event.target.value)
+              }
+            />
+          </label>
+        ) : null}
+
+        {filterKey === "type" ? (
+          <div className="space-y-2">
+            <div className={`${TEXT_BADGE} text-muted-foreground`}>
+              File types
+            </div>
+            {libraryTableTypeOptions.length ? (
+              libraryTableTypeOptions.map((type) => (
+                <label
+                  key={type}
+                  className="flex items-center gap-2 font-terminal text-sm text-foreground"
+                >
+                  <input
+                    type="checkbox"
+                    checked={libraryTableFilters.types.includes(type)}
+                    onChange={() => toggleTypeTableFilter(type)}
+                    className="h-4 w-4 accent-primary"
+                  />
+                  <span>{type}</span>
+                </label>
+              ))
+            ) : (
+              <div className={TEXT_MUTED}>No file types in this view.</div>
+            )}
+          </div>
+        ) : null}
+
+        {filterKey === "status" ? (
+          <div className="space-y-2">
+            <div className={`${TEXT_BADGE} text-muted-foreground`}>
+              Status
+            </div>
+            {(["on", "off"] as LibraryStatusFilter[]).map((status) => (
+              <label
+                key={status}
+                className="flex items-center gap-2 font-terminal text-sm text-foreground"
+              >
+                <input
+                  type="checkbox"
+                  checked={libraryTableFilters.statuses.includes(status)}
+                  onChange={() => toggleStatusTableFilter(status)}
+                  className="h-4 w-4 accent-primary"
+                />
+                <span>{status === "on" ? "On" : "Off"}</span>
+              </label>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="mt-3 flex justify-between gap-2">
+          <button
+            type="button"
+            className="library-action-button min-h-8 px-3 text-xs"
+            onClick={() => clearTableFilter(filterKey)}
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            className="library-action-button min-h-8 px-3 text-xs"
+            onClick={() => setOpenLibraryTableFilter(null)}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderLibraryTableHeaderCell = (columnId: LibraryTableColumnId) => {
+    const column = getLibraryTableColumnConfig(columnId);
+    const filterActive = tableFilterIsActive(
+      libraryTableFilters,
+      column.filter,
+    );
+    return (
+      <div
+        key={column.id}
+        data-testid={`library-table-header-${column.id}`}
+        data-library-column-id={column.id}
+        draggable
+        onDragStart={() => setDraggedLibraryColumnId(column.id)}
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={() => dropLibraryColumn(column.id)}
+        className={cn(
+          "relative flex min-w-0 items-center gap-2 pr-3 font-terminal text-sm uppercase tracking-[0.12em] text-muted-foreground",
+          column.align === "right" ? "justify-end text-right" : "justify-start",
+        )}
+      >
+        <span className="truncate">{column.label}</span>
+        {column.filter ? (
+          <>
+            <button
+              type="button"
+              aria-label={`Filter ${column.label} column`}
+              title={`Filter ${column.label}`}
+              className={cn(
+                "library-icon-button h-6 w-6 shrink-0 border-primary/20 text-muted-foreground",
+                filterActive ? "border-primary/60 text-primary" : "",
+              )}
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                setOpenLibraryTableFilter((prev) =>
+                  prev === column.filter ? null : column.filter || null,
+                );
+              }}
+            >
+              <ListFilter className="h-3 w-3" />
+            </button>
+            {openLibraryTableFilter === column.filter
+              ? renderLibraryTableFilterMenu(
+                  column.filter,
+                  column.id === "type" || column.id === "status",
+                )
+              : null}
+          </>
+        ) : null}
+        <button
+          type="button"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={`Resize ${column.label} column`}
+          title="Drag to resize. Double-click to auto-fit."
+          className="absolute -right-2 top-0 h-full w-4 cursor-col-resize rounded-none border-0 bg-transparent p-0 hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/70"
+          onMouseDown={(event) => startLibraryColumnResize(event, column.id)}
+          onDoubleClick={(event) => {
+            event.stopPropagation();
+            autoFitLibraryColumn(column.id);
+          }}
+        />
+      </div>
+    );
+  };
 
   return (
     <PageScaffold
@@ -2020,22 +2704,18 @@ function useLibraryPageController() {
                     </div>
                   ) : (
                     <div className="h-full min-h-0 overflow-auto">
-                      <div className="min-w-[1240px]">
+                      <div style={{ minWidth: libraryTableMinWidth }}>
                         <div
                           className="grid gap-3 px-3 py-2 border-b border-primary/15 bg-black/80 sticky top-0 z-10"
+                          data-testid="library-material-table-header"
                           style={{
-                            gridTemplateColumns: MATERIAL_TABLE_GRID_TEMPLATE,
+                            gridTemplateColumns: libraryTableGridTemplate,
                           }}
                         >
                           <div aria-hidden="true" />
-                          <div className={TEXT_MUTED}>Title</div>
-                          <div className={TEXT_MUTED}>Folder</div>
-                          <div className={TEXT_MUTED}>Type</div>
-                          <div className={TEXT_MUTED}>Size</div>
-                          <div className={TEXT_MUTED}>Status</div>
-                          <div className={`${TEXT_MUTED} text-right`}>
-                            Actions
-                          </div>
+                          {libraryTableColumnOrder.map((columnId) =>
+                            renderLibraryTableHeaderCell(columnId),
+                          )}
                         </div>
                         {visibleCatalogMaterials.map((mat) =>
                           renderMaterialRow(
@@ -2056,6 +2736,8 @@ function useLibraryPageController() {
                             setViewingMaterialId,
                             reextractMaterial,
                             reextractingMaterialIds.includes(mat.id),
+                            libraryTableColumnOrder,
+                            libraryTableGridTemplate,
                           ),
                         )}
                       </div>

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -790,7 +790,7 @@ function useLibraryPageController() {
     null,
   );
   const [addCourseworkMode, setAddCourseworkMode] =
-    useState<AddCourseworkMode>("intake");
+    useState<AddCourseworkMode>("upload");
   const [uploadCourseTarget, setUploadCourseTarget] = useState<string>(
     initialLaunchState.uploadCourseTarget,
   );
@@ -2138,15 +2138,15 @@ function useLibraryPageController() {
                       <div className="min-w-0">
                         <div className={LIBRARY_SECTION_LABEL}>ADD COURSEWORK</div>
                         <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
-                          Choose one source path at a time. Scans classify
-                          files; only checked materials are loaded.
+                          Choose the files you want for this study run. Intake
+                          and sync stay available for setup and selective import.
                         </div>
                       </div>
                       <div className="library-segmented-control grid grid-cols-3 gap-1 p-1">
                         {[
+                          ["upload", "CHOOSE FILES"],
                           ["intake", "SEMESTER INTAKE"],
                           ["sync", "FOLDER SYNC"],
-                          ["upload", "DIRECT UPLOAD"],
                         ].map(([mode, label]) => (
                           <HudButton
                             key={mode}
@@ -2171,8 +2171,8 @@ function useLibraryPageController() {
                     </div>
                     <div className="mt-3 grid gap-2 md:grid-cols-3">
                       {[
-                        ["COURSE SETUP", "Syllabus and schedule readiness."],
                         ["STUDY MATERIALS", "Pick weekly files manually."],
+                        ["COURSE SETUP", "Syllabus and schedule readiness."],
                         ["CURRENT RUN", "Study one file or a small set."],
                       ].map(([label, copy]) => (
                         <div

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -16,6 +16,8 @@ import type {
   MaterialContent,
   TutorEmbedStatus,
   TutorContentSources,
+  TutorSyncPreviewNode,
+  TutorSyncPreviewResult,
 } from "@/lib/api";
 import type { Course } from "@shared/schema";
 import {
@@ -390,28 +392,6 @@ interface FolderListItem {
   hasChildren: boolean;
 }
 
-function getFolderNode(
-  root: FolderNode,
-  folderPath: string,
-): FolderNode | null {
-  if (!folderPath) return root;
-  const parts = folderPath.split("/").filter(Boolean);
-  let node: FolderNode | undefined = root;
-  for (const part of parts) {
-    node = node?.children[part];
-    if (!node) return null;
-  }
-  return node;
-}
-
-function collectFolderMaterials(node: FolderNode): Material[] {
-  const collected = [...node.files];
-  for (const child of Object.values(node.children)) {
-    collected.push(...collectFolderMaterials(child));
-  }
-  return collected;
-}
-
 function flattenFolders(
   node: FolderNode,
   depth = 0,
@@ -432,6 +412,49 @@ function flattenFolders(
     items.push(...flattenFolders(child, depth + 1, path));
   }
   return items;
+}
+
+function countPreviewFiles(node: TutorSyncPreviewNode | undefined): number {
+  if (!node?.children?.length) return 0;
+  return node.children.reduce((total, child) => {
+    if (child.type === "file") return total + 1;
+    return total + countPreviewFiles(child);
+  }, 0);
+}
+
+function flattenPreviewFolders(
+  node: TutorSyncPreviewNode | undefined,
+  depth = 0,
+): FolderListItem[] {
+  if (!node?.children?.length) return [];
+  const items: FolderListItem[] = [];
+  const folderChildren = node.children.filter((child) => child.type === "folder");
+
+  for (const child of folderChildren) {
+    const path = (child.path || child.name).replace(/^\/+|\/+$/g, "");
+    items.push({
+      path,
+      name: child.name,
+      depth,
+      filesCount: countPreviewFiles(child),
+      hasChildren: Boolean(
+        child.children?.some((grandchild) => grandchild.type === "folder"),
+      ),
+    });
+    items.push(...flattenPreviewFolders(child, depth + 1));
+  }
+
+  return items;
+}
+
+function materialIsInFolder(mat: Material, folderPath: string): boolean {
+  if (!folderPath) return true;
+  const normalizedFolder = folderPath.replace(/^\/+|\/+$/g, "");
+  const materialFolder = getMaterialFolder(mat).replace(/^\/+|\/+$/g, "");
+  return (
+    materialFolder === normalizedFolder ||
+    materialFolder.startsWith(`${normalizedFolder}/`)
+  );
 }
 
 function getFolderAncestorPaths(path: string): string[] {
@@ -725,6 +748,16 @@ function useLibraryPageController() {
     queryKey: ["tutor-materials", "include-setup"],
     queryFn: () => api.tutor.getMaterials({ include_setup: true }),
   });
+  const {
+    data: sourceFolderPreview,
+    error: sourceFolderPreviewError,
+    isFetching: isSourceFolderFetching,
+    refetch: refetchSourceFolderPreview,
+  } = useQuery<TutorSyncPreviewResult>({
+    queryKey: ["library-source-folder-preview"],
+    queryFn: () => api.tutor.previewSyncMaterialsFolder({}),
+    staleTime: 15_000,
+  });
   const { data: courses = [] } = useQuery<Course[]>({
     queryKey: ["courses-active"],
     queryFn: () => api.courses.getActive(),
@@ -846,27 +879,35 @@ function useLibraryPageController() {
     [queryClient],
   );
 
-  const folderTree = useMemo(() => buildFolderTree(materials), [materials]);
-  const folderItems = useMemo(() => flattenFolders(folderTree), [folderTree]);
-  const activeFolderItems = folderItems;
+  const uploadedFolderTree = useMemo(() => buildFolderTree(materials), [materials]);
+  const uploadedFolderItems = useMemo(
+    () => flattenFolders(uploadedFolderTree),
+    [uploadedFolderTree],
+  );
+  const sourceFolderItems = useMemo(
+    () => flattenPreviewFolders(sourceFolderPreview?.tree),
+    [sourceFolderPreview],
+  );
+  const hasLiveSourceFolders = sourceFolderItems.length > 0;
+  const folderItems = hasLiveSourceFolders
+    ? sourceFolderItems
+    : uploadedFolderItems;
+  const sourceFolderFileCount = sourceFolderPreview?.counts?.files;
+  const sourceFolderRoot = sourceFolderPreview?.folder || "";
   const activeFolderPathSet = useMemo(
-    () => new Set(activeFolderItems.map((item) => item.path)),
-    [activeFolderItems],
+    () => new Set(folderItems.map((item) => item.path)),
+    [folderItems],
   );
   const visibleFolderItems = useMemo(
     () =>
-      activeFolderItems.filter((item) => {
+      folderItems.filter((item) => {
         if (item.depth === 0) return true;
         const ancestorPaths = getFolderAncestorPaths(item.path).slice(0, -1);
         return ancestorPaths.every((ancestor) =>
           expandedFolderPaths.has(ancestor),
         );
       }),
-    [activeFolderItems, expandedFolderPaths],
-  );
-  const selectedFolderNode = useMemo(
-    () => getFolderNode(folderTree, selectedFolderPath),
-    [folderTree, selectedFolderPath],
+    [folderItems, expandedFolderPaths],
   );
   const unlinkedCount = materials.filter((m) => m.course_id === null).length;
   const visibleMaterials = useMemo(() => {
@@ -883,14 +924,13 @@ function useLibraryPageController() {
         getMaterialTitle(a).localeCompare(getMaterialTitle(b)),
       );
     }
-    if (!selectedFolderNode) return [];
-    return collectFolderMaterials(selectedFolderNode).sort((a, b) =>
-      getMaterialTitle(a).localeCompare(getMaterialTitle(b)),
-    );
+    return materials
+      .filter((material) => materialIsInFolder(material, selectedFolderPath))
+      .sort((a, b) =>
+        getMaterialTitle(a).localeCompare(getMaterialTitle(b)),
+      );
   }, [
-    activeFolderPathSet,
     selectedFolderPath,
-    selectedFolderNode,
     selectedCourseId,
     sidebarMode,
     materials,
@@ -911,8 +951,15 @@ function useLibraryPageController() {
       );
       return course ? course.name || course.code : "All Materials";
     }
-    return selectedFolderPath || "All Materials";
-  }, [sidebarMode, selectedCourseId, contentSources, selectedFolderPath]);
+    if (selectedFolderPath) return selectedFolderPath;
+    return hasLiveSourceFolders ? "All PT School folders" : "All Materials";
+  }, [
+    sidebarMode,
+    selectedCourseId,
+    contentSources,
+    selectedFolderPath,
+    hasLiveSourceFolders,
+  ]);
   const selectFolderPath = (path: string) => {
     setSelectedFolderPath(path);
     const ancestors = getFolderAncestorPaths(path);
@@ -950,22 +997,20 @@ function useLibraryPageController() {
     if (
       selectedFolderPath !== ALL_FOLDERS_KEY &&
       !activeFolderPathSet.has(selectedFolderPath) &&
-      !getFolderNode(folderTree, selectedFolderPath)
+      !materials.some((material) => materialIsInFolder(material, selectedFolderPath))
     ) {
       selectFolderPath(ALL_FOLDERS_KEY);
     }
   }, [
     activeFolderPathSet,
-    folderTree,
     isLoading,
     materials,
     selectedFolderPath,
   ]);
 
   useEffect(() => {
-    if (initializedFolderExpansion) return;
     // Start with top-level folders expanded so first interaction is not empty.
-    const topLevelPaths = activeFolderItems
+    const topLevelPaths = folderItems
       .filter((item) => item.depth === 0)
       .map((item) => item.path);
     if (!topLevelPaths.length) return;
@@ -974,8 +1019,8 @@ function useLibraryPageController() {
       for (const path of topLevelPaths) next.add(path);
       return next;
     });
-    setInitializedFolderExpansion(true);
-  }, [activeFolderItems, initializedFolderExpansion]);
+    if (!initializedFolderExpansion) setInitializedFolderExpansion(true);
+  }, [folderItems, initializedFolderExpansion]);
 
   const toggleFolderExpanded = (path: string) => {
     const isCollapsing = expandedFolderPaths.has(path);
@@ -1168,13 +1213,46 @@ function useLibraryPageController() {
                 </div>
                 {sidebarMode === "folders" ? (
                   <div className="mt-3 rounded-[0.85rem] border border-primary/15 bg-black/35 p-2">
-                    <div className="min-w-0">
-                      <div className={LIBRARY_SECTION_LABEL}>FOLDERS</div>
-                      <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
-                        Shows folders from files already uploaded into the
-                        Library catalog.
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className={LIBRARY_SECTION_LABEL}>FOLDERS</div>
+                        <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
+                          {hasLiveSourceFolders
+                            ? "Shows the live PT School source tree. Counts are source files; rows are uploaded Library files."
+                            : "Shows folders from uploaded Library files until the PT School source scan is available."}
+                        </div>
+                        {sourceFolderRoot ? (
+                          <div
+                            className={`${LIBRARY_HELP_TEXT} mt-2 truncate text-primary/70`}
+                            title={sourceFolderRoot}
+                          >
+                            Source: {sourceFolderRoot}
+                          </div>
+                        ) : null}
+                        {sourceFolderPreviewError ? (
+                          <div className="mt-2 text-ui-xs text-amber-300">
+                            Source scan unavailable.
+                          </div>
+                        ) : null}
                       </div>
+                      <button
+                        type="button"
+                        aria-label="Refresh source folders"
+                        title="Refresh source folders"
+                        className="library-icon-button shrink-0"
+                        onClick={() => void refetchSourceFolderPreview()}
+                        disabled={isSourceFolderFetching}
+                      >
+                        <RefreshCw
+                          className={`${ICON_SM} ${isSourceFolderFetching ? "animate-spin" : ""}`}
+                        />
+                      </button>
                     </div>
+                    {hasLiveSourceFolders && sourceFolderFileCount !== undefined ? (
+                      <div className={`${TEXT_MUTED} mt-2 text-ui-xs`}>
+                        {sourceFolderFileCount} source files detected.
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
               </div>
@@ -1191,9 +1269,11 @@ function useLibraryPageController() {
                       type="button"
                     >
                       <FolderOpen className={ICON_SM} />
-                      <span className="truncate flex-1">All Materials</span>
+                      <span className="truncate flex-1">
+                        {hasLiveSourceFolders ? "All PT School" : "All Materials"}
+                      </span>
                       <span className="text-sm">
-                        {materials.length}
+                        {sourceFolderFileCount ?? materials.length}
                       </span>
                     </button>
                     {visibleFolderItems.map((folder) => {
@@ -1267,9 +1347,9 @@ function useLibraryPageController() {
                         </div>
                       );
                     })}
-                    {!activeFolderItems.length && materials.length === 0 ? (
+                    {!folderItems.length && materials.length === 0 ? (
                       <div className={`${TEXT_MUTED} px-2 py-3 text-sm`}>
-                        Upload files to populate this rail.
+                        Upload files or refresh the PT School source scan to populate this rail.
                       </div>
                     ) : null}
                   </>

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -392,6 +392,15 @@ interface FolderListItem {
   hasChildren: boolean;
 }
 
+interface SourceUploadCandidate {
+  path: string;
+  name: string;
+  folderPath: string;
+  size: number;
+  modifiedAt?: string | null;
+  fileType: string;
+}
+
 function flattenFolders(
   node: FolderNode,
   depth = 0,
@@ -447,6 +456,97 @@ function flattenPreviewFolders(
   return items;
 }
 
+function getPreviewFolderNode(
+  root: TutorSyncPreviewNode | undefined,
+  folderPath: string,
+): TutorSyncPreviewNode | undefined {
+  if (!root) return undefined;
+  const normalizedPath = folderPath.replace(/^\/+|\/+$/g, "");
+  if (!normalizedPath) return root;
+  const parts = normalizedPath.split("/").filter(Boolean);
+  let node: TutorSyncPreviewNode | undefined = root;
+  for (const part of parts) {
+    node = node?.children?.find(
+      (child) => child.type === "folder" && child.name === part,
+    );
+    if (!node) return undefined;
+  }
+  return node;
+}
+
+function collectPreviewFiles(
+  node: TutorSyncPreviewNode | undefined,
+): TutorSyncPreviewNode[] {
+  if (!node?.children?.length) return [];
+  const files: TutorSyncPreviewNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "file") {
+      files.push(child);
+    } else {
+      files.push(...collectPreviewFiles(child));
+    }
+  }
+  return files;
+}
+
+function getSourceFileFolder(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash > 0 ? normalized.slice(0, lastSlash) : "";
+}
+
+function getSourceFileType(path: string): string {
+  const suffix = path.split(".").pop()?.trim().toLowerCase();
+  return suffix && suffix !== path ? suffix : "file";
+}
+
+function normalizeComparablePath(value: string | null | undefined): string {
+  return String(value || "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+|\/+$/g, "")
+    .toLowerCase();
+}
+
+function getPathBaseName(value: string | null | undefined): string {
+  const normalized = String(value || "").replace(/\\/g, "/").trim();
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.at(-1) || "";
+}
+
+function materialMatchesSourceCandidate(
+  material: Material,
+  candidate: SourceUploadCandidate,
+): boolean {
+  const candidatePath = normalizeComparablePath(candidate.path);
+  const materialSource = normalizeComparablePath(material.source_path);
+  const materialFolder = normalizeComparablePath(material.folder_path);
+  const materialTitle = normalizeComparablePath(getMaterialTitle(material));
+  const materialFileName = normalizeComparablePath(
+    getPathBaseName(material.source_path) || getMaterialTitle(material),
+  );
+
+  if (
+    materialSource === candidatePath ||
+    materialSource.endsWith(`/${candidatePath}`)
+  ) {
+    return true;
+  }
+
+  if (
+    materialFolder &&
+    materialFileName &&
+    normalizeComparablePath(`${materialFolder}/${materialFileName}`) ===
+      candidatePath
+  ) {
+    return true;
+  }
+
+  return (
+    materialTitle === normalizeComparablePath(candidate.name) &&
+    getMaterialSize(material) === candidate.size
+  );
+}
+
 function materialIsInFolder(mat: Material, folderPath: string): boolean {
   if (!folderPath) return true;
   const normalizedFolder = folderPath.replace(/^\/+|\/+$/g, "");
@@ -491,6 +591,19 @@ function readInitialLibraryLaunchState(): InitialLibraryLaunchState {
     uploadCourseTarget: courseId,
     selectedFolderPath: ALL_FOLDERS_KEY,
   };
+}
+
+async function waitForMaterialSyncJob(jobId: string) {
+  let lastStatus: Awaited<ReturnType<typeof api.tutor.getSyncMaterialsStatus>> | null =
+    null;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    lastStatus = await api.tutor.getSyncMaterialsStatus(jobId);
+    if (lastStatus.status === "completed" || lastStatus.status === "failed") {
+      return lastStatus;
+    }
+  }
+  return lastStatus;
 }
 
 function renderMaterialRow(
@@ -729,6 +842,9 @@ function useLibraryPageController() {
   const [selectedFolderPath, setSelectedFolderPath] = useState<string>(
     initialLaunchState.selectedFolderPath,
   );
+  const [selectedSourceUploadPaths, setSelectedSourceUploadPaths] = useState<
+    Set<string>
+  >(new Set());
   const [expandedFolderPaths, setExpandedFolderPaths] = useState<Set<string>>(
     new Set(),
   );
@@ -894,6 +1010,49 @@ function useLibraryPageController() {
     : uploadedFolderItems;
   const sourceFolderFileCount = sourceFolderPreview?.counts?.files;
   const sourceFolderRoot = sourceFolderPreview?.folder || "";
+  const selectedSourceFolderNode = useMemo(
+    () =>
+      getPreviewFolderNode(
+        sourceFolderPreview?.tree,
+        selectedFolderPath,
+      ),
+    [sourceFolderPreview, selectedFolderPath],
+  );
+  const sourceUploadCandidates = useMemo<SourceUploadCandidate[]>(() => {
+    if (
+      !hasLiveSourceFolders ||
+      sidebarMode !== "folders" ||
+      selectedFolderPath === ALL_FOLDERS_KEY
+    ) {
+      return [];
+    }
+    return collectPreviewFiles(selectedSourceFolderNode)
+      .map((file) => ({
+        path: file.path,
+        name: file.name,
+        folderPath: getSourceFileFolder(file.path),
+        size: Number(file.size || 0),
+        modifiedAt: file.modified_at,
+        fileType: getSourceFileType(file.path),
+      }))
+      .filter(
+        (candidate) =>
+          !materials.some((material) =>
+            materialMatchesSourceCandidate(material, candidate),
+          ),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [
+    hasLiveSourceFolders,
+    materials,
+    selectedFolderPath,
+    selectedSourceFolderNode,
+    sidebarMode,
+  ]);
+  const sourceUploadCandidatePathSet = useMemo(
+    () => new Set(sourceUploadCandidates.map((candidate) => candidate.path)),
+    [sourceUploadCandidates],
+  );
   const activeFolderPathSet = useMemo(
     () => new Set(folderItems.map((item) => item.path)),
     [folderItems],
@@ -962,6 +1121,9 @@ function useLibraryPageController() {
   ]);
   const selectFolderPath = (path: string) => {
     setSelectedFolderPath(path);
+    if (path && hasLiveSourceFolders) {
+      setActiveLibraryTab("upload");
+    }
     const ancestors = getFolderAncestorPaths(path);
     if (!ancestors.length) return;
     setExpandedFolderPaths((prev) => {
@@ -992,6 +1154,63 @@ function useLibraryPageController() {
     }
     return dupes;
   }, [materials]);
+  const sourceUploadMutation = useMutation({
+    mutationFn: async (paths: string[]) => {
+      if (!paths.length) {
+        throw new Error("Choose at least one source file to upload.");
+      }
+      const courseId = uploadCourseTarget ? Number(uploadCourseTarget) : null;
+      const start = await api.tutor.startSyncMaterialsFolder({
+        folder_path: sourceFolderRoot || undefined,
+        selected_files: paths,
+        course_id: Number.isFinite(courseId || NaN) ? courseId : null,
+      });
+      const status = start.job_id
+        ? await waitForMaterialSyncJob(start.job_id)
+        : null;
+      if (status?.status === "failed") {
+        throw new Error(status.last_error || "Source upload failed.");
+      }
+      return { start, status, paths };
+    },
+    onSuccess: ({ status, paths }) => {
+      const processed =
+        Number(status?.sync_result?.processed || 0) || paths.length;
+      toast.success(
+        `Uploaded ${pluralizeCount(processed, "source file")} into Library.`,
+      );
+      setSelectedSourceUploadPaths(new Set());
+      setActiveLibraryTab("materials");
+      queryClient.invalidateQueries({ queryKey: ["tutor-materials"] });
+      queryClient.invalidateQueries({ queryKey: ["tutor-embed-status"] });
+      queryClient.invalidateQueries({ queryKey: ["tutor-content-sources"] });
+      queryClient.invalidateQueries({ queryKey: ["library-source-folder-preview"] });
+    },
+    onError: (err) => {
+      toast.error(
+        `Source upload failed: ${err instanceof Error ? err.message : "Unknown"}`,
+      );
+    },
+  });
+
+  const toggleSourceUploadPath = (path: string) => {
+    setSelectedSourceUploadPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  const selectAllSourceUploadCandidates = () => {
+    setSelectedSourceUploadPaths(
+      new Set(sourceUploadCandidates.map((candidate) => candidate.path)),
+    );
+  };
+
   useEffect(() => {
     if (isLoading) return;
     if (
@@ -1007,6 +1226,25 @@ function useLibraryPageController() {
     materials,
     selectedFolderPath,
   ]);
+
+  useEffect(() => {
+    setSelectedSourceUploadPaths((prev) => {
+      const next = new Set(
+        Array.from(prev).filter((path) => sourceUploadCandidatePathSet.has(path)),
+      );
+      return next.size === prev.size ? prev : next;
+    });
+  }, [sourceUploadCandidatePathSet]);
+
+  useEffect(() => {
+    if (
+      sidebarMode === "folders" &&
+      selectedFolderPath !== ALL_FOLDERS_KEY &&
+      sourceUploadCandidates.length > 0
+    ) {
+      setActiveLibraryTab("upload");
+    }
+  }, [selectedFolderPath, sidebarMode, sourceUploadCandidates.length]);
 
   useEffect(() => {
     // Start with top-level folders expanded so first interaction is not empty.
@@ -1128,6 +1366,7 @@ function useLibraryPageController() {
   const materialSectionTitle = "LIBRARY FILES";
   const visibleTabFileCount = visibleCatalogMaterials.length;
   const visibleTabFileLabel = "file";
+  const selectedSourceUploadCount = selectedSourceUploadPaths.size;
 
   return (
     <PageScaffold
@@ -1282,7 +1521,8 @@ function useLibraryPageController() {
                       const hasChildren = folder.hasChildren;
                       return (
                         <div key={folder.path}>
-                          <div
+                          <button
+                            type="button"
                             className={`library-course-nav-row w-full rounded-none border pr-3 py-2 text-left font-terminal flex items-center gap-1 transition-colors ${
                               isSelected
                                 ? "border-primary/60 bg-primary/20 text-primary"
@@ -1292,41 +1532,21 @@ function useLibraryPageController() {
                               paddingLeft: `${0.45 + folder.depth * 0.85}rem`,
                             }}
                             title={folder.path}
-                            role="button"
-                            tabIndex={0}
                             onClick={() => {
                               selectFolderPath(folder.path);
                               if (hasChildren && !isExpanded)
                                 toggleFolderExpanded(folder.path);
                             }}
-                            onKeyDown={(e) => {
-                              if (e.target !== e.currentTarget) return;
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                selectFolderPath(folder.path);
-                                if (hasChildren && !isExpanded)
-                                  toggleFolderExpanded(folder.path);
-                              }
-                            }}
                           >
                             {hasChildren ? (
-                              <button
-                                type="button"
-                                className="p-0.5 hover:text-primary transition-colors"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  toggleFolderExpanded(folder.path);
-                                }}
-                                aria-label={
-                                  isExpanded
-                                    ? "Collapse folder"
-                                    : "Expand folder"
-                                }
+                              <span
+                                className="p-0.5 transition-colors"
+                                aria-hidden="true"
                               >
                                 <ChevronRight
                                   className={`${ICON_SM} transition-transform ${isExpanded ? "rotate-90" : "rotate-0"}`}
                                 />
-                              </button>
+                              </span>
                             ) : (
                               <span className="w-4" />
                             )}
@@ -1343,7 +1563,7 @@ function useLibraryPageController() {
                             <span className="text-sm">
                               {folder.filesCount}
                             </span>
-                          </div>
+                          </button>
                         </div>
                       );
                     })}
@@ -1620,6 +1840,109 @@ function useLibraryPageController() {
                         ))}
                       </select>
                     </div>
+                    {sidebarMode === "folders" &&
+                    selectedFolderPath !== ALL_FOLDERS_KEY ? (
+                      <div
+                        className="rounded-[0.85rem] border border-primary/15 bg-black/35 p-3"
+                        data-testid="library-source-upload-candidates"
+                      >
+                        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                          <div className="min-w-0">
+                            <div className={LIBRARY_SECTION_LABEL}>
+                              SOURCE FOLDER FILES
+                            </div>
+                            <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
+                              Pick unchecked files from{" "}
+                              <span className="text-foreground">
+                                {selectedFolderLabel}
+                              </span>{" "}
+                              to upload them into the Library catalog.
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <HudButton
+                              type="button"
+                              variant="outline"
+                              className="min-h-[34px] px-3 text-ui-xs"
+                              onClick={selectAllSourceUploadCandidates}
+                              disabled={
+                                sourceUploadCandidates.length === 0 ||
+                                sourceUploadMutation.isPending
+                              }
+                            >
+                              Select All
+                            </HudButton>
+                            <HudButton
+                              type="button"
+                              variant="primary"
+                              className="min-h-[34px] px-3 text-ui-xs"
+                              disabled={
+                                selectedSourceUploadCount === 0 ||
+                                sourceUploadMutation.isPending
+                              }
+                              onClick={() =>
+                                sourceUploadMutation.mutate(
+                                  Array.from(selectedSourceUploadPaths),
+                                )
+                              }
+                            >
+                              {sourceUploadMutation.isPending
+                                ? "Uploading..."
+                                : `Upload Selected (${selectedSourceUploadCount})`}
+                            </HudButton>
+                          </div>
+                        </div>
+                        {sourceUploadCandidates.length > 0 ? (
+                          <div className="mt-3 max-h-72 overflow-y-auto border border-primary/10">
+                            {sourceUploadCandidates.map((candidate) => {
+                              const checked = selectedSourceUploadPaths.has(
+                                candidate.path,
+                              );
+                              return (
+                                <label
+                                  key={candidate.path}
+                                  className="flex cursor-pointer items-center gap-3 border-b border-primary/10 px-3 py-2 last:border-b-0 hover:bg-primary/5"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={checked}
+                                    onChange={() =>
+                                      toggleSourceUploadPath(candidate.path)
+                                    }
+                                    disabled={sourceUploadMutation.isPending}
+                                    aria-label={`Upload ${candidate.name}`}
+                                    className="h-4 w-4 accent-primary"
+                                  />
+                                  <FileText className={`${ICON_SM} text-primary/70`} />
+                                  <span className="min-w-0 flex-1">
+                                    <span className="block truncate text-base text-foreground">
+                                      {candidate.name}
+                                    </span>
+                                    <span className="block truncate text-sm text-muted-foreground">
+                                      {candidate.folderPath || "PT School root"}
+                                    </span>
+                                  </span>
+                                  <Badge
+                                    variant="outline"
+                                    className={`${TEXT_BADGE} h-5 shrink-0 px-2`}
+                                  >
+                                    {getFileTypeLabel(candidate.fileType)}
+                                  </Badge>
+                                  <span className={`${TEXT_MUTED} shrink-0`}>
+                                    {formatSize(candidate.size)}
+                                  </span>
+                                </label>
+                              );
+                            })}
+                          </div>
+                        ) : (
+                          <div className={`${TEXT_MUTED} mt-3 text-sm`}>
+                            This source folder does not have any new supported
+                            files to upload.
+                          </div>
+                        )}
+                      </div>
+                    ) : null}
                     <MaterialUploader
                       courseId={
                         uploadCourseTarget

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -58,6 +58,7 @@ import {
   ArchiveRestore,
   ChevronDown,
   Plus,
+  Play,
 } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -98,6 +99,7 @@ const LIBRARY_READY_BADGE =
 const LIBRARY_WARN_BADGE =
   "rounded-[0.55rem] border border-amber-400/35 bg-amber-400/10 px-2 py-1 font-terminal text-sm uppercase tracking-[0.12em] text-amber-200";
 type AddCourseworkMode = "intake" | "sync" | "upload";
+type MaterialRole = "study" | "reference" | "setup";
 type SemesterPreviewCourse = SemesterIntakePreviewResult["courses"][number];
 
 function collectSemesterMaterialFilePaths(
@@ -285,6 +287,45 @@ function getMaterialFolder(mat: Material): string {
   return folders.join("/") || "Unsorted";
 }
 
+function getMaterialRole(mat: Material): MaterialRole {
+  const segments = [
+    mat.folder_path || "",
+    mat.source_path || "",
+    mat.title || "",
+  ]
+    .join("/")
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((part) => part.toLowerCase().trim())
+    .filter(Boolean);
+  const text = segments.join(" ");
+
+  if (
+    segments.some((segment) =>
+      /^(0?1|textbook|textbooks|reference|references)[\s_-]*(textbook|textbooks|reference|references)?$/.test(
+        segment,
+      ),
+    ) ||
+    /\b(textbook|course reference|reference material|references)\b/.test(text)
+  ) {
+    return "reference";
+  }
+
+  if (
+    segments.some((segment) =>
+      /\b(syllabus|schedule|course calendar|course map)\b/.test(segment),
+    )
+  ) {
+    return "setup";
+  }
+
+  return "study";
+}
+
+function isDefaultStudyMaterial(mat: Material): boolean {
+  return mat.enabled && getMaterialRole(mat) === "study";
+}
+
 function buildFolderTree(materials: Material[]): FolderNode {
   const root: FolderNode = { name: "root", files: [], children: {} };
 
@@ -425,6 +466,7 @@ function renderMaterialRow(
   setEditingId: (id: number | null) => void,
   saveEdit: () => void,
   toggleMaterialForTutor: (id: number) => void,
+  studyMaterialInTutor: (id: number) => void,
   toggleEnabled: (mat: Material) => void,
   deleteMutation: MutateDeleteLike,
   startEdit: (mat: Material) => void,
@@ -440,6 +482,7 @@ function renderMaterialRow(
   const canReextract = ["pdf", "docx", "pptx", "powerpoint"].includes(
     normalizedType,
   );
+  const materialRole = getMaterialRole(mat);
   const hasDoclingAssets = Boolean(mat.has_docling_assets);
   const doclingAssetCount = Number(mat.docling_asset_count || 0);
 
@@ -517,6 +560,24 @@ function renderMaterialRow(
         <Badge variant="outline" className={`${TEXT_BADGE} h-4 px-1 w-fit`}>
           {getFileTypeLabel(mat.file_type)}
         </Badge>
+        {materialRole === "reference" ? (
+          <Badge
+            variant="outline"
+            className={`${TEXT_BADGE} h-4 px-1 w-fit border-sky-500/50 text-sky-300`}
+            title="Course reference; manually selectable for Current Run"
+          >
+            COURSE REF
+          </Badge>
+        ) : null}
+        {materialRole === "setup" ? (
+          <Badge
+            variant="outline"
+            className={`${TEXT_BADGE} h-4 px-1 w-fit border-emerald-500/50 text-emerald-300`}
+            title="Course setup file"
+          >
+            SETUP
+          </Badge>
+        ) : null}
         {canReextract ? (
           <Badge
             variant="outline"
@@ -555,6 +616,15 @@ function renderMaterialRow(
 
       {/* Actions */}
       <div className="flex items-center gap-1 justify-end">
+        <button
+          onClick={() => studyMaterialInTutor(mat.id)}
+          disabled={!mat.enabled}
+          className="text-muted-foreground hover:text-primary transition-colors p-0.5 disabled:opacity-40 disabled:cursor-not-allowed"
+          title="Study this file"
+          aria-label={`Study ${displayTitle} in Tutor`}
+        >
+          <Play className={ICON_SM} />
+        </button>
         <button
           onClick={() => viewContent(mat.id)}
           className="text-muted-foreground hover:text-primary transition-colors p-0.5"
@@ -983,8 +1053,8 @@ function useLibraryPageController() {
     }
     return dupes;
   }, [materials]);
-  const selectableVisibleMaterialIds = useMemo(
-    () => visibleMaterials.filter((m) => m.enabled).map((m) => m.id),
+  const defaultVisibleStudyMaterialIds = useMemo(
+    () => visibleMaterials.filter(isDefaultStudyMaterial).map((m) => m.id),
     [visibleMaterials],
   );
   const selectedVisibleMaterialIds = useMemo(
@@ -999,8 +1069,8 @@ function useLibraryPageController() {
     selectedForTutor.length - selectedVisibleMaterialIds.length,
   );
   const allTutorMaterialsSelected =
-    selectableVisibleMaterialIds.length > 0 &&
-    selectableVisibleMaterialIds.every((id) => selectedForTutorSet.has(id));
+    defaultVisibleStudyMaterialIds.length > 0 &&
+    defaultVisibleStudyMaterialIds.every((id) => selectedForTutorSet.has(id));
   const syncPreviewFiles = useMemo(
     () => collectSyncPreviewFilePaths(syncPreview?.tree),
     [syncPreview],
@@ -1026,13 +1096,13 @@ function useLibraryPageController() {
     writeTutorSelectedMaterialIds(selectedForTutor);
   }, [selectedForTutor]);
 
-  const handleOpenTutor = () => {
-    if (!selectedForTutor.length) {
-      toast.error("Choose files for the Tutor queue before opening Tutor.");
+  const openTutorWithMaterialIds = (materialIds: number[]) => {
+    if (!materialIds.length) {
+      toast.error("Choose a file for the Current Run before opening Tutor.");
       return;
     }
     const selectedTutorMaterials = materials.filter((material) =>
-      selectedForTutor.includes(material.id),
+      materialIds.includes(material.id),
     );
     const selectedCourseIds = Array.from(
       new Set(
@@ -1048,11 +1118,11 @@ function useLibraryPageController() {
           ? selectedCourseId
           : undefined;
 
-    writeTutorSelectedMaterialIds(selectedForTutor);
+    writeTutorSelectedMaterialIds(materialIds);
     writeTutorStoredStartState({
       courseId: handoffCourseId,
       topic: "",
-      selectedMaterials: selectedForTutor,
+      selectedMaterials: materialIds,
       chainId: undefined,
       customBlockIds: [],
       accuracyProfile: "strict",
@@ -1079,36 +1149,45 @@ function useLibraryPageController() {
     );
   };
 
+  const handleOpenTutor = () => {
+    openTutorWithMaterialIds(selectedForTutor);
+  };
+
+  const studyMaterialInTutor = (id: number) => {
+    setSelectedForTutor([id]);
+    openTutorWithMaterialIds([id]);
+  };
+
   const replaceTutorQueueWithVisible = () => {
-    if (!selectableVisibleMaterialIds.length) {
-      toast.error("No enabled files are visible in this view.");
+    if (!defaultVisibleStudyMaterialIds.length) {
+      toast.error("No enabled study files are visible in this view.");
       return;
     }
-    setSelectedForTutor([...selectableVisibleMaterialIds]);
+    setSelectedForTutor([...defaultVisibleStudyMaterialIds]);
     toast.success(
-      `Tutor queue replaced with ${selectableVisibleMaterialIds.length} visible file${selectableVisibleMaterialIds.length === 1 ? "" : "s"}.`,
+      `Current Run replaced with ${defaultVisibleStudyMaterialIds.length} study file${defaultVisibleStudyMaterialIds.length === 1 ? "" : "s"}.`,
     );
   };
 
   const addVisibleToTutorQueue = () => {
-    if (!selectableVisibleMaterialIds.length) {
-      toast.error("No enabled files are visible in this view.");
+    if (!defaultVisibleStudyMaterialIds.length) {
+      toast.error("No enabled study files are visible in this view.");
       return;
     }
     setSelectedForTutor((prev) => {
       const next = new Set(prev);
-      for (const id of selectableVisibleMaterialIds) next.add(id);
+      for (const id of defaultVisibleStudyMaterialIds) next.add(id);
       return [...next];
     });
     toast.success(
-      `Added ${selectableVisibleMaterialIds.length} visible file${selectableVisibleMaterialIds.length === 1 ? "" : "s"} to the Tutor queue.`,
+      `Added ${defaultVisibleStudyMaterialIds.length} study file${defaultVisibleStudyMaterialIds.length === 1 ? "" : "s"} to the Current Run.`,
     );
   };
 
   const clearTutorQueue = () => {
     if (!selectedForTutor.length) return;
     setSelectedForTutor([]);
-    toast.success("Tutor queue cleared.");
+    toast.success("Current Run cleared.");
   };
 
   useEffect(() => {
@@ -1266,12 +1345,12 @@ function useLibraryPageController() {
 
   const toggleAllMaterialsForTutor = () => {
     setSelectedForTutor((prev) => {
-      if (!selectableVisibleMaterialIds.length) return prev;
+      if (!defaultVisibleStudyMaterialIds.length) return prev;
       const next = new Set(prev);
       if (allTutorMaterialsSelected) {
-        for (const id of selectableVisibleMaterialIds) next.delete(id);
+        for (const id of defaultVisibleStudyMaterialIds) next.delete(id);
       } else {
-        for (const id of selectableVisibleMaterialIds) next.add(id);
+        for (const id of defaultVisibleStudyMaterialIds) next.add(id);
       }
       return [...next];
     });
@@ -2092,9 +2171,9 @@ function useLibraryPageController() {
                     </div>
                     <div className="mt-3 grid gap-2 md:grid-cols-3">
                       {[
-                        ["SOURCE", "Pick intake, sync, or direct upload."],
-                        ["REVIEW", "Confirm course setup and chosen files."],
-                        ["STUDY", "Send ready materials to Tutor."],
+                        ["COURSE SETUP", "Syllabus and schedule readiness."],
+                        ["STUDY MATERIALS", "Pick weekly files manually."],
+                        ["CURRENT RUN", "Study one file or a small set."],
                       ].map(([label, copy]) => (
                         <div
                           key={label}
@@ -2603,7 +2682,7 @@ function useLibraryPageController() {
                         </div>
                       </div>
                       <div className={LIBRARY_PANEL_INSET + " p-2"}>
-                        <div className={TEXT_MUTED}>Tutor queue</div>
+                        <div className={TEXT_MUTED}>Current Run</div>
                         <div className="font-terminal text-lg text-foreground">
                           {selectedForTutor.length}
                         </div>
@@ -2623,25 +2702,25 @@ function useLibraryPageController() {
                     </div>
                     <div className={LIBRARY_HELP_TEXT}>
                       {selectedForTutor.length
-                        ? `${selectedForTutor.length} file${selectedForTutor.length === 1 ? "" : "s"} ready for Tutor handoff.`
-                        : "Select materials below to make them ready for Tutor handoff."}
+                        ? `${selectedForTutor.length} file${selectedForTutor.length === 1 ? "" : "s"} in Current Run for Tutor handoff.`
+                        : "Use Study on a row or select files below to build the Current Run."}
                     </div>
                     <div className="flex flex-wrap gap-2">
                       <HudButton
                         variant="outline"
                         className={LIBRARY_COMPACT_BUTTON}
-                        disabled={!selectableVisibleMaterialIds.length}
+                        disabled={!defaultVisibleStudyMaterialIds.length}
                         onClick={replaceTutorQueueWithVisible}
                       >
-                        REPLACE WITH VIEW
+                        REPLACE RUN
                       </HudButton>
                       <HudButton
                         variant="outline"
                         className={LIBRARY_COMPACT_BUTTON}
-                        disabled={!selectableVisibleMaterialIds.length}
+                        disabled={!defaultVisibleStudyMaterialIds.length}
                         onClick={addVisibleToTutorQueue}
                       >
-                        ADD VIEW
+                        ADD STUDY FILES
                       </HudButton>
                       <HudButton
                         variant="outline"
@@ -2649,7 +2728,7 @@ function useLibraryPageController() {
                         disabled={!selectedForTutor.length}
                         onClick={clearTutorQueue}
                       >
-                        CLEAR QUEUE
+                        CLEAR RUN
                       </HudButton>
                       <HudButton
                         className={LIBRARY_COMPACT_BUTTON}
@@ -2679,7 +2758,7 @@ function useLibraryPageController() {
                       {visibleMaterials.length === 1 ? "" : "s"}
                     </div>
                     <div className={TEXT_MUTED}>
-                      Tutor queue: {selectedForTutor.length} file
+                      Current Run: {selectedForTutor.length} file
                       {selectedForTutor.length === 1 ? "" : "s"} total •{" "}
                       {selectedVisibleMaterialIds.length} in this view
                       {hiddenTutorSelectionCount > 0
@@ -2810,11 +2889,11 @@ function useLibraryPageController() {
 
                 {hiddenTutorSelectionCount > 0 ? (
                   <div className="border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm font-terminal text-yellow-100">
-                    The Tutor queue still includes {hiddenTutorSelectionCount}{" "}
+                    The Current Run still includes {hiddenTutorSelectionCount}{" "}
                     file{hiddenTutorSelectionCount === 1 ? "" : "s"} from other
                     views. Use{" "}
-                    <span className="text-white">REPLACE WITH VIEW</span> if you
-                    want Tutor to use only what is visible right now.
+                    <span className="text-white">REPLACE RUN</span> if you
+                    want Tutor to use only visible study files right now.
                   </div>
                 ) : null}
 
@@ -2859,20 +2938,20 @@ function useLibraryPageController() {
                             className="flex items-center justify-center"
                             title={
                               allTutorMaterialsSelected
-                                ? "Unselect all visible tutor materials"
-                                : "Select all visible tutor materials"
+                                ? "Unselect all visible study files"
+                                : "Select all visible study files"
                             }
                           >
                             <Checkbox
                               checked={allTutorMaterialsSelected}
                               onCheckedChange={toggleAllMaterialsForTutor}
                               disabled={
-                                selectableVisibleMaterialIds.length === 0
+                                defaultVisibleStudyMaterialIds.length === 0
                               }
                               aria-label={
                                 allTutorMaterialsSelected
-                                  ? "Unselect all visible tutor materials"
-                                  : "Select all visible tutor materials"
+                                  ? "Unselect all visible study files"
+                                  : "Select all visible study files"
                               }
                             />
                           </div>
@@ -2898,6 +2977,7 @@ function useLibraryPageController() {
                             setEditingId,
                             saveEdit,
                             toggleMaterialForTutor,
+                            studyMaterialInTutor,
                             toggleEnabled,
                             deleteMutation,
                             startEdit,

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -79,6 +79,20 @@ const LIBRARY_MAIN_TITLE =
   "font-arcade text-base uppercase tracking-[0.16em] text-white";
 const LIBRARY_PANEL_TITLE = "library-panel-title";
 const LIBRARY_HELP_TEXT = "library-help-text";
+const MATERIAL_TABLE_GRID_TEMPLATE =
+  "40px minmax(340px,1.35fr) minmax(220px,0.9fr) minmax(240px,0.85fr) 92px 96px 132px";
+const MATERIAL_READER_MARKDOWN_CLASS = `
+  prose prose-invert prose-base max-w-none font-sans text-[15px] leading-7
+  prose-headings:font-arcade prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-2
+  prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
+  prose-p:text-foreground/90 prose-p:leading-7
+  prose-li:text-foreground/90 prose-li:leading-7
+  prose-strong:text-primary/90
+  prose-table:border-collapse prose-table:text-sm prose-th:border prose-th:border-primary/30 prose-th:bg-primary/10 prose-th:px-3 prose-th:py-2
+  prose-td:border prose-td:border-primary/20 prose-td:px-3 prose-td:py-2
+  prose-code:text-primary/80 prose-code:bg-primary/10 prose-code:px-1 prose-code:rounded-none
+  prose-pre:bg-black/60 prose-pre:border prose-pre:border-primary/20 prose-pre:text-sm
+`;
 type LibraryWorkflowTab = "upload" | "materials";
 type MaterialRole = "study" | "reference" | "setup";
 
@@ -441,8 +455,7 @@ function renderMaterialRow(
       key={mat.id}
       className={`grid gap-3 px-3 py-2.5 items-center border-b border-primary/10 hover:bg-primary/5 transition-colors ${!mat.enabled ? "opacity-50" : ""}`}
       style={{
-        gridTemplateColumns:
-          "32px minmax(250px,1.55fr) minmax(180px,1fr) 78px 84px 92px 126px",
+        gridTemplateColumns: MATERIAL_TABLE_GRID_TEMPLATE,
       }}
     >
       <div className="flex items-center justify-center">
@@ -493,22 +506,25 @@ function renderMaterialRow(
       </div>
 
       {/* Type */}
-      <div className="flex items-center gap-1">
+      <div className="flex min-w-0 flex-wrap items-center gap-1.5 overflow-visible">
         {isDuplicate ? (
           <Badge
             variant="outline"
-            className={`${TEXT_BADGE} h-4 px-1 w-fit border-yellow-500/50 text-yellow-400`}
+            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-yellow-500/50 text-yellow-400`}
           >
             DUPE
           </Badge>
         ) : null}
-        <Badge variant="outline" className={`${TEXT_BADGE} h-4 px-1 w-fit`}>
+        <Badge
+          variant="outline"
+          className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit`}
+        >
           {getFileTypeLabel(mat.file_type)}
         </Badge>
         {materialRole === "reference" ? (
           <Badge
             variant="outline"
-            className={`${TEXT_BADGE} h-4 px-1 w-fit border-sky-500/50 text-sky-300`}
+            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-sky-500/50 text-sky-300`}
             title="Course reference; manually selectable for Tutor"
           >
             COURSE REF
@@ -517,7 +533,7 @@ function renderMaterialRow(
         {materialRole === "setup" ? (
           <Badge
             variant="outline"
-            className={`${TEXT_BADGE} h-4 px-1 w-fit border-emerald-500/50 text-emerald-300`}
+            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit border-emerald-500/50 text-emerald-300`}
             title="Course setup file"
           >
             SETUP
@@ -526,7 +542,7 @@ function renderMaterialRow(
         {canReextract ? (
           <Badge
             variant="outline"
-            className={`${TEXT_BADGE} h-4 px-1 w-fit ${hasDoclingAssets ? "border-green-500/60 text-green-300" : "border-yellow-500/60 text-yellow-300"}`}
+            className={`${TEXT_BADGE} h-4 shrink-0 px-1 w-fit ${hasDoclingAssets ? "border-green-500/60 text-green-300" : "border-yellow-500/60 text-yellow-300"}`}
             title={
               hasDoclingAssets
                 ? `${doclingAssetCount} Docling asset${doclingAssetCount === 1 ? "" : "s"} detected`
@@ -565,6 +581,7 @@ function renderMaterialRow(
           onClick={() => viewContent(mat.id)}
           className="text-muted-foreground hover:text-primary transition-colors p-0.5"
           title="View content"
+          aria-label="View content"
         >
           <Eye className={ICON_SM} />
         </button>
@@ -574,6 +591,7 @@ function renderMaterialRow(
             disabled={isReextracting}
             className="text-muted-foreground hover:text-primary transition-colors p-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
             title="Re-extract with Docling"
+            aria-label="Re-extract with Docling"
           >
             <RefreshCw
               className={`${ICON_SM} ${isReextracting ? "animate-spin" : ""}`}
@@ -584,6 +602,7 @@ function renderMaterialRow(
           onClick={() => startEdit(mat)}
           className="text-muted-foreground hover:text-primary transition-colors p-0.5"
           title="Edit title"
+          aria-label="Edit title"
         >
           <Pencil className={ICON_SM} />
         </button>
@@ -594,6 +613,7 @@ function renderMaterialRow(
               onClick={() => deleteMutation.mutate(mat.id)}
               className="text-red-400 hover:text-red-300 p-0.5"
               title="Confirm delete"
+              aria-label="Confirm delete"
             >
               <Check className={ICON_SM} />
             </button>
@@ -601,6 +621,7 @@ function renderMaterialRow(
               onClick={() => setDeleteConfirm(null)}
               className="text-muted-foreground hover:text-foreground p-0.5"
               title="Cancel"
+              aria-label="Cancel delete"
             >
               <X className={ICON_SM} />
             </button>
@@ -610,6 +631,7 @@ function renderMaterialRow(
             onClick={() => setDeleteConfirm(mat.id)}
             className="text-muted-foreground hover:text-red-400 transition-colors p-0.5"
             title="Delete"
+            aria-label="Delete"
           >
             <Trash2 className={ICON_SM} />
           </button>
@@ -1548,12 +1570,11 @@ function useLibraryPageController() {
                     </div>
                   ) : (
                     <div className="h-full min-h-0 overflow-auto">
-                      <div className="min-w-[1040px]">
+                      <div className="min-w-[1240px]">
                         <div
                           className="grid gap-3 px-3 py-2 border-b border-primary/15 bg-black/80 sticky top-0 z-10"
                           style={{
-                            gridTemplateColumns:
-                              "32px minmax(250px,1.55fr) minmax(180px,1fr) 78px 84px 92px 126px",
+                            gridTemplateColumns: MATERIAL_TABLE_GRID_TEMPLATE,
                           }}
                         >
                           <div aria-hidden="true" />
@@ -1687,135 +1708,127 @@ function useLibraryPageController() {
           if (!open) setViewingMaterialId(null);
         }}
       >
-        <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col gap-0">
-          <DialogHeader className="shrink-0 pb-3">
+        <DialogContent className="flex h-[90vh] max-h-[90vh] max-w-5xl flex-col gap-0 overflow-hidden p-0">
+          <DialogHeader className="shrink-0 border-b border-primary/20 px-5 py-4">
             <DialogTitle className="flex items-center gap-2">
               <FileText className={ICON_SM} />
               {materialContent?.title || "Material Content"}
             </DialogTitle>
-            <DialogDescription className="flex items-center gap-2">
-              {materialContent?.file_type && (
-                <Badge variant="outline" className={`${TEXT_BADGE} h-4 px-1`}>
-                  {getFileTypeLabel(materialContent.file_type)}
-                </Badge>
-              )}
-              {materialContent?.char_count !== undefined && (
-                <span>
-                  {materialContent.char_count.toLocaleString()} characters
-                </span>
-              )}
+            <DialogDescription asChild>
+              <div className="flex items-center gap-2 text-sm font-terminal text-muted-foreground">
+                {materialContent?.file_type && (
+                  <Badge variant="outline" className={`${TEXT_BADGE} h-4 px-1`}>
+                    {getFileTypeLabel(materialContent.file_type)}
+                  </Badge>
+                )}
+                {materialContent?.char_count !== undefined && (
+                  <span>
+                    {materialContent.char_count.toLocaleString()} characters
+                  </span>
+                )}
+              </div>
             </DialogDescription>
           </DialogHeader>
           <HudPanel
             variant="b"
-            className="flex-1 min-h-0 overflow-y-auto bg-black/40 p-5"
+            className="min-h-0 flex-1 bg-black/40 p-0"
           >
-            {isContentLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2
-                  className={`${ICON_MD} animate-spin text-muted-foreground`}
-                />
-              </div>
-            ) : materialContent?.extraction_lossy ? (
-              <div className="space-y-4">
-                <div className="flex items-start gap-2 border border-yellow-500/40 bg-yellow-500/10 p-3">
-                  <AlertTriangle className="w-5 h-5 text-yellow-400 shrink-0 mt-0.5" />
-                  <div>
-                    <div className="font-arcade text-sm text-yellow-400">
-                      EXTRACTION INCOMPLETE
-                    </div>
-                    <div className={`${TEXT_MUTED} text-sm mt-1`}>
-                      {Math.round(materialContent.replacement_ratio * 100)}% of
-                      this PDF could not be decoded — it may use scanned images
-                      or an embedded font. The readable portions are shown
-                      below. Consider re-uploading with an OCR-processed
-                      version.
-                    </div>
-                  </div>
+            <div
+              className="relative z-10 h-full min-h-0 overflow-y-auto overscroll-contain p-5 sm:p-6"
+              data-testid="library-material-reader"
+              tabIndex={0}
+            >
+              {isContentLoading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2
+                    className={`${ICON_MD} animate-spin text-muted-foreground`}
+                  />
                 </div>
-                {materialContent.content ? (
-                  <div
-                    className="prose prose-invert prose-sm max-w-none font-terminal
-                    prose-headings:font-arcade prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-1
-                    prose-h1:text-lg prose-h2:text-base prose-h3:text-sm
-                    prose-p:text-foreground/90 prose-p:leading-relaxed
-                    prose-li:text-foreground/90
-                    prose-strong:text-primary/90
-                    prose-table:border-collapse prose-th:border prose-th:border-primary/30 prose-th:bg-primary/10 prose-th:px-2 prose-th:py-1
-                    prose-td:border prose-td:border-primary/20 prose-td:px-2 prose-td:py-1
-                    prose-code:text-primary/80 prose-code:bg-primary/10 prose-code:px-1 prose-code:rounded-none
-                    prose-pre:bg-black/60 prose-pre:border prose-pre:border-primary/20"
-                  >
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      components={{
-                        img: ({ src, alt }: { src?: string; alt?: string }) => {
-                          const resolvedSrc = resolveMaterialAssetUrl(
+              ) : materialContent?.extraction_lossy ? (
+                <div className="space-y-4">
+                  <div className="flex items-start gap-2 border border-yellow-500/40 bg-yellow-500/10 p-3">
+                    <AlertTriangle className="w-5 h-5 text-yellow-400 shrink-0 mt-0.5" />
+                    <div>
+                      <div className="font-arcade text-sm text-yellow-400">
+                        EXTRACTION INCOMPLETE
+                      </div>
+                      <div className={`${TEXT_MUTED} text-sm mt-1`}>
+                        {Math.round(materialContent.replacement_ratio * 100)}%
+                        of this PDF could not be decoded — it may use scanned
+                        images or an embedded font. The readable portions are
+                        shown below. Consider re-uploading with an OCR-processed
+                        version.
+                      </div>
+                    </div>
+                  </div>
+                  {materialContent.content ? (
+                    <div className={MATERIAL_READER_MARKDOWN_CLASS}>
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        components={{
+                          img: ({
                             src,
-                            materialContent.id,
-                          );
-                          if (!resolvedSrc) return null;
-                          return (
-                            <img
-                              src={resolvedSrc}
-                              alt={alt || "Extracted figure"}
-                              loading="lazy"
-                              className="max-w-full h-auto border border-primary/30 bg-black/20"
-                            />
-                          );
-                        },
-                      }}
-                    >
-                      {materialContent.content}
-                    </ReactMarkdown>
-                  </div>
-                ) : (
-                  <div className={`${TEXT_MUTED} text-center py-4`}>
-                    No readable text could be recovered.
-                  </div>
-                )}
-              </div>
-            ) : materialContent?.content ? (
-              <div
-                className="prose prose-invert prose-sm max-w-none font-terminal
-                prose-headings:font-arcade prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-1
-                prose-h1:text-lg prose-h2:text-base prose-h3:text-sm
-                prose-p:text-foreground/90 prose-p:leading-relaxed
-                prose-li:text-foreground/90
-                prose-strong:text-primary/90
-                prose-table:border-collapse prose-th:border prose-th:border-primary/30 prose-th:bg-primary/10 prose-th:px-2 prose-th:py-1
-                prose-td:border prose-td:border-primary/20 prose-td:px-2 prose-td:py-1
-                prose-code:text-primary/80 prose-code:bg-primary/10 prose-code:px-1 prose-code:rounded-none
-                prose-pre:bg-black/60 prose-pre:border prose-pre:border-primary/20"
-              >
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={{
-                    img: ({ src, alt }: { src?: string; alt?: string }) => {
-                      const resolvedSrc = resolveMaterialAssetUrl(
-                        src,
-                        materialContent.id,
-                      );
-                      if (!resolvedSrc) return null;
-                      return (
-                        <img
-                          src={resolvedSrc}
-                          alt={alt || "Extracted figure"}
-                          loading="lazy"
-                          className="max-w-full h-auto border border-primary/30 bg-black/20"
-                        />
-                      );
-                    },
-                  }}
-                >
-                  {materialContent.content}
-                </ReactMarkdown>
-              </div>
-            ) : (
-              <div className={`${TEXT_MUTED} text-center py-8`}>
-                No extracted content available for this material.
-              </div>
-            )}
+                            alt,
+                          }: {
+                            src?: string;
+                            alt?: string;
+                          }) => {
+                            const resolvedSrc = resolveMaterialAssetUrl(
+                              src,
+                              materialContent.id,
+                            );
+                            if (!resolvedSrc) return null;
+                            return (
+                              <img
+                                src={resolvedSrc}
+                                alt={alt || "Extracted figure"}
+                                loading="lazy"
+                                className="max-w-full h-auto border border-primary/30 bg-black/20"
+                              />
+                            );
+                          },
+                        }}
+                      >
+                        {materialContent.content}
+                      </ReactMarkdown>
+                    </div>
+                  ) : (
+                    <div className={`${TEXT_MUTED} text-center py-4`}>
+                      No readable text could be recovered.
+                    </div>
+                  )}
+                </div>
+              ) : materialContent?.content ? (
+                <div className={MATERIAL_READER_MARKDOWN_CLASS}>
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      img: ({ src, alt }: { src?: string; alt?: string }) => {
+                        const resolvedSrc = resolveMaterialAssetUrl(
+                          src,
+                          materialContent.id,
+                        );
+                        if (!resolvedSrc) return null;
+                        return (
+                          <img
+                            src={resolvedSrc}
+                            alt={alt || "Extracted figure"}
+                            loading="lazy"
+                            className="max-w-full h-auto border border-primary/30 bg-black/20"
+                          />
+                        );
+                      },
+                    }}
+                  >
+                    {materialContent.content}
+                  </ReactMarkdown>
+                </div>
+              ) : (
+                <div className={`${TEXT_MUTED} text-center py-8`}>
+                  No extracted content available for this material.
+                </div>
+              )}
+            </div>
           </HudPanel>
         </DialogContent>
       </Dialog>

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -82,8 +82,8 @@ const LIBRARY_HELP_TEXT = "library-help-text";
 const MATERIAL_TABLE_GRID_TEMPLATE =
   "40px minmax(340px,1.35fr) minmax(220px,0.9fr) minmax(240px,0.85fr) 92px 96px 132px";
 const MATERIAL_READER_MARKDOWN_CLASS = `
-  prose prose-invert prose-base max-w-none font-sans text-[15px] leading-7
-  prose-headings:font-arcade prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-2
+  library-material-markdown prose prose-invert prose-base max-w-none font-sans text-[15px] leading-7 tracking-normal
+  prose-headings:font-sans prose-headings:font-semibold prose-headings:tracking-normal prose-headings:normal-case prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-2
   prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
   prose-p:text-foreground/90 prose-p:leading-7
   prose-li:text-foreground/90 prose-li:leading-7
@@ -1762,7 +1762,10 @@ function useLibraryPageController() {
                     </div>
                   </div>
                   {materialContent.content ? (
-                    <div className={MATERIAL_READER_MARKDOWN_CLASS}>
+                    <div
+                      className={MATERIAL_READER_MARKDOWN_CLASS}
+                      data-testid="library-material-markdown"
+                    >
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
                         components={{
@@ -1799,7 +1802,10 @@ function useLibraryPageController() {
                   )}
                 </div>
               ) : materialContent?.content ? (
-                <div className={MATERIAL_READER_MARKDOWN_CLASS}>
+                <div
+                  className={MATERIAL_READER_MARKDOWN_CLASS}
+                  data-testid="library-material-markdown"
+                >
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
                     components={{

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -88,7 +88,7 @@ const LIBRARY_HELP_TEXT = "library-help-text";
 const MATERIAL_TABLE_GRID_TEMPLATE =
   "40px minmax(340px,1.35fr) minmax(220px,0.9fr) minmax(240px,0.85fr) 92px 96px 132px";
 const MATERIAL_READER_MARKDOWN_CLASS = `
-  library-material-markdown prose prose-invert prose-base max-w-none font-sans text-[15px] leading-7 tracking-normal
+  library-material-markdown prose prose-invert prose-base mx-auto max-w-[86ch] font-sans text-[16px] leading-8 tracking-normal sm:text-[17px]
   prose-headings:font-sans prose-headings:font-semibold prose-headings:tracking-normal prose-headings:normal-case prose-headings:text-primary prose-headings:border-b prose-headings:border-primary/20 prose-headings:pb-2
   prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg
   prose-p:text-foreground/90 prose-p:leading-7
@@ -188,6 +188,14 @@ function getMaterialTitle(mat: Material): string {
   if (sourcePath) return toBaseName(sourcePath);
 
   return `Material ${mat.id}`;
+}
+
+function getMaterialContentTitle(material: MaterialContent | undefined): string {
+  const title = (material?.title || "").trim();
+  if (title) return title;
+  const rawPath = (material?.source_path || "").replace(/\\/g, "/").trim();
+  const fallback = rawPath.split("/").filter(Boolean).pop();
+  return fallback || "Material Content";
 }
 
 function getMaterialSize(mat: Material): number {
@@ -1747,16 +1755,18 @@ function useLibraryPageController() {
           if (!open) setViewingMaterialId(null);
         }}
       >
-        <DialogContent className="flex h-[90vh] max-h-[90vh] max-w-5xl flex-col gap-0 overflow-hidden p-0">
-          <DialogHeader className="shrink-0 border-b border-primary/20 px-5 py-4">
-            <DialogTitle className="flex items-center gap-2">
-              <FileText className={ICON_SM} />
-              {materialContent?.title || "Material Content"}
+        <DialogContent className="flex h-[88vh] max-h-[88vh] max-w-6xl flex-col gap-0 overflow-hidden border-primary/35 bg-[#050506] p-0">
+          <DialogHeader className="shrink-0 border-b border-primary/15 bg-black/70 px-5 py-4">
+            <DialogTitle className="library-material-dialog-title flex items-start gap-2 pr-8">
+              <FileText className={`${ICON_SM} mt-1 shrink-0 text-primary/80`} />
+              <span className="min-w-0 truncate">
+                {getMaterialContentTitle(materialContent)}
+              </span>
             </DialogTitle>
             <DialogDescription asChild>
-              <div className="flex items-center gap-2 text-sm font-terminal text-muted-foreground">
+              <div className="mt-2 flex items-center gap-2 font-sans text-sm text-muted-foreground">
                 {materialContent?.file_type && (
-                  <Badge variant="outline" className={`${TEXT_BADGE} h-4 px-1`}>
+                  <Badge variant="outline" className="h-6 rounded-full px-2 font-mono text-xs uppercase tracking-normal">
                     {getFileTypeLabel(materialContent.file_type)}
                   </Badge>
                 )}
@@ -1770,10 +1780,10 @@ function useLibraryPageController() {
           </DialogHeader>
           <HudPanel
             variant="b"
-            className="min-h-0 flex-1 bg-black/40 p-0"
+            className="min-h-0 flex-1 bg-[linear-gradient(180deg,rgba(255,255,255,0.035),rgba(0,0,0,0.86))] p-0"
           >
             <div
-              className="relative z-10 h-full min-h-0 overflow-y-auto overscroll-contain p-5 sm:p-6"
+              className="library-material-reader-shell relative z-10 h-full min-h-0 overflow-y-auto overscroll-contain px-5 py-7 sm:px-8"
               data-testid="library-material-reader"
               tabIndex={0}
             >

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -1,25 +1,17 @@
 import { PageScaffold } from "@/components/PageScaffold";
-import { useState, useEffect, useMemo, useCallback, type ReactElement } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import {
   consumeLibraryLaunchFromTutor,
-  readTutorSelectedMaterialIds,
-  writeTutorStoredStartState,
-  writeTutorSelectedMaterialIds,
 } from "@/lib/tutorClientState";
 import type {
   Material,
   MaterialContent,
   TutorEmbedStatus,
-  TutorSyncJobStatus,
   TutorContentSources,
-  TutorSyncPreviewNode,
-  TutorSyncPreviewResult,
-  SemesterIntakePreviewResult,
 } from "@/lib/api";
 import type { Course } from "@shared/schema";
-import { useLocation } from "wouter";
 import {
   TEXT_PAGE_TITLE,
   TEXT_BODY,
@@ -46,7 +38,6 @@ import {
   X,
   BookOpen,
   RefreshCw,
-  Link2,
   Folder,
   FolderOpen,
   ChevronRight,
@@ -58,9 +49,7 @@ import {
   ArchiveRestore,
   ChevronDown,
   Plus,
-  Play,
 } from "lucide-react";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -81,35 +70,17 @@ const FILE_TYPE_LABEL: Record<string, string> = {
   txt: "TXT",
 };
 const ALL_FOLDERS_KEY = "";
-const DEFAULT_SEMESTER_INTAKE_FOLDER =
-  "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School";
 const LIBRARY_PANEL_SURFACE = "library-panel-surface";
 const LIBRARY_PANEL_INSET = "library-panel-inset";
 const LIBRARY_ACTION_BUTTON = "library-action-button";
-const LIBRARY_COMPACT_BUTTON = `${LIBRARY_ACTION_BUTTON} w-auto h-9 min-h-[36px] px-4`;
-const LIBRARY_INLINE_BUTTON = `${LIBRARY_ACTION_BUTTON} library-action-button--inline w-auto h-8 min-h-[32px] px-3`;
 const LIBRARY_SELECT = `${SELECT_BASE} library-field h-10 min-h-[40px] rounded-[0.75rem] px-3`;
 const LIBRARY_SECTION_LABEL = "library-section-label";
 const LIBRARY_MAIN_TITLE =
   "font-arcade text-base uppercase tracking-[0.16em] text-white";
 const LIBRARY_PANEL_TITLE = "library-panel-title";
 const LIBRARY_HELP_TEXT = "library-help-text";
-const LIBRARY_READY_BADGE =
-  "rounded-[0.55rem] border border-emerald-400/35 bg-emerald-400/10 px-2 py-1 font-terminal text-sm uppercase tracking-[0.12em] text-emerald-200";
-const LIBRARY_WARN_BADGE =
-  "rounded-[0.55rem] border border-amber-400/35 bg-amber-400/10 px-2 py-1 font-terminal text-sm uppercase tracking-[0.12em] text-amber-200";
-type AddCourseworkMode = "intake" | "sync" | "upload";
+type LibraryWorkflowTab = "upload" | "materials";
 type MaterialRole = "study" | "reference" | "setup";
-type SemesterPreviewCourse = SemesterIntakePreviewResult["courses"][number];
-
-function collectSemesterMaterialFilePaths(
-  preview: SemesterIntakePreviewResult | null | undefined,
-): string[] {
-  if (!preview) return [];
-  return preview.courses.flatMap((course) =>
-    course.material_files.map((file) => file.path),
-  );
-}
 
 function getFileTypeLabel(fileType: string | null | undefined): string {
   const normalizedRaw = (fileType || "").toLowerCase().trim();
@@ -173,25 +144,23 @@ function getMaterialSize(mat: Material): number {
     : 0;
 }
 
-function pluralizeCount(count: number, singular: string, plural = `${singular}s`) {
-  return `${count} ${count === 1 ? singular : plural}`;
+function materialMatchesLibrarySearch(mat: Material, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  const haystack = [
+    getMaterialTitle(mat),
+    getMaterialFolder(mat),
+    mat.source_path || "",
+    mat.file_type || "",
+    getMaterialRole(mat),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(needle);
 }
 
-function getSemesterCourseReviewStatus(course: SemesterPreviewCourse): {
-  label: string;
-  tone: "ready" | "warn";
-} {
-  if (course.readiness.readyForTutor) {
-    return { label: "Ready for Tutor", tone: "ready" };
-  }
-  if (
-    course.syllabus_files.length > 0 ||
-    course.schedule_files.length > 0 ||
-    course.material_files.length > 0
-  ) {
-    return { label: "Ready to review", tone: "ready" };
-  }
-  return { label: "Needs files", tone: "warn" };
+function pluralizeCount(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 
 function formatCourseSecondaryLabel(course: {
@@ -288,6 +257,14 @@ function getMaterialFolder(mat: Material): string {
 }
 
 function getMaterialRole(mat: Material): MaterialRole {
+  const explicitRole = String(mat.material_role || "").toLowerCase().trim();
+  if (explicitRole === "setup" || String(mat.corpus || "").toLowerCase() === "course_setup") {
+    return "setup";
+  }
+  const explicitDocType = String(mat.doc_type || "").toLowerCase().trim();
+  if (explicitDocType === "course_setup" || explicitDocType === "syllabus" || explicitDocType === "schedule") {
+    return "setup";
+  }
   const segments = [
     mat.folder_path || "",
     mat.source_path || "",
@@ -320,10 +297,6 @@ function getMaterialRole(mat: Material): MaterialRole {
   }
 
   return "study";
-}
-
-function isDefaultStudyMaterial(mat: Material): boolean {
-  return mat.enabled && getMaterialRole(mat) === "study";
 }
 
 function buildFolderTree(materials: Material[]): FolderNode {
@@ -410,28 +383,10 @@ function getFolderAncestorPaths(path: string): string[] {
   return ancestors;
 }
 
-function normalizePathForCompare(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/+$/g, "").toLowerCase();
-}
-
-function collectSyncPreviewFilePaths(
-  node: TutorSyncPreviewNode | null | undefined,
-): string[] {
-  if (!node) return [];
-  if (node.type === "file") return [node.path];
-  const children = Array.isArray(node.children) ? node.children : [];
-  const files: string[] = [];
-  for (const child of children) {
-    files.push(...collectSyncPreviewFilePaths(child));
-  }
-  return files;
-}
-
 type InitialLibraryLaunchState = {
   sidebarMode: "folders" | "courses";
   selectedCourseId: number | "unlinked" | null;
   uploadCourseTarget: string;
-  syncCourseTarget: string;
   selectedFolderPath: string;
 };
 
@@ -442,7 +397,6 @@ function readInitialLibraryLaunchState(): InitialLibraryLaunchState {
       sidebarMode: "courses",
       selectedCourseId: null,
       uploadCourseTarget: "",
-      syncCourseTarget: "",
       selectedFolderPath: ALL_FOLDERS_KEY,
     };
   }
@@ -451,7 +405,6 @@ function readInitialLibraryLaunchState(): InitialLibraryLaunchState {
     sidebarMode: "courses",
     selectedCourseId: handoff.courseId,
     uploadCourseTarget: courseId,
-    syncCourseTarget: courseId,
     selectedFolderPath: ALL_FOLDERS_KEY,
   };
 }
@@ -459,14 +412,11 @@ function readInitialLibraryLaunchState(): InitialLibraryLaunchState {
 function renderMaterialRow(
   mat: Material,
   isDuplicate: boolean,
-  selectedForTutor: number[],
   editingId: number | null,
   editTitle: string,
   setEditTitle: (value: string) => void,
   setEditingId: (id: number | null) => void,
   saveEdit: () => void,
-  toggleMaterialForTutor: (id: number) => void,
-  studyMaterialInTutor: (id: number) => void,
   toggleEnabled: (mat: Material) => void,
   deleteMutation: MutateDeleteLike,
   startEdit: (mat: Material) => void,
@@ -496,12 +446,7 @@ function renderMaterialRow(
       }}
     >
       <div className="flex items-center justify-center">
-        <Checkbox
-          checked={selectedForTutor.includes(mat.id)}
-          onCheckedChange={() => toggleMaterialForTutor(mat.id)}
-          disabled={!mat.enabled}
-          aria-label={`Select ${displayTitle} for tutor`}
-        />
+        <FileText className={`${ICON_SM} text-primary/70`} />
       </div>
 
       {/* Title */}
@@ -564,7 +509,7 @@ function renderMaterialRow(
           <Badge
             variant="outline"
             className={`${TEXT_BADGE} h-4 px-1 w-fit border-sky-500/50 text-sky-300`}
-            title="Course reference; manually selectable for Current Run"
+            title="Course reference; manually selectable for Tutor"
           >
             COURSE REF
           </Badge>
@@ -616,15 +561,6 @@ function renderMaterialRow(
 
       {/* Actions */}
       <div className="flex items-center gap-1 justify-end">
-        <button
-          onClick={() => studyMaterialInTutor(mat.id)}
-          disabled={!mat.enabled}
-          className="text-muted-foreground hover:text-primary transition-colors p-0.5 disabled:opacity-40 disabled:cursor-not-allowed"
-          title="Study this file"
-          aria-label={`Study ${displayTitle} in Tutor`}
-        >
-          <Play className={ICON_SM} />
-        </button>
         <button
           onClick={() => viewContent(mat.id)}
           className="text-muted-foreground hover:text-primary transition-colors p-0.5"
@@ -683,133 +619,17 @@ function renderMaterialRow(
   );
 }
 
-function SyncPreviewTreeNode({
-  node,
-  depth = 0,
-  selectedSyncFiles,
-  expandedSyncFolders,
-  onToggleFile,
-  onToggleFolder,
-}: {
-  node: TutorSyncPreviewNode;
-  depth?: number;
-  selectedSyncFiles: Set<string>;
-  expandedSyncFolders: Set<string>;
-  onToggleFile: (path: string) => void;
-  onToggleFolder: (path: string) => void;
-}): ReactElement | null {
-  if (node.type === "file") {
-    const isChecked = selectedSyncFiles.has(node.path);
-    return (
-      <div
-        className="w-full rounded-none border border-primary/10 px-2 py-1.5 text-left text-sm font-terminal flex items-center gap-2 text-muted-foreground hover:text-foreground"
-        style={{ paddingLeft: `${0.6 + depth * 0.8}rem` }}
-        title={node.path}
-      >
-        <Checkbox
-          aria-label={`Sync ${node.name}`}
-          checked={isChecked}
-          onCheckedChange={() => onToggleFile(node.path)}
-        />
-        <FileText className={`${ICON_SM} shrink-0`} />
-        <span className="truncate flex-1">{node.name}</span>
-        <span className="text-sm">{formatSize(node.size)}</span>
-      </div>
-    );
-  }
-
-  const children = Array.isArray(node.children) ? node.children : [];
-  const isRoot = node.path === "";
-  const isExpanded = isRoot || expandedSyncFolders.has(node.path);
-
-  return (
-    <div>
-      {!isRoot && (
-        <div
-          className="w-full rounded-none border border-primary/15 pr-2 py-1.5 text-left text-sm font-terminal flex items-center gap-1 text-muted-foreground hover:text-foreground"
-          style={{ paddingLeft: `${0.45 + depth * 0.8}rem` }}
-          title={node.path}
-        >
-          {children.length > 0 ? (
-            <button
-              type="button"
-              className="p-0.5 hover:text-primary transition-colors"
-              onClick={() => onToggleFolder(node.path)}
-              aria-label={isExpanded ? "Collapse folder" : "Expand folder"}
-            >
-              <ChevronRight
-                className={`${ICON_SM} transition-transform ${isExpanded ? "rotate-90" : "rotate-0"}`}
-              />
-            </button>
-          ) : (
-            <span className="w-4" />
-          )}
-          {isExpanded ? (
-            <FolderOpen className={`${ICON_SM} shrink-0`} />
-          ) : (
-            <Folder className={`${ICON_SM} shrink-0`} />
-          )}
-          <span className="truncate flex-1">{node.name}</span>
-          <span className="text-sm">{children.length}</span>
-        </div>
-      )}
-      {isExpanded &&
-        children.map((child) => (
-          <SyncPreviewTreeNode
-            key={child.path}
-            node={child}
-            depth={isRoot ? depth : depth + 1}
-            selectedSyncFiles={selectedSyncFiles}
-            expandedSyncFolders={expandedSyncFolders}
-            onToggleFile={onToggleFile}
-            onToggleFolder={onToggleFolder}
-          />
-        ))}
-    </div>
-  );
-}
-
 function useLibraryPageController() {
-  const [, setLocation] = useLocation();
   const queryClient = useQueryClient();
   const initialLaunchState = useMemo(() => readInitialLibraryLaunchState(), []);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editTitle, setEditTitle] = useState("");
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
-  const [materialsFolder, setMaterialsFolder] = useState("");
-  const [semesterIntakeFolder, setSemesterIntakeFolder] = useState(
-    DEFAULT_SEMESTER_INTAKE_FOLDER,
-  );
-  const [semesterPreview, setSemesterPreview] =
-    useState<SemesterIntakePreviewResult | null>(null);
-  const [selectedSemesterMaterialFiles, setSelectedSemesterMaterialFiles] =
-    useState<Set<string>>(() => new Set());
-  const [semesterScanLoading, setSemesterScanLoading] = useState(false);
-  const [semesterApplyLoading, setSemesterApplyLoading] = useState(false);
-  const [semesterIntakeError, setSemesterIntakeError] = useState<string | null>(
-    null,
-  );
-  const [addCourseworkMode, setAddCourseworkMode] =
-    useState<AddCourseworkMode>("upload");
+  const [activeLibraryTab, setActiveLibraryTab] =
+    useState<LibraryWorkflowTab>("materials");
+  const [librarySearchQuery, setLibrarySearchQuery] = useState("");
   const [uploadCourseTarget, setUploadCourseTarget] = useState<string>(
     initialLaunchState.uploadCourseTarget,
-  );
-  const [syncCourseTarget, setSyncCourseTarget] = useState<string>(
-    initialLaunchState.syncCourseTarget,
-  );
-  const [syncJobId, setSyncJobId] = useState<string | null>(null);
-  const [syncStatus, setSyncStatus] = useState<TutorSyncJobStatus | null>(null);
-  const [syncing, setSyncing] = useState(false);
-  const [syncPreview, setSyncPreview] = useState<TutorSyncPreviewResult | null>(
-    null,
-  );
-  const [syncPreviewLoading, setSyncPreviewLoading] = useState(false);
-  const [syncPreviewError, setSyncPreviewError] = useState<string | null>(null);
-  const [selectedSyncFiles, setSelectedSyncFiles] = useState<Set<string>>(
-    new Set(),
-  );
-  const [expandedSyncFolders, setExpandedSyncFolders] = useState<Set<string>>(
-    new Set([""]),
   );
   const [reextractingMaterialIds, setReextractingMaterialIds] = useState<
     number[]
@@ -822,7 +642,6 @@ function useLibraryPageController() {
   );
   const [initializedFolderExpansion, setInitializedFolderExpansion] =
     useState(false);
-  const [courseLinkTarget, setCourseLinkTarget] = useState<string>("");
   const [sidebarMode, setSidebarMode] = useState<"folders" | "courses">(
     initialLaunchState.sidebarMode,
   );
@@ -832,13 +651,10 @@ function useLibraryPageController() {
   const [viewingMaterialId, setViewingMaterialId] = useState<number | null>(
     null,
   );
-  const [selectedForTutor, setSelectedForTutor] = useState<number[]>(() =>
-    readTutorSelectedMaterialIds(),
-  );
 
   const { data: materials = [], isLoading } = useQuery<Material[]>({
-    queryKey: ["tutor-materials"],
-    queryFn: () => api.tutor.getMaterials(),
+    queryKey: ["tutor-materials", "include-setup"],
+    queryFn: () => api.tutor.getMaterials({ include_setup: true }),
   });
   const { data: courses = [] } = useQuery<Course[]>({
     queryKey: ["courses-active"],
@@ -963,16 +779,21 @@ function useLibraryPageController() {
 
   const folderTree = useMemo(() => buildFolderTree(materials), [materials]);
   const folderItems = useMemo(() => flattenFolders(folderTree), [folderTree]);
+  const activeFolderItems = folderItems;
+  const activeFolderPathSet = useMemo(
+    () => new Set(activeFolderItems.map((item) => item.path)),
+    [activeFolderItems],
+  );
   const visibleFolderItems = useMemo(
     () =>
-      folderItems.filter((item) => {
+      activeFolderItems.filter((item) => {
         if (item.depth === 0) return true;
         const ancestorPaths = getFolderAncestorPaths(item.path).slice(0, -1);
         return ancestorPaths.every((ancestor) =>
           expandedFolderPaths.has(ancestor),
         );
       }),
-    [folderItems, expandedFolderPaths],
+    [activeFolderItems, expandedFolderPaths],
   );
   const selectedFolderNode = useMemo(
     () => getFolderNode(folderTree, selectedFolderPath),
@@ -997,7 +818,21 @@ function useLibraryPageController() {
     return collectFolderMaterials(selectedFolderNode).sort((a, b) =>
       getMaterialTitle(a).localeCompare(getMaterialTitle(b)),
     );
-  }, [sidebarMode, selectedCourseId, materials, selectedFolderNode]);
+  }, [
+    activeFolderPathSet,
+    selectedFolderPath,
+    selectedFolderNode,
+    selectedCourseId,
+    sidebarMode,
+    materials,
+  ]);
+  const visibleCatalogMaterials = useMemo(
+    () =>
+      visibleMaterials.filter((material) =>
+        materialMatchesLibrarySearch(material, librarySearchQuery),
+      ),
+    [librarySearchQuery, visibleMaterials],
+  );
   const selectedFolderLabel = useMemo(() => {
     if (sidebarMode === "courses") {
       if (selectedCourseId === null) return "All Materials";
@@ -1009,7 +844,6 @@ function useLibraryPageController() {
     }
     return selectedFolderPath || "All Materials";
   }, [sidebarMode, selectedCourseId, contentSources, selectedFolderPath]);
-
   const selectFolderPath = (path: string) => {
     setSelectedFolderPath(path);
     const ancestors = getFolderAncestorPaths(path);
@@ -1021,13 +855,6 @@ function useLibraryPageController() {
     });
   };
 
-  const resetSyncPreviewState = (errorMessage: string | null) => {
-    setSyncPreview(null);
-    setSelectedSyncFiles(new Set());
-    setExpandedSyncFolders(new Set([""]));
-    setSyncPreviewError(errorMessage);
-  };
-
   const handleSidebarModeChange = (mode: "folders" | "courses") => {
     setSidebarMode(mode);
     if (mode === "folders") {
@@ -1037,10 +864,6 @@ function useLibraryPageController() {
     }
   };
 
-  const selectedForTutorSet = useMemo(
-    () => new Set(selectedForTutor),
-    [selectedForTutor],
-  );
   const dupeChecksums = useMemo(() => {
     const counts = new Map<string, number>();
     for (const m of materials) {
@@ -1053,160 +876,27 @@ function useLibraryPageController() {
     }
     return dupes;
   }, [materials]);
-  const defaultVisibleStudyMaterialIds = useMemo(
-    () => visibleMaterials.filter(isDefaultStudyMaterial).map((m) => m.id),
-    [visibleMaterials],
-  );
-  const selectedVisibleMaterialIds = useMemo(
-    () =>
-      visibleMaterials
-        .filter((m) => m.enabled && selectedForTutorSet.has(m.id))
-        .map((m) => m.id),
-    [visibleMaterials, selectedForTutorSet],
-  );
-  const hiddenTutorSelectionCount = Math.max(
-    0,
-    selectedForTutor.length - selectedVisibleMaterialIds.length,
-  );
-  const allTutorMaterialsSelected =
-    defaultVisibleStudyMaterialIds.length > 0 &&
-    defaultVisibleStudyMaterialIds.every((id) => selectedForTutorSet.has(id));
-  const syncPreviewFiles = useMemo(
-    () => collectSyncPreviewFilePaths(syncPreview?.tree),
-    [syncPreview],
-  );
-  const semesterMaterialFiles = useMemo(
-    () => collectSemesterMaterialFilePaths(semesterPreview),
-    [semesterPreview],
-  );
-  const selectedSyncCount = selectedSyncFiles.size;
-  const selectedSemesterMaterialCount = semesterMaterialFiles.filter((path) =>
-    selectedSemesterMaterialFiles.has(path),
-  ).length;
-  const allSyncFilesSelected =
-    syncPreviewFiles.length > 0 &&
-    syncPreviewFiles.every((path) => selectedSyncFiles.has(path));
-  const allSemesterMaterialFilesSelected =
-    semesterMaterialFiles.length > 0 &&
-    semesterMaterialFiles.every((path) =>
-      selectedSemesterMaterialFiles.has(path),
-    );
-
-  useEffect(() => {
-    writeTutorSelectedMaterialIds(selectedForTutor);
-  }, [selectedForTutor]);
-
-  const openTutorWithMaterialIds = (materialIds: number[]) => {
-    if (!materialIds.length) {
-      toast.error("Choose a file for the Current Run before opening Tutor.");
-      return;
-    }
-    const selectedTutorMaterials = materials.filter((material) =>
-      materialIds.includes(material.id),
-    );
-    const selectedCourseIds = Array.from(
-      new Set(
-        selectedTutorMaterials
-          .map((material) => material.course_id)
-          .filter((value): value is number => typeof value === "number" && value > 0),
-      ),
-    );
-    const handoffCourseId =
-      selectedCourseIds.length === 1
-        ? selectedCourseIds[0]
-        : typeof selectedCourseId === "number"
-          ? selectedCourseId
-          : undefined;
-
-    writeTutorSelectedMaterialIds(materialIds);
-    writeTutorStoredStartState({
-      courseId: handoffCourseId,
-      topic: "",
-      selectedMaterials: materialIds,
-      chainId: undefined,
-      customBlockIds: [],
-      accuracyProfile: "strict",
-      objectiveScope: "module_all",
-      selectedObjectiveId: "",
-      selectedObjectiveGroup: "",
-      selectedPaths: [],
-    });
-    try {
-      localStorage.removeItem("tutor.wizard.progress.v1");
-      localStorage.setItem("tutor-studio-last-tab", "workspace");
-    } catch {
-      /* localStorage unavailable — ignore */
-    }
-    try {
-      sessionStorage.setItem("tutor.open_from_library.v1", "1");
-    } catch {
-      /* sessionStorage unavailable — ignore */
-    }
-    setLocation(
-      handoffCourseId
-        ? `/tutor?course_id=${handoffCourseId}`
-        : "/tutor",
-    );
-  };
-
-  const handleOpenTutor = () => {
-    openTutorWithMaterialIds(selectedForTutor);
-  };
-
-  const studyMaterialInTutor = (id: number) => {
-    setSelectedForTutor([id]);
-    openTutorWithMaterialIds([id]);
-  };
-
-  const replaceTutorQueueWithVisible = () => {
-    if (!defaultVisibleStudyMaterialIds.length) {
-      toast.error("No enabled study files are visible in this view.");
-      return;
-    }
-    setSelectedForTutor([...defaultVisibleStudyMaterialIds]);
-    toast.success(
-      `Current Run replaced with ${defaultVisibleStudyMaterialIds.length} study file${defaultVisibleStudyMaterialIds.length === 1 ? "" : "s"}.`,
-    );
-  };
-
-  const addVisibleToTutorQueue = () => {
-    if (!defaultVisibleStudyMaterialIds.length) {
-      toast.error("No enabled study files are visible in this view.");
-      return;
-    }
-    setSelectedForTutor((prev) => {
-      const next = new Set(prev);
-      for (const id of defaultVisibleStudyMaterialIds) next.add(id);
-      return [...next];
-    });
-    toast.success(
-      `Added ${defaultVisibleStudyMaterialIds.length} study file${defaultVisibleStudyMaterialIds.length === 1 ? "" : "s"} to the Current Run.`,
-    );
-  };
-
-  const clearTutorQueue = () => {
-    if (!selectedForTutor.length) return;
-    setSelectedForTutor([]);
-    toast.success("Current Run cleared.");
-  };
-
   useEffect(() => {
     if (isLoading) return;
-    setSelectedForTutor((ids) =>
-      ids.filter((id) => materials.some((m) => m.id === id)),
-    );
     if (
       selectedFolderPath !== ALL_FOLDERS_KEY &&
+      !activeFolderPathSet.has(selectedFolderPath) &&
       !getFolderNode(folderTree, selectedFolderPath)
     ) {
       selectFolderPath(ALL_FOLDERS_KEY);
     }
-  }, [isLoading, materials, selectedFolderPath, folderTree]);
+  }, [
+    activeFolderPathSet,
+    folderTree,
+    isLoading,
+    materials,
+    selectedFolderPath,
+  ]);
 
   useEffect(() => {
     if (initializedFolderExpansion) return;
     // Start with top-level folders expanded so first interaction is not empty.
-    const topLevelPaths = folderItems
+    const topLevelPaths = activeFolderItems
       .filter((item) => item.depth === 0)
       .map((item) => item.path);
     if (!topLevelPaths.length) return;
@@ -1216,145 +906,7 @@ function useLibraryPageController() {
       return next;
     });
     setInitializedFolderExpansion(true);
-  }, [folderItems, initializedFolderExpansion]);
-
-  const handleMaterialsFolderChange = (value: string) => {
-    setMaterialsFolder(value);
-    if (!syncPreview) return;
-    const normalizedPreview = normalizePathForCompare(syncPreview.folder || "");
-    const normalizedCurrent = normalizePathForCompare(value.trim());
-    if (!normalizedCurrent || normalizedPreview === normalizedCurrent) return;
-    resetSyncPreviewState("Folder path changed. Scan the folder again.");
-  };
-
-  const handleSemesterIntakeFolderChange = (value: string) => {
-    setSemesterIntakeFolder(value);
-    if (!semesterPreview) return;
-    const normalizedPreview = normalizePathForCompare(
-      semesterPreview.folder || "",
-    );
-    const normalizedCurrent = normalizePathForCompare(value.trim());
-    if (!normalizedCurrent || normalizedPreview === normalizedCurrent) return;
-    setSelectedSemesterMaterialFiles(new Set());
-  };
-
-  const finalizeSyncStatus = (status: TutorSyncJobStatus) => {
-    setSyncing(false);
-    setSyncJobId(null);
-    queryClient.invalidateQueries({ queryKey: ["tutor-materials"] });
-    queryClient.invalidateQueries({ queryKey: ["tutor-content-sources"] });
-
-    if (status.status === "completed") {
-      const syncCount = Number(
-        status.sync_result?.processed ?? status.processed ?? 0,
-      );
-      const failedCount = Number(
-        status.sync_result?.failed ?? status.errors ?? 0,
-      );
-      const embedResult = status.embed_result as
-        | { embedded?: number }
-        | null
-        | undefined;
-      const embedCount = Number(embedResult?.embedded ?? 0);
-      const embedErrorResult = status.embed_result as
-        | { error?: string }
-        | null
-        | undefined;
-      const embedError = (embedErrorResult?.error || "").trim();
-      if (embedError) {
-        toast.warning(
-          `Sync complete: ${syncCount} processed, ${failedCount} failed. Embedding error: ${embedError}`,
-        );
-      } else if (failedCount > 0) {
-        toast.warning(
-          `Sync complete: ${syncCount} processed, ${failedCount} failed${embedCount > 0 ? `, ${embedCount} embedded` : ""}`,
-        );
-      } else {
-        toast.success(`Synced ${syncCount} materials, embedded ${embedCount}`);
-      }
-      return;
-    }
-
-    toast.error(`Sync failed: ${status.last_error || "Unknown error"}`);
-  };
-
-  const handleSyncPollingFailure = (errorMessage: string) => {
-    setSyncing(false);
-    setSyncJobId(null);
-    toast.error(`Sync status failed after retries: ${errorMessage}`);
-  };
-
-  useEffect(() => {
-    if (!syncJobId) return;
-
-    let cancelled = false;
-    let transientFailures = 0;
-    let pollTimeoutId: number | null = null;
-
-    const scheduleNextPoll = () => {
-      if (cancelled) return;
-      if (pollTimeoutId !== null) {
-        window.clearTimeout(pollTimeoutId);
-      }
-      pollTimeoutId = window.setTimeout(pollSyncStatus, 1500);
-    };
-
-    const pollSyncStatus = async () => {
-      try {
-        const status = await api.tutor.getSyncMaterialsStatus(syncJobId);
-        if (cancelled) return;
-        transientFailures = 0;
-        setSyncStatus(status);
-
-        if (status.status === "completed" || status.status === "failed") {
-          finalizeSyncStatus(status);
-          return;
-        }
-      } catch (err) {
-        if (cancelled) return;
-        transientFailures += 1;
-        if (transientFailures < 5) {
-          scheduleNextPoll();
-          return;
-        }
-        handleSyncPollingFailure(
-          err instanceof Error ? err.message : "Unknown",
-        );
-        return;
-      }
-
-      scheduleNextPoll();
-    };
-
-    pollSyncStatus();
-
-    return () => {
-      cancelled = true;
-      if (pollTimeoutId !== null) {
-        window.clearTimeout(pollTimeoutId);
-      }
-    };
-  }, [syncJobId, queryClient]);
-
-  const toggleMaterialForTutor = (id: number) => {
-    setSelectedForTutor((prev) => {
-      if (prev.includes(id)) return prev.filter((x) => x !== id);
-      return [...prev, id];
-    });
-  };
-
-  const toggleAllMaterialsForTutor = () => {
-    setSelectedForTutor((prev) => {
-      if (!defaultVisibleStudyMaterialIds.length) return prev;
-      const next = new Set(prev);
-      if (allTutorMaterialsSelected) {
-        for (const id of defaultVisibleStudyMaterialIds) next.delete(id);
-      } else {
-        for (const id of defaultVisibleStudyMaterialIds) next.add(id);
-      }
-      return [...next];
-    });
-  };
+  }, [activeFolderItems, initializedFolderExpansion]);
 
   const toggleFolderExpanded = (path: string) => {
     const isCollapsing = expandedFolderPaths.has(path);
@@ -1377,20 +929,6 @@ function useLibraryPageController() {
     ) {
       selectFolderPath(ALL_FOLDERS_KEY);
     }
-  };
-
-  const handleLinkSelectedToCourse = () => {
-    const targetCourseId = Number(courseLinkTarget);
-    if (
-      !targetCourseId ||
-      !selectedVisibleMaterialIds.length ||
-      courseLinkMutation.isPending
-    )
-      return;
-    courseLinkMutation.mutate({
-      ids: [...selectedVisibleMaterialIds],
-      courseId: targetCourseId,
-    });
   };
 
   const updateMutation = useMutation({
@@ -1428,82 +966,6 @@ function useLibraryPageController() {
     },
   });
 
-  const clearMaterialsMutation = useMutation({
-    mutationFn: async (ids: number[]) => {
-      const results = await Promise.allSettled(
-        ids.map((id) => api.tutor.deleteMaterial(id)),
-      );
-      const failed = results.filter((r) => r.status === "rejected").length;
-      return {
-        deleted: ids.length - failed,
-        failed,
-        total: ids.length,
-      };
-    },
-    onSuccess: ({ deleted, failed, total }, ids) => {
-      queryClient.invalidateQueries({ queryKey: ["tutor-materials"] });
-      queryClient.invalidateQueries({ queryKey: ["tutor-content-sources"] });
-      setSelectedForTutor((prev) => prev.filter((id) => !ids.includes(id)));
-      if (failed > 0) {
-        toast.warning(
-          `${deleted}/${total} materials deleted; ${failed} failed. Some files may still remain.`,
-        );
-      } else {
-        toast.success(`Deleted ${deleted} materials`);
-      }
-    },
-    onError: (err) => {
-      toast.error(
-        `Clear failed: ${err instanceof Error ? err.message : "Unknown"}`,
-      );
-    },
-  });
-
-  const courseLinkMutation = useMutation({
-    mutationFn: async ({
-      ids,
-      courseId,
-    }: {
-      ids: number[];
-      courseId: number;
-    }) => {
-      let failed = 0;
-      for (const id of ids) {
-        try {
-          await api.tutor.updateMaterial(id, { course_id: courseId });
-        } catch {
-          failed += 1;
-        }
-      }
-      return {
-        linked: ids.length - failed,
-        failed,
-        total: ids.length,
-        courseId,
-      };
-    },
-    onSuccess: ({ linked, failed, total, courseId }) => {
-      const targetCourse = courses.find((course) => course.id === courseId);
-      const courseLabel =
-        targetCourse?.code || targetCourse?.name || `Course ${courseId}`;
-      queryClient.invalidateQueries({ queryKey: ["tutor-materials"] });
-      queryClient.invalidateQueries({ queryKey: ["tutor-content-sources"] });
-      setCourseLinkTarget("");
-      if (failed > 0) {
-        toast.warning(
-          `${linked}/${total} materials linked to ${courseLabel}; ${failed} failed.`,
-        );
-      } else {
-        toast.success(`Linked ${linked} materials to ${courseLabel}`);
-      }
-    },
-    onError: (err) => {
-      toast.error(
-        `Course link failed: ${err instanceof Error ? err.message : "Unknown"}`,
-      );
-    },
-  });
-
   const startEdit = (mat: Material) => {
     setEditingId(mat.id);
     setEditTitle(getMaterialTitle(mat));
@@ -1516,249 +978,6 @@ function useLibraryPageController() {
 
   const toggleEnabled = (mat: Material) => {
     updateMutation.mutate({ id: mat.id, data: { enabled: !mat.enabled } });
-  };
-
-  const toggleSyncFolderExpanded = (path: string) => {
-    if (!path) return;
-    setExpandedSyncFolders((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) {
-        for (const expandedPath of Array.from(next)) {
-          if (expandedPath === path || expandedPath.startsWith(`${path}/`)) {
-            next.delete(expandedPath);
-          }
-        }
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
-  };
-
-  const toggleSyncFile = (path: string) => {
-    setSelectedSyncFiles((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
-  };
-
-  const selectAllSyncFiles = (selectAll: boolean) => {
-    setSelectedSyncFiles(selectAll ? new Set(syncPreviewFiles) : new Set());
-  };
-
-  const toggleSemesterMaterialFile = (path: string) => {
-    setSelectedSemesterMaterialFiles((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
-  };
-
-  const selectAllSemesterMaterialFiles = (selectAll: boolean) => {
-    setSelectedSemesterMaterialFiles(
-      selectAll ? new Set(semesterMaterialFiles) : new Set(),
-    );
-  };
-
-  const scanSemesterIntakeFolder = async () => {
-    const trimmedFolder = semesterIntakeFolder.trim();
-    if (!trimmedFolder || semesterScanLoading || semesterApplyLoading) return;
-
-    setSemesterScanLoading(true);
-    setSemesterIntakeError(null);
-    try {
-      const preview = await api.semesterIntake.preview({
-        folder_path: trimmedFolder,
-      });
-      setSemesterPreview(preview);
-      setSelectedSemesterMaterialFiles(new Set());
-      if (!preview.courses.length) {
-        toast.warning("Semester intake found no course folders.");
-      } else {
-        toast.success(`Found ${preview.courses.length} course folders.`);
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown";
-      setSemesterPreview(null);
-      setSelectedSemesterMaterialFiles(new Set());
-      setSemesterIntakeError(message);
-      toast.error(`Semester intake scan failed: ${message}`);
-    } finally {
-      setSemesterScanLoading(false);
-    }
-  };
-
-  const applySemesterIntake = async () => {
-    const trimmedFolder = semesterIntakeFolder.trim();
-    if (!trimmedFolder || semesterApplyLoading || semesterScanLoading) return;
-    if (!semesterPreview) {
-      toast.error("Scan the semester folder first.");
-      return;
-    }
-    if (
-      normalizePathForCompare(semesterPreview.folder) !==
-      normalizePathForCompare(trimmedFolder)
-    ) {
-      toast.error("Folder path changed. Re-scan before applying setup.");
-      return;
-    }
-
-    const coursesToApply = semesterPreview.courses.map((course) => ({
-      name: course.name,
-      code: course.code ?? null,
-      folder_path: course.folder_path,
-      syllabus_files: course.syllabus_files.map((file) => file.path),
-      schedule_files: course.schedule_files.map((file) => file.path),
-      material_files: course.material_files
-        .filter((file) => selectedSemesterMaterialFiles.has(file.path))
-        .map((file) => file.path),
-      syllabus: { modules: [] },
-      schedule: { events: [] },
-    }));
-    if (!coursesToApply.length) {
-      toast.error("No course folders are ready to apply.");
-      return;
-    }
-
-    setSemesterApplyLoading(true);
-    setSemesterIntakeError(null);
-    try {
-      const result = await api.semesterIntake.apply({
-        folder_path: trimmedFolder,
-        courses: coursesToApply,
-      });
-      queryClient.invalidateQueries({ queryKey: ["courses-active"] });
-      queryClient.invalidateQueries({ queryKey: ["courses-all"] });
-      queryClient.invalidateQueries({ queryKey: ["tutor-materials"] });
-      queryClient.invalidateQueries({ queryKey: ["tutor-content-sources"] });
-      queryClient.invalidateQueries({ queryKey: ["tutor-embed-status"] });
-      queryClient.invalidateQueries({ queryKey: ["tutor-hub"] });
-      toast.success(
-        `Semester setup applied: ${result.coursesCreated} created, ${result.coursesUpdated} updated, ${result.modulesCreated} modules, ${result.eventsCreated} events, ${result.materialSyncJobs.length} sync job${result.materialSyncJobs.length === 1 ? "" : "s"} started.`,
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown";
-      setSemesterIntakeError(message);
-      toast.error(`Semester setup failed: ${message}`);
-    } finally {
-      setSemesterApplyLoading(false);
-    }
-  };
-
-  const scanSyncFolder = async () => {
-    const trimmedFolder = materialsFolder.trim();
-    if (!trimmedFolder || syncPreviewLoading || syncing) return;
-
-    setSyncPreviewLoading(true);
-    setSyncPreviewError(null);
-
-    try {
-      const preview = await api.tutor.previewSyncMaterialsFolder({
-        folder_path: trimmedFolder,
-      });
-      const discoveredFiles = collectSyncPreviewFilePaths(preview.tree);
-      const topLevelFolderPaths = (preview.tree.children || [])
-        .filter((child) => child.type === "folder")
-        .map((child) => child.path);
-      setSyncPreview(preview);
-      setSelectedSyncFiles(new Set());
-      setExpandedSyncFolders(new Set(["", ...topLevelFolderPaths]));
-      if (!discoveredFiles.length) {
-        setSyncPreviewError("No supported files found in this folder.");
-        toast.warning("Folder scanned: no supported files found.");
-      } else if (preview.truncated) {
-        setSyncPreviewError(
-          `Preview limited to first ${preview.max_files || 5000} files. Select from displayed files.`,
-        );
-        toast.warning(
-          `Preview loaded with ${discoveredFiles.length} files (truncated).`,
-        );
-      } else {
-        setSyncPreviewError(null);
-        toast.success(`Scanned ${discoveredFiles.length} files.`);
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Unknown";
-      setSyncPreview(null);
-      setSelectedSyncFiles(new Set());
-      setExpandedSyncFolders(new Set([""]));
-      setSyncPreviewError(message);
-      toast.error(`Folder scan failed: ${message}`);
-    } finally {
-      setSyncPreviewLoading(false);
-    }
-  };
-
-  const startSync = async () => {
-    const trimmedFolder = materialsFolder.trim();
-    if (!trimmedFolder || syncing || syncPreviewLoading) return;
-    if (!syncPreview) {
-      toast.error("Scan the folder first so you can choose files.");
-      return;
-    }
-    if (
-      normalizePathForCompare(syncPreview.folder) !==
-      normalizePathForCompare(trimmedFolder)
-    ) {
-      toast.error("Folder path changed. Re-scan before syncing.");
-      return;
-    }
-    const selectedFiles = syncPreviewFiles.filter((path) =>
-      selectedSyncFiles.has(path),
-    );
-    if (!selectedFiles.length) {
-      toast.error("Choose at least one file to sync.");
-      return;
-    }
-    const parsedCourseId = syncCourseTarget ? Number(syncCourseTarget) : null;
-    const courseId =
-      parsedCourseId && Number.isFinite(parsedCourseId) ? parsedCourseId : null;
-
-    setSyncing(true);
-    setSyncStatus({
-      job_id: "pending",
-      status: "pending",
-      phase: "pending",
-      processed: 0,
-      total: 0,
-      index: 0,
-      current_file: null,
-      errors: 0,
-      started_at: new Date().toISOString(),
-    });
-
-    try {
-      const started = await api.tutor.startSyncMaterialsFolder({
-        folder_path: trimmedFolder,
-        selected_files: selectedFiles,
-        course_id: courseId,
-      });
-      setSyncJobId(started.job_id);
-      setSyncStatus((prev) =>
-        prev
-          ? { ...prev, job_id: started.job_id, folder: started.folder }
-          : prev,
-      );
-      toast.success(
-        `Sync started for ${selectedFiles.length} file${selectedFiles.length === 1 ? "" : "s"}`,
-      );
-    } catch (err) {
-      setSyncing(false);
-      setSyncJobId(null);
-      setSyncStatus(null);
-      toast.error(
-        `Sync failed: ${err instanceof Error ? err.message : "Unknown"}`,
-      );
-    }
   };
 
   const reextractMaterial = async (materialId: number) => {
@@ -1790,22 +1009,20 @@ function useLibraryPageController() {
     }
   };
 
-  const syncProgressPercent = useMemo(() => {
-    if (!syncStatus) return 0;
-    const total = Number(syncStatus.total ?? 0);
-    const indexed = Number(syncStatus.index ?? syncStatus.processed ?? 0);
-    if (!Number.isFinite(total) || total <= 0) return 0;
-    return Math.max(0, Math.min(100, Math.round((indexed / total) * 100)));
-  }, [syncStatus]);
+  const showSourceTab = activeLibraryTab === "upload";
+  const showMaterialsTab = activeLibraryTab === "materials";
+  const materialSectionTitle = "LIBRARY FILES";
+  const visibleTabFileCount = visibleCatalogMaterials.length;
+  const visibleTabFileLabel = "file";
 
   return (
     <PageScaffold
       eyebrow="Library Support System"
       title="Materials Library"
-      subtitle="Brain-owned study materials, Tutor scope, and clean handoff into live study all run through one intake surface."
+      subtitle="A searchable catalog of uploaded course files. Upload, find, rename, view, and organize coursework in one place."
       className="flex h-full min-h-[72vh] flex-col"
       contentClassName="flex-1 min-h-0"
-      heroClassName="library-page-hero"
+      heroClassName="library-page-hero library-page-hero--compact"
       stats={[
         {
           label: "Embeddings",
@@ -1824,7 +1041,7 @@ function useLibraryPageController() {
         },
       ]}
     >
-      <div className="brain-workspace brain-workspace--ready app-workspace-shell library-ops-workspace relative flex-1 min-h-[70vh] w-full overflow-hidden">
+      <div className="brain-workspace brain-workspace--ready app-workspace-shell library-ops-workspace library-ops-workspace--calm relative flex-1 min-h-[70vh] w-full overflow-hidden">
         <div className="flex flex-col lg:flex-row h-full min-h-0">
           <aside className="brain-workspace__sidebar-wrap w-full lg:w-80 shrink-0 min-h-0 max-h-[40vh] lg:max-h-none lg:pr-3">
             <HudPanel
@@ -1880,6 +1097,17 @@ function useLibraryPageController() {
                     COURSES
                   </HudButton>
                 </div>
+                {sidebarMode === "folders" ? (
+                  <div className="mt-3 rounded-[0.85rem] border border-primary/15 bg-black/35 p-2">
+                    <div className="min-w-0">
+                      <div className={LIBRARY_SECTION_LABEL}>FOLDERS</div>
+                      <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
+                        Shows folders from files already uploaded into the
+                        Library catalog.
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
               </div>
               <div className="flex-1 overflow-y-auto p-2 space-y-1">
                 {sidebarMode === "folders" ? (
@@ -1895,7 +1123,9 @@ function useLibraryPageController() {
                     >
                       <FolderOpen className={ICON_SM} />
                       <span className="truncate flex-1">All Materials</span>
-                      <span className="text-sm">{materials.length}</span>
+                      <span className="text-sm">
+                        {materials.length}
+                      </span>
                     </button>
                     {visibleFolderItems.map((folder) => {
                       const isSelected = selectedFolderPath === folder.path;
@@ -1968,9 +1198,9 @@ function useLibraryPageController() {
                         </div>
                       );
                     })}
-                    {!folderItems.length && materials.length === 0 ? (
+                    {!activeFolderItems.length && materials.length === 0 ? (
                       <div className={`${TEXT_MUTED} px-2 py-3 text-sm`}>
-                        Sync a folder or upload files to populate this rail.
+                        Upload files to populate this rail.
                       </div>
                     ) : null}
                   </>
@@ -2008,7 +1238,11 @@ function useLibraryPageController() {
                                   ? "text-primary"
                                   : "text-muted-foreground hover:text-foreground"
                               }`}
-                              onClick={() => setSelectedCourseId(course.id!)}
+                              onClick={() => {
+                                const nextId = course.id!;
+                                setSelectedCourseId(nextId);
+                                setUploadCourseTarget(String(nextId));
+                              }}
                               type="button"
                             >
                               <GraduationCap className={ICON_SM} />
@@ -2126,54 +1360,63 @@ function useLibraryPageController() {
 
               <section className="brain-workspace__main-wrap brain-workspace__canvas flex-1 min-h-0 flex flex-col overflow-hidden">
             <HudPanel className="library-main-panel flex h-full min-h-0 flex-col overflow-hidden">
+              <div className={`${PANEL_PADDING} border-b border-primary/10 bg-black/25`}>
+                <div
+                  className="library-segmented-control library-workflow-tabs grid grid-cols-2 gap-1 p-1"
+                  aria-label="Library workflow"
+                  role="tablist"
+                >
+                  {[
+                    ["materials", "ALL FILES"],
+                    ["upload", "UPLOAD"],
+                  ].map(([tab, label]) => (
+                    <HudButton
+                      key={tab}
+                      type="button"
+                      role="tab"
+                      aria-selected={activeLibraryTab === tab}
+                      variant={
+                        activeLibraryTab === tab ? "primary" : "outline"
+                      }
+                      className={cn(
+                        "min-h-[38px] px-3",
+                        activeLibraryTab === tab
+                          ? "bg-primary/20 text-primary"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                      onClick={() =>
+                        setActiveLibraryTab(tab as LibraryWorkflowTab)
+                      }
+                    >
+                      {label}
+                    </HudButton>
+                  ))}
+                </div>
+              </div>
               <div className="border-b border-primary/10 bg-transparent">
                 <div
                   className={`${PANEL_PADDING} space-y-3`}
                 >
+                  {showSourceTab ? (
                   <HudPanel
                     variant="b"
                     className={`${LIBRARY_PANEL_SURFACE} p-3`}
                   >
                     <div className="flex flex-col gap-3 2xl:flex-row 2xl:items-center 2xl:justify-between">
                       <div className="min-w-0">
-                        <div className={LIBRARY_SECTION_LABEL}>ADD COURSEWORK</div>
+                        <div className={LIBRARY_SECTION_LABEL}>UPLOAD FILES</div>
                         <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
-                          Choose the files you want for this study run. Intake
-                          and sync stay available for setup and selective import.
+                          Add one-off files from Downloads, email, Blackboard,
+                          or your course folders. Library stores and extracts
+                          each file so it stays searchable.
                         </div>
-                      </div>
-                      <div className="library-segmented-control grid grid-cols-3 gap-1 p-1">
-                        {[
-                          ["upload", "CHOOSE FILES"],
-                          ["intake", "SEMESTER INTAKE"],
-                          ["sync", "FOLDER SYNC"],
-                        ].map(([mode, label]) => (
-                          <HudButton
-                            key={mode}
-                            type="button"
-                            variant={
-                              addCourseworkMode === mode ? "primary" : "outline"
-                            }
-                            className={cn(
-                              "min-h-[38px] px-3",
-                              addCourseworkMode === mode
-                                ? "bg-primary/20 text-primary"
-                                : "text-muted-foreground hover:text-foreground",
-                            )}
-                            onClick={() =>
-                              setAddCourseworkMode(mode as AddCourseworkMode)
-                            }
-                          >
-                            {label}
-                          </HudButton>
-                        ))}
                       </div>
                     </div>
                     <div className="mt-3 grid gap-2 md:grid-cols-3">
                       {[
-                        ["STUDY MATERIALS", "Pick weekly files manually."],
-                        ["COURSE SETUP", "Syllabus and schedule readiness."],
-                        ["CURRENT RUN", "Study one file or a small set."],
+                        ["CATALOG", "Uploaded files become searchable Library records."],
+                        ["COURSE LINK", "Choose a course when you know where a file belongs."],
+                        ["AVAILABLE LATER", "Keep the file organized here for future study."],
                       ].map(([label, copy]) => (
                         <div
                           key={label}
@@ -2189,218 +1432,21 @@ function useLibraryPageController() {
                       ))}
                     </div>
                   </HudPanel>
-
-                  <div className="grid gap-3 2xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.42fr)]">
-                  {addCourseworkMode === "intake" ? (
-                  <HudPanel
-                    variant="b"
-                    className={`${LIBRARY_PANEL_SURFACE} space-y-2 p-3`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <GraduationCap className={ICON_SM} />
-                      <div className={LIBRARY_PANEL_TITLE}>SEMESTER INTAKE</div>
-                    </div>
-                    <div className={LIBRARY_HELP_TEXT}>
-                      Start from one PT School folder, separate course setup
-                      files from study materials, then create the Study courses.
-                    </div>
-                    <input
-                      aria-label="Semester intake folder"
-                      value={semesterIntakeFolder}
-                      onChange={(e) =>
-                        handleSemesterIntakeFolderChange(e.target.value)
-                      }
-                      className={INPUT_BASE}
-                      placeholder="Paste the semester folder path"
-                    />
-                    <div className="flex flex-wrap items-center gap-2">
-                      <HudButton
-                        variant="outline"
-                        onClick={scanSemesterIntakeFolder}
-                        disabled={
-                          semesterScanLoading ||
-                          semesterApplyLoading ||
-                          !semesterIntakeFolder.trim()
-                        }
-                        className={LIBRARY_COMPACT_BUTTON}
-                      >
-                        {semesterScanLoading ? (
-                          <Loader2 className={`${ICON_SM} animate-spin mr-1`} />
-                        ) : (
-                          <RefreshCw className={`${ICON_SM} mr-1`} />
-                        )}
-                        {semesterScanLoading ? "SCANNING..." : "SCAN INTAKE"}
-                      </HudButton>
-                      <HudButton
-                        onClick={applySemesterIntake}
-                        disabled={
-                          semesterScanLoading ||
-                          semesterApplyLoading ||
-                          !semesterPreview ||
-                          !semesterIntakeFolder.trim()
-                        }
-                        className={LIBRARY_COMPACT_BUTTON}
-                      >
-                        {semesterApplyLoading ? (
-                          <Loader2 className={`${ICON_SM} animate-spin mr-1`} />
-                        ) : (
-                          <Check className={`${ICON_SM} mr-1`} />
-                        )}
-                        APPLY SETUP + SELECTED FILES
-                      </HudButton>
-                    </div>
-                    {semesterPreview ? (
-                      <div className="space-y-2">
-                        <div className="grid grid-cols-2 gap-2">
-                          <div className="border border-primary/15 bg-black/30 p-2">
-                            <div className={TEXT_MUTED}>Courses</div>
-                            <div className="font-terminal text-base text-foreground">
-                              {semesterPreview.counts.courses}
-                            </div>
-                          </div>
-                          <div className="border border-primary/15 bg-black/30 p-2">
-                            <div className={TEXT_MUTED}>Materials</div>
-                            <div className="font-terminal text-base text-foreground">
-                              {semesterPreview.counts.material_files}
-                            </div>
-                          </div>
-                          <div className="border border-primary/15 bg-black/30 p-2">
-                            <div className={TEXT_MUTED}>Syllabus</div>
-                            <div className="font-terminal text-base text-foreground">
-                              {semesterPreview.counts.syllabus_files}
-                            </div>
-                          </div>
-                          <div className="border border-primary/15 bg-black/30 p-2">
-                            <div className={TEXT_MUTED}>Schedule</div>
-                            <div className="font-terminal text-base text-foreground">
-                              {semesterPreview.counts.schedule_files}
-                            </div>
-                          </div>
-                        </div>
-                        <div className="flex flex-wrap items-center justify-between gap-2 border border-primary/10 bg-black/45 p-2 text-sm">
-                          <div className={TEXT_MUTED}>
-                            {selectedSemesterMaterialCount} selected for
-                            Library
-                            {semesterMaterialFiles.length
-                              ? ` / ${semesterMaterialFiles.length} found`
-                              : ""}
-                          </div>
-                          <HudButton
-                            variant="outline"
-                            className={LIBRARY_INLINE_BUTTON}
-                            disabled={!semesterMaterialFiles.length}
-                            onClick={() =>
-                              selectAllSemesterMaterialFiles(
-                                !allSemesterMaterialFilesSelected,
-                              )
-                            }
-                          >
-                            {allSemesterMaterialFilesSelected
-                              ? "CLEAR MATERIALS"
-                              : "SELECT MATERIALS"}
-                          </HudButton>
-                        </div>
-                        <div className="max-h-40 overflow-auto border border-primary/15 bg-black/30 p-2 space-y-1">
-                          {semesterPreview.courses.map((course) => (
-                            <div
-                              key={course.folder_path}
-                              className="border border-primary/10 bg-black/35 p-2 text-sm"
-                            >
-                              <div className="flex items-start justify-between gap-2">
-                                <div className="min-w-0">
-                                  <div className="truncate font-terminal text-base text-foreground">
-                                    {course.name}
-                                  </div>
-                                  <div className={TEXT_MUTED}>
-                                    {course.syllabus_files.length} syllabus /{" "}
-                                    {course.schedule_files.length} schedule /{" "}
-                                    {course.material_files.length} material
-                                  </div>
-                                </div>
-                                <Badge
-                                  variant="outline"
-                                  className="shrink-0 rounded-none border-primary/25 bg-primary/10 text-sm uppercase"
-                                >
-                                  {course.readiness.course}
-                                </Badge>
-                              </div>
-                              {course.material_files.length ? (
-                                <div className="mt-2 space-y-1">
-                                  {course.material_files.map((file) => {
-                                    const checked =
-                                      selectedSemesterMaterialFiles.has(
-                                        file.path,
-                                      );
-                                    return (
-                                      <div
-                                        key={file.path}
-                                        className="flex items-center gap-2 border border-primary/10 bg-black/35 px-2 py-1.5 font-terminal text-sm text-muted-foreground"
-                                        title={file.path}
-                                      >
-                                        <Checkbox
-                                          aria-label={`Load ${file.name} from ${course.name}`}
-                                          checked={checked}
-                                          onCheckedChange={() =>
-                                            toggleSemesterMaterialFile(
-                                              file.path,
-                                            )
-                                          }
-                                        />
-                                        <FileText
-                                          className={`${ICON_SM} shrink-0`}
-                                        />
-                                        <span className="min-w-0 flex-1 truncate">
-                                          {file.name}
-                                        </span>
-                                        <span className="text-ui-xs">
-                                          {formatSize(file.size)}
-                                        </span>
-                                      </div>
-                                    );
-                                  })}
-                                </div>
-                              ) : null}
-                            </div>
-                          ))}
-                        </div>
-                        {semesterPreview.global_schedule_files.length ||
-                        semesterPreview.ignored_files.length ? (
-                          <div className={LIBRARY_HELP_TEXT}>
-                            Global schedules:{" "}
-                            {semesterPreview.global_schedule_files.length} /
-                            ignored: {semesterPreview.ignored_files.length}
-                          </div>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <div
-                        className={`${LIBRARY_HELP_TEXT} border border-primary/10 bg-black/45 p-3`}
-                      >
-                        Scan the semester folder before applying setup.
-                      </div>
-                    )}
-                    {semesterIntakeError ? (
-                      <div className="text-sm text-yellow-300 break-all">
-                        <AlertTriangle className={`${ICON_SM} inline mr-1`} />
-                        {semesterIntakeError}
-                      </div>
-                    ) : null}
-                  </HudPanel>
                   ) : null}
 
-                  {addCourseworkMode === "upload" ? (
+                  {showSourceTab ? (
                   <HudPanel
                     variant="b"
                     className={`${LIBRARY_PANEL_SURFACE} space-y-2 p-3`}
                   >
                     <div className="flex items-center gap-2">
                       <Upload className={ICON_SM} />
-                      <div className={LIBRARY_PANEL_TITLE}>UPLOAD MATERIALS</div>
+                      <div className={LIBRARY_PANEL_TITLE}>UPLOAD FILES</div>
                     </div>
                     <div className={LIBRARY_HELP_TEXT}>
-                      Use this for one-off files from Downloads, email, or
-                      Blackboard. Upload puts the file into the Tutor library
-                      immediately.
+                      Upload files into the Library catalog. Syllabus,
+                      schedule, slides, readings, notes, and recordings all
+                      land here as searchable file records.
                     </div>
                     <div className="flex items-center gap-2">
                       <label
@@ -2430,475 +1476,51 @@ function useLibraryPageController() {
                         uploadCourseTarget
                           ? Number(uploadCourseTarget)
                           : undefined
-                        }
-                    />
-                  </HudPanel>
-                  ) : null}
-
-                  {addCourseworkMode === "sync" ? (
-                  <HudPanel
-                    variant="b"
-                    className={`${LIBRARY_PANEL_SURFACE} space-y-2 p-3`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <FolderOpen className={ICON_SM} />
-                      <div className={LIBRARY_PANEL_TITLE}>SYNC STUDY FOLDER</div>
-                    </div>
-                    <div className={LIBRARY_HELP_TEXT}>
-                      Use this for a whole course or week folder. Scan first,
-                      choose files, then sync only the files you want in the
-                      Tutor library.
-                    </div>
-                    <input
-                      value={materialsFolder}
-                      onChange={(e) =>
-                        handleMaterialsFolderChange(e.target.value)
                       }
-                      className={INPUT_BASE}
-                      placeholder="Paste the local PT School folder path"
+                      role="study"
                     />
-                    <div className="flex flex-wrap items-center gap-2">
-                      <HudButton
-                        variant="outline"
-                        onClick={scanSyncFolder}
-                        disabled={
-                          syncPreviewLoading ||
-                          syncing ||
-                          !materialsFolder.trim()
-                        }
-                        className={LIBRARY_COMPACT_BUTTON}
-                      >
-                        {syncPreviewLoading ? (
-                          <Loader2 className={`${ICON_SM} animate-spin mr-1`} />
-                        ) : (
-                          <RefreshCw className={`${ICON_SM} mr-1`} />
-                        )}
-                        {syncPreviewLoading
-                          ? "SCANNING..."
-                          : "SCAN FOLDER TREE"}
-                      </HudButton>
-                      <HudButton
-                        onClick={startSync}
-                        disabled={
-                          syncing ||
-                          syncPreviewLoading ||
-                          !materialsFolder.trim() ||
-                          selectedSyncCount === 0
-                        }
-                        className={LIBRARY_COMPACT_BUTTON}
-                      >
-                        {syncing ? (
-                          <Loader2 className={`${ICON_SM} animate-spin mr-1`} />
-                        ) : (
-                          <RefreshCw className={`${ICON_SM} mr-1`} />
-                        )}
-                        SYNC SELECTED FILES
-                      </HudButton>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <label
-                        htmlFor="library-sync-course-target"
-                        className={`${LIBRARY_HELP_TEXT} whitespace-nowrap`}
-                      >
-                        Link synced files to course
-                      </label>
-                      <select
-                        id="library-sync-course-target"
-                        aria-label="Sync course"
-                        value={syncCourseTarget}
-                        onChange={(e) => setSyncCourseTarget(e.target.value)}
-                        className={cn(LIBRARY_SELECT, "flex-1")}
-                      >
-                        <option value="">No class</option>
-                        {courses.map((course) => (
-                          <option key={course.id} value={String(course.id)}>
-                            {course.name}
-                            {course.code ? ` (${course.code})` : ""}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    {syncPreview ? (
-                      <HudPanel
-                        variant="b"
-                        className="space-y-2 bg-black/35 p-2"
-                      >
-                        <div className="flex flex-wrap items-center justify-between gap-2">
-                          <div className={TEXT_MUTED}>
-                            {syncPreview.counts.files} file
-                            {syncPreview.counts.files === 1 ? "" : "s"} found •{" "}
-                            {selectedSyncCount} selected
-                          </div>
-                          <div className="flex items-center gap-1">
-                            <HudButton
-                              variant="outline"
-                              className={LIBRARY_INLINE_BUTTON}
-                              disabled={!syncPreviewFiles.length}
-                              onClick={() =>
-                                selectAllSyncFiles(!allSyncFilesSelected)
-                              }
-                            >
-                              {allSyncFilesSelected
-                                ? "CLEAR ALL"
-                                : "SELECT ALL"}
-                            </HudButton>
-                          </div>
-                        </div>
-                        <div className="max-h-48 overflow-auto border border-primary/15 bg-black/30 p-1 space-y-1">
-                          <SyncPreviewTreeNode
-                            node={syncPreview.tree}
-                            selectedSyncFiles={selectedSyncFiles}
-                            expandedSyncFolders={expandedSyncFolders}
-                            onToggleFile={toggleSyncFile}
-                            onToggleFolder={toggleSyncFolderExpanded}
-                          />
-                        </div>
-                      </HudPanel>
-                    ) : (
-                      <HudPanel
-                        variant="b"
-                        className={`${LIBRARY_HELP_TEXT} bg-black/45 p-3`}
-                      >
-                        <div>0 selected</div>
-                        <div>
-                          Scan the folder to browse your structure and choose
-                          files.
-                        </div>
-                      </HudPanel>
-                    )}
-                    {syncPreviewError ? (
-                      <div className="text-sm text-yellow-300 break-all">
-                        <AlertTriangle className={`${ICON_SM} inline mr-1`} />
-                        {syncPreviewError}
-                      </div>
-                    ) : null}
-                    {(syncing || syncStatus) && (
-                      <div className="mt-1 border border-primary/10 bg-black/45 p-3 space-y-1 text-sm">
-                        <div className="flex items-center justify-between">
-                          <span className={TEXT_MUTED}>Status</span>
-                          <span className="font-terminal !text-white uppercase">
-                            {syncStatus?.status ||
-                              (syncing ? "running" : "idle")}
-                          </span>
-                        </div>
-                        <div className="h-2 w-full bg-primary/15 overflow-hidden">
-                          <div
-                            className="h-full bg-primary transition-all duration-300"
-                            style={{ width: `${syncProgressPercent}%` }}
-                          />
-                        </div>
-                        <div className={TEXT_MUTED}>
-                          Processed {syncStatus?.processed ?? 0} /{" "}
-                          {syncStatus?.total ?? 0} files
-                          {typeof syncStatus?.errors === "number"
-                            ? ` • errors ${syncStatus.errors}`
-                            : ""}
-                        </div>
-                        <div className={`${TEXT_MUTED} break-all`}>
-                          Current:{" "}
-                          <span className="!text-white">
-                            {syncStatus?.current_file ||
-                              (syncing ? "Scanning files..." : "Idle")}
-                          </span>
-                        </div>
-                        {syncStatus?.last_error ? (
-                          <div className="text-red-300 break-all">
-                            {syncStatus.last_error}
-                          </div>
-                        ) : null}
-                        {(
-                          syncStatus?.sync_result?.errors as
-                            | string[]
-                            | undefined
-                        )?.length ? (
-                          <details className="mt-1">
-                            <summary className="text-red-400 cursor-pointer text-sm font-terminal">
-                              {
-                                (syncStatus!.sync_result!.errors as string[])
-                                  .length
-                              }{" "}
-                              file error
-                              {(syncStatus!.sync_result!.errors as string[])
-                                .length > 1
-                                ? "s"
-                                : ""}{" "}
-                              — click to expand
-                            </summary>
-                            <ul className="mt-1 text-red-300 text-sm font-terminal list-disc pl-4 max-h-32 overflow-y-auto">
-                              {(
-                                syncStatus!.sync_result!.errors as string[]
-                              ).map((err: string) => (
-                                <li key={err} className="break-all">
-                                  {err}
-                                </li>
-                              ))}
-                            </ul>
-                            {Number(
-                              (
-                                syncStatus?.sync_result as
-                                  | { errors_total?: number }
-                                  | undefined
-                              )?.errors_total || 0,
-                            ) >
-                            (syncStatus!.sync_result!.errors as string[])
-                              .length ? (
-                              <div className="mt-1 text-red-300">
-                                Showing first{" "}
-                                {
-                                  (syncStatus!.sync_result!.errors as string[])
-                                    .length
-                                }{" "}
-                                of{" "}
-                                {Number(
-                                  (
-                                    syncStatus!.sync_result as {
-                                      errors_total?: number;
-                                    }
-                                  ).errors_total,
-                                )}{" "}
-                                errors.
-                              </div>
-                            ) : null}
-                          </details>
-                        ) : null}
-                      </div>
-                    )}
                   </HudPanel>
                   ) : null}
+	                </div>
+	              </div>
 
-                  <HudPanel
-                    variant="b"
-                    className={`${LIBRARY_PANEL_SURFACE} space-y-3 p-3`}
-                  >
-                    <div className="flex items-center gap-2">
-                      <BookOpen className={ICON_SM} />
-                      <div className={LIBRARY_PANEL_TITLE}>STUDY READINESS</div>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
-                        <div className={TEXT_MUTED}>Visible files</div>
-                        <div className="font-terminal text-lg text-foreground">
-                          {visibleMaterials.length}
-                        </div>
-                      </div>
-                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
-                        <div className={TEXT_MUTED}>Current Run</div>
-                        <div className="font-terminal text-lg text-foreground">
-                          {selectedForTutor.length}
-                        </div>
-                      </div>
-                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
-                        <div className={TEXT_MUTED}>Embedded</div>
-                        <div className="font-terminal text-lg text-foreground">
-                          {embedStatus?.embedded ?? 0}
-                        </div>
-                      </div>
-                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
-                        <div className={TEXT_MUTED}>Needs work</div>
-                        <div className="font-terminal text-lg text-foreground">
-                          {(embedStatus?.pending ?? 0) + (embedStatus?.stale ?? 0)}
-                        </div>
-                      </div>
-                    </div>
-                    <div className={LIBRARY_HELP_TEXT}>
-                      {selectedForTutor.length
-                        ? `${selectedForTutor.length} file${selectedForTutor.length === 1 ? "" : "s"} in Current Run for Tutor handoff.`
-                        : "Use Study on a row or select files below to build the Current Run."}
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <HudButton
-                        variant="outline"
-                        className={LIBRARY_COMPACT_BUTTON}
-                        disabled={!defaultVisibleStudyMaterialIds.length}
-                        onClick={replaceTutorQueueWithVisible}
-                      >
-                        REPLACE RUN
-                      </HudButton>
-                      <HudButton
-                        variant="outline"
-                        className={LIBRARY_COMPACT_BUTTON}
-                        disabled={!defaultVisibleStudyMaterialIds.length}
-                        onClick={addVisibleToTutorQueue}
-                      >
-                        ADD STUDY FILES
-                      </HudButton>
-                      <HudButton
-                        variant="outline"
-                        className={LIBRARY_COMPACT_BUTTON}
-                        disabled={!selectedForTutor.length}
-                        onClick={clearTutorQueue}
-                      >
-                        CLEAR RUN
-                      </HudButton>
-                      <HudButton
-                        className={LIBRARY_COMPACT_BUTTON}
-                        disabled={!selectedForTutor.length}
-                        onClick={handleOpenTutor}
-                      >
-                        OPEN TUTOR ({selectedForTutor.length})
-                      </HudButton>
-                    </div>
-                  </HudPanel>
-                  </div>
-                </div>
-              </div>
-
-              <div
-                className={`${PANEL_PADDING} flex-1 min-h-0 flex flex-col gap-3`}
-              >
+		              {showMaterialsTab ? (
+		              <div
+		                className={`${PANEL_PADDING} flex-1 min-h-0 flex flex-col gap-3`}
+		              >
                 <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
                   <div className="space-y-1">
-                    <div className={LIBRARY_PANEL_TITLE}>YOUR MATERIALS</div>
+                    <div className={LIBRARY_PANEL_TITLE}>
+                      {materialSectionTitle}
+                    </div>
                     <div className={TEXT_MUTED}>
                       {sidebarMode === "courses" ? "Course" : "Folder"}:{" "}
                       <span className="!text-white font-terminal">
                         {selectedFolderLabel}
                       </span>{" "}
-                      • showing {visibleMaterials.length} file
-                      {visibleMaterials.length === 1 ? "" : "s"}
-                    </div>
-                    <div className={TEXT_MUTED}>
-                      Current Run: {selectedForTutor.length} file
-                      {selectedForTutor.length === 1 ? "" : "s"} total •{" "}
-                      {selectedVisibleMaterialIds.length} in this view
-                      {hiddenTutorSelectionCount > 0
-                        ? ` • ${hiddenTutorSelectionCount} from other views`
-                        : ""}
+                      • showing {visibleTabFileCount} {visibleTabFileLabel}
+                      {visibleTabFileCount === 1 ? "" : "s"}
                     </div>
                   </div>
-                  <div className="grid gap-2 lg:grid-cols-[auto_auto_auto]">
-                    <HudPanel
-                      variant="b"
-                      className={`${LIBRARY_PANEL_INSET} space-y-2 p-2`}
-                    >
-                      <div
-                        className={`${TEXT_MUTED} text-ui-xs uppercase tracking-wide`}
-                      >
-                        Course Linking
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <select
-                          value={courseLinkTarget}
-                          onChange={(e) => setCourseLinkTarget(e.target.value)}
-                          className={LIBRARY_SELECT}
-                          disabled={
-                            courses.length === 0 || courseLinkMutation.isPending
-                          }
-                        >
-                          <option value="">Select course</option>
-                          {courses.map((course) => (
-                            <option key={course.id} value={String(course.id)}>
-                              {course.name}
-                              {course.code ? ` (${course.code})` : ""}
-                            </option>
-                          ))}
-                        </select>
-                        <HudButton
-                          variant="outline"
-                          className={LIBRARY_COMPACT_BUTTON}
-                          disabled={
-                            courseLinkMutation.isPending ||
-                            !selectedVisibleMaterialIds.length ||
-                            !courseLinkTarget
-                          }
-                          onClick={handleLinkSelectedToCourse}
-                        >
-                          {courseLinkMutation.isPending ? (
-                            <Loader2
-                              className={`${ICON_SM} animate-spin mr-1`}
-                            />
-                          ) : (
-                            <Link2 className={`${ICON_SM} mr-1`} />
-                          )}
-                          LINK VIEW
-                        </HudButton>
-                      </div>
-                    </HudPanel>
+                  <div className="grid gap-2 lg:grid-cols-[minmax(260px,420px)_auto]">
+                    {showMaterialsTab ? (
+                      <input
+                        aria-label="Search Library files"
+                        className={INPUT_BASE}
+                        placeholder="Search Library files"
+                        value={librarySearchQuery}
+                        onChange={(event) =>
+                          setLibrarySearchQuery(event.target.value)
+                        }
+                      />
+                    ) : null}
 
-                    <HudPanel
-                      variant="b"
-                      className="space-y-2 border-destructive/30 bg-destructive/5 p-2"
-                    >
-                      <div className="text-ui-xs uppercase tracking-wide text-red-200">
-                        Library Cleanup
-                      </div>
-                      <div className="flex items-center flex-wrap gap-2">
-                        <HudButton
-                          variant="outline"
-                          className="w-auto min-h-[34px] rounded-none border-destructive/50 px-3 text-sm text-destructive hover:bg-destructive/10"
-                          disabled={
-                            selectedVisibleMaterialIds.length === 0 ||
-                            clearMaterialsMutation.isPending
-                          }
-                          onClick={() => {
-                            if (!selectedVisibleMaterialIds.length) return;
-                            if (
-                              !window.confirm(
-                                `Delete ${selectedVisibleMaterialIds.length} selected materials from the current folder view? This will not delete your local PT School files.`,
-                              )
-                            )
-                              return;
-                            clearMaterialsMutation.mutate([
-                              ...selectedVisibleMaterialIds,
-                            ]);
-                          }}
-                        >
-                          {clearMaterialsMutation.isPending ? (
-                            <Loader2
-                              className={`${ICON_SM} animate-spin mr-1`}
-                            />
-                          ) : (
-                            <Trash2 className={`${ICON_SM} mr-1`} />
-                          )}
-                          DELETE VIEW SELECTION
-                        </HudButton>
-                        <HudButton
-                          variant="outline"
-                          className="w-auto min-h-[34px] rounded-none border-destructive/50 px-3 text-sm text-destructive hover:bg-destructive/10"
-                          disabled={
-                            materials.length === 0 ||
-                            clearMaterialsMutation.isPending
-                          }
-                          onClick={() => {
-                            const safeCount = materials.length;
-                            if (!safeCount) return;
-                            if (
-                              !window.confirm(
-                                `Delete all ${safeCount} materials from tutor library? This will not delete your local PT School files.`,
-                              )
-                            )
-                              return;
-                            clearMaterialsMutation.mutate(
-                              materials.map((m) => m.id),
-                            );
-                          }}
-                        >
-                          {clearMaterialsMutation.isPending ? (
-                            <Loader2
-                              className={`${ICON_SM} animate-spin mr-1`}
-                            />
-                          ) : (
-                            <Trash2 className={`${ICON_SM} mr-1`} />
-                          )}
-                          DELETE ALL LIBRARY FILES
-                        </HudButton>
-                      </div>
-                    </HudPanel>
-                  </div>
-                </div>
+	                  </div>
+	                </div>
 
-                {hiddenTutorSelectionCount > 0 ? (
-                  <div className="border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm font-terminal text-yellow-100">
-                    The Current Run still includes {hiddenTutorSelectionCount}{" "}
-                    file{hiddenTutorSelectionCount === 1 ? "" : "s"} from other
-                    views. Use{" "}
-                    <span className="text-white">REPLACE RUN</span> if you
-                    want Tutor to use only visible study files right now.
-                  </div>
-                ) : null}
-
-                <HudPanel
-                  variant="b"
+	                {showMaterialsTab ? (
+	                <HudPanel
+	                  variant="b"
                   className="flex-1 min-h-0 overflow-hidden bg-transparent backdrop-blur-lg"
                 >
                   {isLoading ? (
@@ -2917,11 +1539,11 @@ function useLibraryPageController() {
                         Upload PDF, DOCX, PPTX, MD, or TXT files above
                       </div>
                     </div>
-                  ) : visibleMaterials.length === 0 ? (
+                  ) : visibleCatalogMaterials.length === 0 ? (
                     <div className="text-center py-10">
                       <FileText className="w-8 h-8 text-muted-foreground/30 mx-auto mb-2" />
                       <div className={TEXT_MUTED}>
-                        No materials found in this folder view.
+                        No materials found in this Library view.
                       </div>
                     </div>
                   ) : (
@@ -2934,27 +1556,7 @@ function useLibraryPageController() {
                               "32px minmax(250px,1.55fr) minmax(180px,1fr) 78px 84px 92px 126px",
                           }}
                         >
-                          <div
-                            className="flex items-center justify-center"
-                            title={
-                              allTutorMaterialsSelected
-                                ? "Unselect all visible study files"
-                                : "Select all visible study files"
-                            }
-                          >
-                            <Checkbox
-                              checked={allTutorMaterialsSelected}
-                              onCheckedChange={toggleAllMaterialsForTutor}
-                              disabled={
-                                defaultVisibleStudyMaterialIds.length === 0
-                              }
-                              aria-label={
-                                allTutorMaterialsSelected
-                                  ? "Unselect all visible study files"
-                                  : "Select all visible study files"
-                              }
-                            />
-                          </div>
+                          <div aria-hidden="true" />
                           <div className={TEXT_MUTED}>Title</div>
                           <div className={TEXT_MUTED}>Folder</div>
                           <div className={TEXT_MUTED}>Type</div>
@@ -2964,20 +1566,17 @@ function useLibraryPageController() {
                             Actions
                           </div>
                         </div>
-                        {visibleMaterials.map((mat) =>
+                        {visibleCatalogMaterials.map((mat) =>
                           renderMaterialRow(
                             mat,
                             Boolean(
                               mat.checksum && dupeChecksums.has(mat.checksum),
                             ),
-                            selectedForTutor,
                             editingId,
                             editTitle,
                             setEditTitle,
                             setEditingId,
                             saveEdit,
-                            toggleMaterialForTutor,
-                            studyMaterialInTutor,
                             toggleEnabled,
                             deleteMutation,
                             startEdit,
@@ -2990,9 +1589,11 @@ function useLibraryPageController() {
                         )}
                       </div>
                     </div>
-                  )}
-                </HudPanel>
-              </div>
+	                  )}
+	                </HudPanel>
+	                ) : null}
+	              </div>
+	              ) : null}
             </HudPanel>
           </section>
         </div>
@@ -3011,8 +1612,8 @@ function useLibraryPageController() {
               New Course
             </DialogTitle>
             <DialogDescription>
-              Creates a course record. Upload materials and create the
-              Obsidian folder afterward.
+              Creates a course record. Upload materials afterward when files
+              belong with this class.
             </DialogDescription>
           </DialogHeader>
           <form

--- a/dashboard_rebuild/client/src/pages/library.tsx
+++ b/dashboard_rebuild/client/src/pages/library.tsx
@@ -22,7 +22,6 @@ import type { Course } from "@shared/schema";
 import { useLocation } from "wouter";
 import {
   TEXT_PAGE_TITLE,
-  TEXT_PANEL_TITLE,
   TEXT_BODY,
   TEXT_MUTED,
   TEXT_BADGE,
@@ -83,13 +82,32 @@ const FILE_TYPE_LABEL: Record<string, string> = {
 const ALL_FOLDERS_KEY = "";
 const DEFAULT_SEMESTER_INTAKE_FOLDER =
   "/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School";
-const LIBRARY_PANEL_SURFACE =
-  "bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.01)_18%,rgba(0,0,0,0.18)_100%),linear-gradient(135deg,rgba(110,14,34,0.18),rgba(10,4,7,0.18)_58%,rgba(0,0,0,0.1)_100%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_16px_30px_rgba(0,0,0,0.16)] backdrop-blur-xl";
-const LIBRARY_PANEL_INSET =
-  "bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(0,0,0,0.06)_18%,rgba(0,0,0,0.14)_100%),linear-gradient(135deg,rgba(110,14,34,0.12),rgba(10,4,7,0.1)_58%,rgba(0,0,0,0.08)_100%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_12px_24px_rgba(0,0,0,0.12)] backdrop-blur-lg";
-const LIBRARY_COMPACT_BUTTON = "w-auto h-8 min-h-[32px] px-3 text-xs";
-const LIBRARY_INLINE_BUTTON = "w-auto h-7 min-h-[28px] px-2 text-ui-xs";
-const LIBRARY_SELECT = `${SELECT_BASE} h-8 min-h-[32px] rounded-[0.95rem] border-primary/30 bg-[linear-gradient(180deg,rgba(255,255,255,0.06),rgba(255,255,255,0.02)_38%,rgba(0,0,0,0.22)_100%)] px-2 text-sm`;
+const LIBRARY_PANEL_SURFACE = "library-panel-surface";
+const LIBRARY_PANEL_INSET = "library-panel-inset";
+const LIBRARY_ACTION_BUTTON = "library-action-button";
+const LIBRARY_COMPACT_BUTTON = `${LIBRARY_ACTION_BUTTON} w-auto h-9 min-h-[36px] px-4`;
+const LIBRARY_INLINE_BUTTON = `${LIBRARY_ACTION_BUTTON} library-action-button--inline w-auto h-8 min-h-[32px] px-3`;
+const LIBRARY_SELECT = `${SELECT_BASE} library-field h-10 min-h-[40px] rounded-[0.75rem] px-3`;
+const LIBRARY_SECTION_LABEL = "library-section-label";
+const LIBRARY_MAIN_TITLE =
+  "font-arcade text-base uppercase tracking-[0.16em] text-white";
+const LIBRARY_PANEL_TITLE = "library-panel-title";
+const LIBRARY_HELP_TEXT = "library-help-text";
+const LIBRARY_READY_BADGE =
+  "rounded-[0.55rem] border border-emerald-400/35 bg-emerald-400/10 px-2 py-1 font-terminal text-sm uppercase tracking-[0.12em] text-emerald-200";
+const LIBRARY_WARN_BADGE =
+  "rounded-[0.55rem] border border-amber-400/35 bg-amber-400/10 px-2 py-1 font-terminal text-sm uppercase tracking-[0.12em] text-amber-200";
+type AddCourseworkMode = "intake" | "sync" | "upload";
+type SemesterPreviewCourse = SemesterIntakePreviewResult["courses"][number];
+
+function collectSemesterMaterialFilePaths(
+  preview: SemesterIntakePreviewResult | null | undefined,
+): string[] {
+  if (!preview) return [];
+  return preview.courses.flatMap((course) =>
+    course.material_files.map((file) => file.path),
+  );
+}
 
 function getFileTypeLabel(fileType: string | null | undefined): string {
   const normalizedRaw = (fileType || "").toLowerCase().trim();
@@ -151,6 +169,35 @@ function getMaterialSize(mat: Material): number {
   return Number.isFinite(candidate) && candidate >= 0
     ? Math.floor(candidate)
     : 0;
+}
+
+function pluralizeCount(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function getSemesterCourseReviewStatus(course: SemesterPreviewCourse): {
+  label: string;
+  tone: "ready" | "warn";
+} {
+  if (course.readiness.readyForTutor) {
+    return { label: "Ready for Tutor", tone: "ready" };
+  }
+  if (
+    course.syllabus_files.length > 0 ||
+    course.schedule_files.length > 0 ||
+    course.material_files.length > 0
+  ) {
+    return { label: "Ready to review", tone: "ready" };
+  }
+  return { label: "Needs files", tone: "warn" };
+}
+
+function formatCourseSecondaryLabel(course: {
+  code?: string | null;
+  term?: string | null;
+}) {
+  const parts = [course.code, course.term].filter(Boolean);
+  return parts.length ? parts.join(" · ") : "No course code";
 }
 
 interface FolderNode {
@@ -351,7 +398,7 @@ function readInitialLibraryLaunchState(): InitialLibraryLaunchState {
   const handoff = consumeLibraryLaunchFromTutor();
   if (!handoff || typeof handoff.courseId !== "number") {
     return {
-      sidebarMode: "folders",
+      sidebarMode: "courses",
       selectedCourseId: null,
       uploadCourseTarget: "",
       syncCourseTarget: "",
@@ -399,10 +446,10 @@ function renderMaterialRow(
   return (
     <div
       key={mat.id}
-      className={`grid gap-2 px-2 py-1.5 items-center border-b border-primary/10 hover:bg-primary/5 transition-colors ${!mat.enabled ? "opacity-50" : ""}`}
+      className={`grid gap-3 px-3 py-2.5 items-center border-b border-primary/10 hover:bg-primary/5 transition-colors ${!mat.enabled ? "opacity-50" : ""}`}
       style={{
         gridTemplateColumns:
-          "28px minmax(210px,1.6fr) minmax(140px,1fr) 64px 72px 84px 116px",
+          "32px minmax(250px,1.55fr) minmax(180px,1fr) 78px 84px 92px 126px",
       }}
     >
       <div className="flex items-center justify-center">
@@ -585,17 +632,18 @@ function SyncPreviewTreeNode({
     const isChecked = selectedSyncFiles.has(node.path);
     return (
       <div
-        className="w-full rounded-none border border-primary/10 px-2 py-1 text-left text-xs font-terminal flex items-center gap-2 text-muted-foreground hover:text-foreground"
+        className="w-full rounded-none border border-primary/10 px-2 py-1.5 text-left text-sm font-terminal flex items-center gap-2 text-muted-foreground hover:text-foreground"
         style={{ paddingLeft: `${0.6 + depth * 0.8}rem` }}
         title={node.path}
       >
         <Checkbox
+          aria-label={`Sync ${node.name}`}
           checked={isChecked}
           onCheckedChange={() => onToggleFile(node.path)}
         />
         <FileText className={`${ICON_SM} shrink-0`} />
         <span className="truncate flex-1">{node.name}</span>
-        <span className="text-ui-xs">{formatSize(node.size)}</span>
+        <span className="text-sm">{formatSize(node.size)}</span>
       </div>
     );
   }
@@ -608,7 +656,7 @@ function SyncPreviewTreeNode({
     <div>
       {!isRoot && (
         <div
-          className="w-full rounded-none border border-primary/15 pr-2 py-1 text-left text-xs font-terminal flex items-center gap-1 text-muted-foreground hover:text-foreground"
+          className="w-full rounded-none border border-primary/15 pr-2 py-1.5 text-left text-sm font-terminal flex items-center gap-1 text-muted-foreground hover:text-foreground"
           style={{ paddingLeft: `${0.45 + depth * 0.8}rem` }}
           title={node.path}
         >
@@ -632,7 +680,7 @@ function SyncPreviewTreeNode({
             <Folder className={`${ICON_SM} shrink-0`} />
           )}
           <span className="truncate flex-1">{node.name}</span>
-          <span className="text-ui-xs">{children.length}</span>
+          <span className="text-sm">{children.length}</span>
         </div>
       )}
       {isExpanded &&
@@ -664,11 +712,15 @@ function useLibraryPageController() {
   );
   const [semesterPreview, setSemesterPreview] =
     useState<SemesterIntakePreviewResult | null>(null);
+  const [selectedSemesterMaterialFiles, setSelectedSemesterMaterialFiles] =
+    useState<Set<string>>(() => new Set());
   const [semesterScanLoading, setSemesterScanLoading] = useState(false);
   const [semesterApplyLoading, setSemesterApplyLoading] = useState(false);
   const [semesterIntakeError, setSemesterIntakeError] = useState<string | null>(
     null,
   );
+  const [addCourseworkMode, setAddCourseworkMode] =
+    useState<AddCourseworkMode>("intake");
   const [uploadCourseTarget, setUploadCourseTarget] = useState<string>(
     initialLaunchState.uploadCourseTarget,
   );
@@ -883,7 +935,7 @@ function useLibraryPageController() {
       const course = contentSources?.courses.find(
         (c) => c.id === selectedCourseId,
       );
-      return course ? course.code || course.name : "All Materials";
+      return course ? course.name || course.code : "All Materials";
     }
     return selectedFolderPath || "All Materials";
   }, [sidebarMode, selectedCourseId, contentSources, selectedFolderPath]);
@@ -953,10 +1005,22 @@ function useLibraryPageController() {
     () => collectSyncPreviewFilePaths(syncPreview?.tree),
     [syncPreview],
   );
+  const semesterMaterialFiles = useMemo(
+    () => collectSemesterMaterialFilePaths(semesterPreview),
+    [semesterPreview],
+  );
   const selectedSyncCount = selectedSyncFiles.size;
+  const selectedSemesterMaterialCount = semesterMaterialFiles.filter((path) =>
+    selectedSemesterMaterialFiles.has(path),
+  ).length;
   const allSyncFilesSelected =
     syncPreviewFiles.length > 0 &&
     syncPreviewFiles.every((path) => selectedSyncFiles.has(path));
+  const allSemesterMaterialFilesSelected =
+    semesterMaterialFiles.length > 0 &&
+    semesterMaterialFiles.every((path) =>
+      selectedSemesterMaterialFiles.has(path),
+    );
 
   useEffect(() => {
     writeTutorSelectedMaterialIds(selectedForTutor);
@@ -1082,6 +1146,17 @@ function useLibraryPageController() {
     const normalizedCurrent = normalizePathForCompare(value.trim());
     if (!normalizedCurrent || normalizedPreview === normalizedCurrent) return;
     resetSyncPreviewState("Folder path changed. Scan the folder again.");
+  };
+
+  const handleSemesterIntakeFolderChange = (value: string) => {
+    setSemesterIntakeFolder(value);
+    if (!semesterPreview) return;
+    const normalizedPreview = normalizePathForCompare(
+      semesterPreview.folder || "",
+    );
+    const normalizedCurrent = normalizePathForCompare(value.trim());
+    if (!normalizedCurrent || normalizedPreview === normalizedCurrent) return;
+    setSelectedSemesterMaterialFiles(new Set());
   };
 
   const finalizeSyncStatus = (status: TutorSyncJobStatus) => {
@@ -1397,6 +1472,24 @@ function useLibraryPageController() {
     setSelectedSyncFiles(selectAll ? new Set(syncPreviewFiles) : new Set());
   };
 
+  const toggleSemesterMaterialFile = (path: string) => {
+    setSelectedSemesterMaterialFiles((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  const selectAllSemesterMaterialFiles = (selectAll: boolean) => {
+    setSelectedSemesterMaterialFiles(
+      selectAll ? new Set(semesterMaterialFiles) : new Set(),
+    );
+  };
+
   const scanSemesterIntakeFolder = async () => {
     const trimmedFolder = semesterIntakeFolder.trim();
     if (!trimmedFolder || semesterScanLoading || semesterApplyLoading) return;
@@ -1408,6 +1501,7 @@ function useLibraryPageController() {
         folder_path: trimmedFolder,
       });
       setSemesterPreview(preview);
+      setSelectedSemesterMaterialFiles(new Set());
       if (!preview.courses.length) {
         toast.warning("Semester intake found no course folders.");
       } else {
@@ -1416,6 +1510,7 @@ function useLibraryPageController() {
     } catch (err) {
       const message = err instanceof Error ? err.message : "Unknown";
       setSemesterPreview(null);
+      setSelectedSemesterMaterialFiles(new Set());
       setSemesterIntakeError(message);
       toast.error(`Semester intake scan failed: ${message}`);
     } finally {
@@ -1440,10 +1535,13 @@ function useLibraryPageController() {
 
     const coursesToApply = semesterPreview.courses.map((course) => ({
       name: course.name,
+      code: course.code ?? null,
       folder_path: course.folder_path,
       syllabus_files: course.syllabus_files.map((file) => file.path),
       schedule_files: course.schedule_files.map((file) => file.path),
-      material_files: course.material_files.map((file) => file.path),
+      material_files: course.material_files
+        .filter((file) => selectedSemesterMaterialFiles.has(file.path))
+        .map((file) => file.path),
       syllabus: { modules: [] },
       schedule: { events: [] },
     }));
@@ -1493,7 +1591,7 @@ function useLibraryPageController() {
         .filter((child) => child.type === "folder")
         .map((child) => child.path);
       setSyncPreview(preview);
-      setSelectedSyncFiles(new Set(discoveredFiles));
+      setSelectedSyncFiles(new Set());
       setExpandedSyncFolders(new Set(["", ...topLevelFolderPaths]));
       if (!discoveredFiles.length) {
         setSyncPreviewError("No supported files found in this folder.");
@@ -1628,6 +1726,7 @@ function useLibraryPageController() {
       subtitle="Brain-owned study materials, Tutor scope, and clean handoff into live study all run through one intake surface."
       className="flex h-full min-h-[72vh] flex-col"
       contentClassName="flex-1 min-h-0"
+      heroClassName="library-page-hero"
       stats={[
         {
           label: "Embeddings",
@@ -1646,20 +1745,40 @@ function useLibraryPageController() {
         },
       ]}
     >
-      <div className="brain-workspace brain-workspace--ready app-workspace-shell relative flex-1 min-h-[70vh] w-full overflow-hidden">
+      <div className="brain-workspace brain-workspace--ready app-workspace-shell library-ops-workspace relative flex-1 min-h-[70vh] w-full overflow-hidden">
         <div className="flex flex-col lg:flex-row h-full min-h-0">
           <aside className="brain-workspace__sidebar-wrap w-full lg:w-80 shrink-0 min-h-0 max-h-[40vh] lg:max-h-none lg:pr-3">
             <HudPanel
               variant="b"
-              className="flex h-full min-h-0 flex-col overflow-hidden bg-transparent backdrop-blur-xl"
+              className="library-rail-panel flex h-full min-h-0 flex-col overflow-hidden"
             >
-              <div className={`${PANEL_PADDING} border-b border-primary/20`}>
-                <div className="flex items-center gap-0 mb-2">
+              <div className={`${PANEL_PADDING} border-b border-white/10`}>
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className={LIBRARY_SECTION_LABEL}>COURSE RAIL</div>
+                    <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
+                      Course names are the primary way to browse; folders are a
+                      secondary filter.
+                    </div>
+                  </div>
+                  {sidebarMode === "courses" ? (
+                    <button
+                      type="button"
+                      aria-label="Add new course"
+                      title="Create a new course"
+                      onClick={() => setAddCourseDialogOpen(true)}
+                      className="library-icon-button shrink-0"
+                    >
+                      <Plus className={ICON_SM} />
+                    </button>
+                  ) : null}
+                </div>
+                <div className="library-segmented-control flex items-center gap-1 p-1">
                   <HudButton
                     type="button"
                     variant={sidebarMode === "folders" ? "primary" : "outline"}
                     className={cn(
-                      "flex-1 min-h-[38px] px-3 text-xs",
+                      "flex-1 min-h-[38px] px-3",
                       sidebarMode === "folders"
                         ? "bg-primary/20 text-primary"
                         : "text-muted-foreground hover:text-foreground",
@@ -1672,7 +1791,7 @@ function useLibraryPageController() {
                     type="button"
                     variant={sidebarMode === "courses" ? "primary" : "outline"}
                     className={cn(
-                      "flex-1 min-h-[38px] px-3 text-xs",
+                      "flex-1 min-h-[38px] px-3",
                       sidebarMode === "courses"
                         ? "bg-primary/20 text-primary"
                         : "text-muted-foreground hover:text-foreground",
@@ -1682,29 +1801,12 @@ function useLibraryPageController() {
                     COURSES
                   </HudButton>
                 </div>
-                <div className={TEXT_MUTED}>
-                  {sidebarMode === "folders"
-                    ? "Mirror your Obsidian-style folder tree."
-                    : "Browse materials by linked course."}
-                </div>
-                {sidebarMode === "courses" ? (
-                  <button
-                    type="button"
-                    aria-label="Add new course"
-                    title="Create a new course (semester-start workflow)"
-                    onClick={() => setAddCourseDialogOpen(true)}
-                    className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-none border border-primary/30 border-dashed bg-primary/5 px-2 py-1.5 font-terminal text-xs uppercase tracking-[0.18em] text-primary/80 transition-colors hover:border-primary/60 hover:bg-primary/10 hover:text-primary"
-                  >
-                    <Plus className={ICON_SM} />
-                    New Course
-                  </button>
-                ) : null}
               </div>
               <div className="flex-1 overflow-y-auto p-2 space-y-1">
                 {sidebarMode === "folders" ? (
                   <>
                     <button
-                      className={`w-full rounded-none border px-2 py-1.5 text-left text-sm font-terminal flex items-center gap-2 transition-colors ${
+                      className={`library-course-nav-row w-full rounded-none border px-3 py-2 text-left font-terminal flex items-center gap-2 transition-colors ${
                         selectedFolderPath === ALL_FOLDERS_KEY
                           ? "border-primary/60 bg-primary/20 text-primary"
                           : "border-primary/15 text-muted-foreground hover:text-foreground hover:border-primary/40"
@@ -1714,7 +1816,7 @@ function useLibraryPageController() {
                     >
                       <FolderOpen className={ICON_SM} />
                       <span className="truncate flex-1">All Materials</span>
-                      <span className="text-ui-xs">{materials.length}</span>
+                      <span className="text-sm">{materials.length}</span>
                     </button>
                     {visibleFolderItems.map((folder) => {
                       const isSelected = selectedFolderPath === folder.path;
@@ -1723,7 +1825,7 @@ function useLibraryPageController() {
                       return (
                         <div key={folder.path}>
                           <div
-                            className={`w-full rounded-none border pr-2 py-1.5 text-left text-sm font-terminal flex items-center gap-1 transition-colors ${
+                            className={`library-course-nav-row w-full rounded-none border pr-3 py-2 text-left font-terminal flex items-center gap-1 transition-colors ${
                               isSelected
                                 ? "border-primary/60 bg-primary/20 text-primary"
                                 : "border-primary/15 text-muted-foreground hover:text-foreground hover:border-primary/40"
@@ -1780,7 +1882,7 @@ function useLibraryPageController() {
                                 {folder.name}
                               </span>
                             </div>
-                            <span className="text-ui-xs">
+                            <span className="text-sm">
                               {folder.filesCount}
                             </span>
                           </div>
@@ -1788,7 +1890,7 @@ function useLibraryPageController() {
                       );
                     })}
                     {!folderItems.length && materials.length === 0 ? (
-                      <div className={`${TEXT_MUTED} px-2 py-3 text-xs`}>
+                      <div className={`${TEXT_MUTED} px-2 py-3 text-sm`}>
                         Sync a folder or upload files to populate this rail.
                       </div>
                     ) : null}
@@ -1796,7 +1898,7 @@ function useLibraryPageController() {
                 ) : (
                   <>
                     <button
-                      className={`w-full rounded-none border px-2 py-1.5 text-left text-sm font-terminal flex items-center gap-2 transition-colors ${
+                      className={`library-course-nav-row w-full rounded-none border px-3 py-2 text-left font-terminal flex items-center gap-2 transition-colors ${
                         selectedCourseId === null
                           ? "border-primary/60 bg-primary/20 text-primary"
                           : "border-primary/15 text-muted-foreground hover:text-foreground hover:border-primary/40"
@@ -1806,7 +1908,7 @@ function useLibraryPageController() {
                     >
                       <BookOpen className={ICON_SM} />
                       <span className="truncate flex-1">All Materials</span>
-                      <span className="text-ui-xs">{materials.length}</span>
+                      <span className="text-sm">{materials.length}</span>
                     </button>
                     {contentSources?.courses
                       .filter((c) => c.id !== null)
@@ -1822,7 +1924,7 @@ function useLibraryPageController() {
                             }`}
                           >
                             <button
-                              className={`flex flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm font-terminal transition-colors ${
+                              className={`flex flex-1 items-center gap-2 px-3 py-2.5 text-left font-terminal transition-colors ${
                                 isSelected
                                   ? "text-primary"
                                   : "text-muted-foreground hover:text-foreground"
@@ -1831,10 +1933,17 @@ function useLibraryPageController() {
                               type="button"
                             >
                               <GraduationCap className={ICON_SM} />
-                              <span className="truncate flex-1">
-                                {course.name || course.code}
+                              <span className="min-w-0 flex-1">
+                                <span className="block truncate text-base text-foreground">
+                                  {course.name || course.code}
+                                </span>
+                                {course.code ? (
+                                  <span className="block truncate text-sm text-muted-foreground">
+                                    {course.code}
+                                  </span>
+                                ) : null}
                               </span>
-                              <span className="text-ui-xs">
+                              <span className="text-sm">
                                 {course.doc_count}
                               </span>
                             </button>
@@ -1869,7 +1978,7 @@ function useLibraryPageController() {
                     >
                       <FileText className={`${ICON_SM} opacity-50`} />
                       <span className="truncate flex-1">Unlinked</span>
-                      <span className="text-ui-xs">{unlinkedCount}</span>
+                      <span className="text-sm">{unlinkedCount}</span>
                     </button>
                     {archivedCourses.length > 0 ? (
                       <div className="mt-2 border-t border-primary/10 pt-2">
@@ -1878,7 +1987,7 @@ function useLibraryPageController() {
                           aria-expanded={archivedExpanded}
                           aria-controls="library-archived-courses"
                           onClick={() => setArchivedExpanded((v) => !v)}
-                          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-xs font-terminal uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground"
+                          className="flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-sm font-terminal uppercase tracking-[0.16em] text-muted-foreground hover:text-foreground"
                         >
                           {archivedExpanded ? (
                             <ChevronDown className={ICON_SM} />
@@ -1936,28 +2045,92 @@ function useLibraryPageController() {
             </HudPanel>
           </aside>
 
-          <section className="brain-workspace__main-wrap brain-workspace__canvas flex-1 min-h-0 flex flex-col overflow-hidden">
-            <HudPanel className="flex h-full min-h-0 flex-col overflow-hidden bg-transparent backdrop-blur-xl">
-              <div className="border-b border-primary/20 bg-transparent">
+              <section className="brain-workspace__main-wrap brain-workspace__canvas flex-1 min-h-0 flex flex-col overflow-hidden">
+            <HudPanel className="library-main-panel flex h-full min-h-0 flex-col overflow-hidden">
+              <div className="border-b border-primary/10 bg-transparent">
                 <div
-                  className={`${PANEL_PADDING} grid gap-3 xl:grid-cols-[minmax(320px,0.95fr)_minmax(340px,1fr)_minmax(380px,1.1fr)]`}
+                  className={`${PANEL_PADDING} space-y-3`}
                 >
+                  <HudPanel
+                    variant="b"
+                    className={`${LIBRARY_PANEL_SURFACE} p-3`}
+                  >
+                    <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                      <div className="min-w-0">
+                        <div className={LIBRARY_SECTION_LABEL}>ADD COURSEWORK</div>
+                        <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
+                          Choose one source path at a time. Scans classify
+                          files; only checked materials are loaded.
+                        </div>
+                      </div>
+                      <div className="library-segmented-control grid grid-cols-3 gap-1 p-1">
+                        {[
+                          ["intake", "SEMESTER INTAKE"],
+                          ["sync", "FOLDER SYNC"],
+                          ["upload", "DIRECT UPLOAD"],
+                        ].map(([mode, label]) => (
+                          <HudButton
+                            key={mode}
+                            type="button"
+                            variant={
+                              addCourseworkMode === mode ? "primary" : "outline"
+                            }
+                            className={cn(
+                              "min-h-[38px] px-3",
+                              addCourseworkMode === mode
+                                ? "bg-primary/20 text-primary"
+                                : "text-muted-foreground hover:text-foreground",
+                            )}
+                            onClick={() =>
+                              setAddCourseworkMode(mode as AddCourseworkMode)
+                            }
+                          >
+                            {label}
+                          </HudButton>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-3">
+                      {[
+                        ["SOURCE", "Pick intake, sync, or direct upload."],
+                        ["REVIEW", "Confirm course setup and chosen files."],
+                        ["STUDY", "Send ready materials to Tutor."],
+                      ].map(([label, copy]) => (
+                        <div
+                          key={label}
+                            className="library-step-card rounded-[0.75rem] p-3"
+                        >
+                          <div className="font-arcade text-base uppercase tracking-[0.14em] text-primary/85">
+                            {label}
+                          </div>
+                          <div className={`${LIBRARY_HELP_TEXT} mt-1`}>
+                            {copy}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </HudPanel>
+
+                  <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.42fr)]">
+                  {addCourseworkMode === "intake" ? (
                   <HudPanel
                     variant="b"
                     className={`${LIBRARY_PANEL_SURFACE} space-y-2 p-3`}
                   >
                     <div className="flex items-center gap-2">
                       <GraduationCap className={ICON_SM} />
-                      <div className={TEXT_PANEL_TITLE}>SEMESTER INTAKE</div>
+                      <div className={LIBRARY_PANEL_TITLE}>SEMESTER INTAKE</div>
                     </div>
-                    <div className={`${TEXT_MUTED} text-xs`}>
+                    <div className={LIBRARY_HELP_TEXT}>
                       Start from one PT School folder, separate course setup
                       files from study materials, then create the Study courses.
                     </div>
                     <input
                       aria-label="Semester intake folder"
                       value={semesterIntakeFolder}
-                      onChange={(e) => setSemesterIntakeFolder(e.target.value)}
+                      onChange={(e) =>
+                        handleSemesterIntakeFolderChange(e.target.value)
+                      }
                       className={INPUT_BASE}
                       placeholder="Paste the semester folder path"
                     />
@@ -1994,12 +2167,12 @@ function useLibraryPageController() {
                         ) : (
                           <Check className={`${ICON_SM} mr-1`} />
                         )}
-                        APPLY COURSE SETUP
+                        APPLY SETUP + SELECTED FILES
                       </HudButton>
                     </div>
                     {semesterPreview ? (
                       <div className="space-y-2">
-                        <div className="grid grid-cols-2 gap-2 text-xs">
+                        <div className="grid grid-cols-2 gap-2">
                           <div className="border border-primary/15 bg-black/30 p-2">
                             <div className={TEXT_MUTED}>Courses</div>
                             <div className="font-terminal text-base text-foreground">
@@ -2025,34 +2198,95 @@ function useLibraryPageController() {
                             </div>
                           </div>
                         </div>
+                        <div className="flex flex-wrap items-center justify-between gap-2 border border-primary/10 bg-black/45 p-2 text-sm">
+                          <div className={TEXT_MUTED}>
+                            {selectedSemesterMaterialCount} selected for
+                            Library
+                            {semesterMaterialFiles.length
+                              ? ` / ${semesterMaterialFiles.length} found`
+                              : ""}
+                          </div>
+                          <HudButton
+                            variant="outline"
+                            className={LIBRARY_INLINE_BUTTON}
+                            disabled={!semesterMaterialFiles.length}
+                            onClick={() =>
+                              selectAllSemesterMaterialFiles(
+                                !allSemesterMaterialFilesSelected,
+                              )
+                            }
+                          >
+                            {allSemesterMaterialFilesSelected
+                              ? "CLEAR MATERIALS"
+                              : "SELECT MATERIALS"}
+                          </HudButton>
+                        </div>
                         <div className="max-h-40 overflow-auto border border-primary/15 bg-black/30 p-2 space-y-1">
                           {semesterPreview.courses.map((course) => (
                             <div
                               key={course.folder_path}
-                              className="flex items-center justify-between gap-2 text-xs"
+                              className="border border-primary/10 bg-black/35 p-2 text-sm"
                             >
-                              <div className="min-w-0">
-                                <div className="truncate font-terminal text-foreground">
-                                  {course.name}
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="min-w-0">
+                                  <div className="truncate font-terminal text-base text-foreground">
+                                    {course.name}
+                                  </div>
+                                  <div className={TEXT_MUTED}>
+                                    {course.syllabus_files.length} syllabus /{" "}
+                                    {course.schedule_files.length} schedule /{" "}
+                                    {course.material_files.length} material
+                                  </div>
                                 </div>
-                                <div className={TEXT_MUTED}>
-                                  {course.syllabus_files.length} syllabus /{" "}
-                                  {course.schedule_files.length} schedule /{" "}
-                                  {course.material_files.length} material
-                                </div>
+                                <Badge
+                                  variant="outline"
+                                  className="shrink-0 rounded-none border-primary/25 bg-primary/10 text-sm uppercase"
+                                >
+                                  {course.readiness.course}
+                                </Badge>
                               </div>
-                              <Badge
-                                variant="outline"
-                                className="shrink-0 rounded-none border-primary/30 bg-primary/10 text-[10px] uppercase"
-                              >
-                                {course.readiness.course}
-                              </Badge>
+                              {course.material_files.length ? (
+                                <div className="mt-2 space-y-1">
+                                  {course.material_files.map((file) => {
+                                    const checked =
+                                      selectedSemesterMaterialFiles.has(
+                                        file.path,
+                                      );
+                                    return (
+                                      <div
+                                        key={file.path}
+                                        className="flex items-center gap-2 border border-primary/10 bg-black/35 px-2 py-1.5 font-terminal text-sm text-muted-foreground"
+                                        title={file.path}
+                                      >
+                                        <Checkbox
+                                          aria-label={`Load ${file.name} from ${course.name}`}
+                                          checked={checked}
+                                          onCheckedChange={() =>
+                                            toggleSemesterMaterialFile(
+                                              file.path,
+                                            )
+                                          }
+                                        />
+                                        <FileText
+                                          className={`${ICON_SM} shrink-0`}
+                                        />
+                                        <span className="min-w-0 flex-1 truncate">
+                                          {file.name}
+                                        </span>
+                                        <span className="text-ui-xs">
+                                          {formatSize(file.size)}
+                                        </span>
+                                      </div>
+                                    );
+                                  })}
+                                </div>
+                              ) : null}
                             </div>
                           ))}
                         </div>
                         {semesterPreview.global_schedule_files.length ||
                         semesterPreview.ignored_files.length ? (
-                          <div className={`${TEXT_MUTED} text-xs`}>
+                          <div className={LIBRARY_HELP_TEXT}>
                             Global schedules:{" "}
                             {semesterPreview.global_schedule_files.length} /
                             ignored: {semesterPreview.ignored_files.length}
@@ -2061,28 +2295,30 @@ function useLibraryPageController() {
                       </div>
                     ) : (
                       <div
-                        className={`${TEXT_MUTED} border border-primary/15 bg-black/30 p-2 text-xs`}
+                        className={`${LIBRARY_HELP_TEXT} border border-primary/10 bg-black/45 p-3`}
                       >
                         Scan the semester folder before applying setup.
                       </div>
                     )}
                     {semesterIntakeError ? (
-                      <div className="text-xs text-yellow-300 break-all">
+                      <div className="text-sm text-yellow-300 break-all">
                         <AlertTriangle className={`${ICON_SM} inline mr-1`} />
                         {semesterIntakeError}
                       </div>
                     ) : null}
                   </HudPanel>
+                  ) : null}
 
+                  {addCourseworkMode === "upload" ? (
                   <HudPanel
                     variant="b"
                     className={`${LIBRARY_PANEL_SURFACE} space-y-2 p-3`}
                   >
                     <div className="flex items-center gap-2">
                       <Upload className={ICON_SM} />
-                      <div className={TEXT_PANEL_TITLE}>UPLOAD MATERIALS</div>
+                      <div className={LIBRARY_PANEL_TITLE}>UPLOAD MATERIALS</div>
                     </div>
-                    <div className={`${TEXT_MUTED} text-xs`}>
+                    <div className={LIBRARY_HELP_TEXT}>
                       Use this for one-off files from Downloads, email, or
                       Blackboard. Upload puts the file into the Tutor library
                       immediately.
@@ -2090,7 +2326,7 @@ function useLibraryPageController() {
                     <div className="flex items-center gap-2">
                       <label
                         htmlFor="library-upload-course-target"
-                        className={`${TEXT_MUTED} text-xs whitespace-nowrap`}
+                        className={`${LIBRARY_HELP_TEXT} whitespace-nowrap`}
                       >
                         Link uploads to course
                       </label>
@@ -2115,19 +2351,21 @@ function useLibraryPageController() {
                         uploadCourseTarget
                           ? Number(uploadCourseTarget)
                           : undefined
-                      }
+                        }
                     />
                   </HudPanel>
+                  ) : null}
 
+                  {addCourseworkMode === "sync" ? (
                   <HudPanel
                     variant="b"
                     className={`${LIBRARY_PANEL_SURFACE} space-y-2 p-3`}
                   >
                     <div className="flex items-center gap-2">
                       <FolderOpen className={ICON_SM} />
-                      <div className={TEXT_PANEL_TITLE}>SYNC STUDY FOLDER</div>
+                      <div className={LIBRARY_PANEL_TITLE}>SYNC STUDY FOLDER</div>
                     </div>
-                    <div className={`${TEXT_MUTED} text-xs`}>
+                    <div className={LIBRARY_HELP_TEXT}>
                       Use this for a whole course or week folder. Scan first,
                       choose files, then sync only the files you want in the
                       Tutor library.
@@ -2181,7 +2419,7 @@ function useLibraryPageController() {
                     <div className="flex items-center gap-2">
                       <label
                         htmlFor="library-sync-course-target"
-                        className={`${TEXT_MUTED} text-xs whitespace-nowrap`}
+                        className={`${LIBRARY_HELP_TEXT} whitespace-nowrap`}
                       >
                         Link synced files to course
                       </label>
@@ -2240,20 +2478,23 @@ function useLibraryPageController() {
                     ) : (
                       <HudPanel
                         variant="b"
-                        className={`${TEXT_MUTED} bg-black/30 p-2 text-xs`}
+                        className={`${LIBRARY_HELP_TEXT} bg-black/45 p-3`}
                       >
-                        Scan the folder to browse your structure and choose
-                        files.
+                        <div>0 selected</div>
+                        <div>
+                          Scan the folder to browse your structure and choose
+                          files.
+                        </div>
                       </HudPanel>
                     )}
                     {syncPreviewError ? (
-                      <div className="text-xs text-yellow-300 break-all">
+                      <div className="text-sm text-yellow-300 break-all">
                         <AlertTriangle className={`${ICON_SM} inline mr-1`} />
                         {syncPreviewError}
                       </div>
                     ) : null}
                     {(syncing || syncStatus) && (
-                      <div className="mt-1 border border-primary/20 bg-black/30 p-2 space-y-1 text-xs">
+                      <div className="mt-1 border border-primary/10 bg-black/45 p-3 space-y-1 text-sm">
                         <div className="flex items-center justify-between">
                           <span className={TEXT_MUTED}>Status</span>
                           <span className="font-terminal !text-white uppercase">
@@ -2292,7 +2533,7 @@ function useLibraryPageController() {
                             | undefined
                         )?.length ? (
                           <details className="mt-1">
-                            <summary className="text-red-400 cursor-pointer text-xs font-terminal">
+                            <summary className="text-red-400 cursor-pointer text-sm font-terminal">
                               {
                                 (syncStatus!.sync_result!.errors as string[])
                                   .length
@@ -2304,7 +2545,7 @@ function useLibraryPageController() {
                                 : ""}{" "}
                               — click to expand
                             </summary>
-                            <ul className="mt-1 text-red-300 text-xs font-terminal list-disc pl-4 max-h-32 overflow-y-auto">
+                            <ul className="mt-1 text-red-300 text-sm font-terminal list-disc pl-4 max-h-32 overflow-y-auto">
                               {(
                                 syncStatus!.sync_result!.errors as string[]
                               ).map((err: string) => (
@@ -2344,49 +2585,91 @@ function useLibraryPageController() {
                       </div>
                     )}
                   </HudPanel>
+                  ) : null}
+
+                  <HudPanel
+                    variant="b"
+                    className={`${LIBRARY_PANEL_SURFACE} space-y-3 p-3`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <BookOpen className={ICON_SM} />
+                      <div className={LIBRARY_PANEL_TITLE}>STUDY READINESS</div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
+                        <div className={TEXT_MUTED}>Visible files</div>
+                        <div className="font-terminal text-lg text-foreground">
+                          {visibleMaterials.length}
+                        </div>
+                      </div>
+                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
+                        <div className={TEXT_MUTED}>Tutor queue</div>
+                        <div className="font-terminal text-lg text-foreground">
+                          {selectedForTutor.length}
+                        </div>
+                      </div>
+                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
+                        <div className={TEXT_MUTED}>Embedded</div>
+                        <div className="font-terminal text-lg text-foreground">
+                          {embedStatus?.embedded ?? 0}
+                        </div>
+                      </div>
+                      <div className={LIBRARY_PANEL_INSET + " p-2"}>
+                        <div className={TEXT_MUTED}>Needs work</div>
+                        <div className="font-terminal text-lg text-foreground">
+                          {(embedStatus?.pending ?? 0) + (embedStatus?.stale ?? 0)}
+                        </div>
+                      </div>
+                    </div>
+                    <div className={LIBRARY_HELP_TEXT}>
+                      {selectedForTutor.length
+                        ? `${selectedForTutor.length} file${selectedForTutor.length === 1 ? "" : "s"} ready for Tutor handoff.`
+                        : "Select materials below to make them ready for Tutor handoff."}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <HudButton
+                        variant="outline"
+                        className={LIBRARY_COMPACT_BUTTON}
+                        disabled={!selectableVisibleMaterialIds.length}
+                        onClick={replaceTutorQueueWithVisible}
+                      >
+                        REPLACE WITH VIEW
+                      </HudButton>
+                      <HudButton
+                        variant="outline"
+                        className={LIBRARY_COMPACT_BUTTON}
+                        disabled={!selectableVisibleMaterialIds.length}
+                        onClick={addVisibleToTutorQueue}
+                      >
+                        ADD VIEW
+                      </HudButton>
+                      <HudButton
+                        variant="outline"
+                        className={LIBRARY_COMPACT_BUTTON}
+                        disabled={!selectedForTutor.length}
+                        onClick={clearTutorQueue}
+                      >
+                        CLEAR QUEUE
+                      </HudButton>
+                      <HudButton
+                        className={LIBRARY_COMPACT_BUTTON}
+                        disabled={!selectedForTutor.length}
+                        onClick={handleOpenTutor}
+                      >
+                        OPEN TUTOR ({selectedForTutor.length})
+                      </HudButton>
+                    </div>
+                  </HudPanel>
+                  </div>
                 </div>
               </div>
 
               <div
                 className={`${PANEL_PADDING} flex-1 min-h-0 flex flex-col gap-3`}
               >
-                <div className="grid gap-3 lg:grid-cols-3">
-                  <HudPanel
-                    variant="b"
-                    className={`${LIBRARY_PANEL_INSET} p-3`}
-                  >
-                    <div className={TEXT_PANEL_TITLE}>1. INGEST</div>
-                    <div className={`${TEXT_MUTED} mt-1 text-xs`}>
-                      Upload for one-off files. Sync for a folder tree you want
-                      to browse before import.
-                    </div>
-                  </HudPanel>
-                  <HudPanel
-                    variant="b"
-                    className={`${LIBRARY_PANEL_INSET} p-3`}
-                  >
-                    <div className={TEXT_PANEL_TITLE}>2. ORGANIZE</div>
-                    <div className={`${TEXT_MUTED} mt-1 text-xs`}>
-                      Use the course link control on the current view when files
-                      need to be assigned or reassigned.
-                    </div>
-                  </HudPanel>
-                  <HudPanel
-                    variant="b"
-                    className={`${LIBRARY_PANEL_INSET} p-3`}
-                  >
-                    <div className={TEXT_PANEL_TITLE}>3. SEND TO TUTOR</div>
-                    <div className={`${TEXT_MUTED} mt-1 text-xs`}>
-                      The Tutor queue persists across views. Replace it with the
-                      current view, add this view to it, or clear it before
-                      opening Tutor.
-                    </div>
-                  </HudPanel>
-                </div>
-
                 <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
                   <div className="space-y-1">
-                    <div className={TEXT_PANEL_TITLE}>YOUR MATERIALS</div>
+                    <div className={LIBRARY_PANEL_TITLE}>YOUR MATERIALS</div>
                     <div className={TEXT_MUTED}>
                       {sidebarMode === "courses" ? "Course" : "Folder"}:{" "}
                       <span className="!text-white font-terminal">
@@ -2455,51 +2738,6 @@ function useLibraryPageController() {
 
                     <HudPanel
                       variant="b"
-                      className={`${LIBRARY_PANEL_INSET} space-y-2 p-2`}
-                    >
-                      <div
-                        className={`${TEXT_MUTED} text-ui-xs uppercase tracking-wide`}
-                      >
-                        Tutor Queue
-                      </div>
-                      <div className="flex items-center flex-wrap gap-2">
-                        <HudButton
-                          variant="outline"
-                          className={LIBRARY_COMPACT_BUTTON}
-                          disabled={!selectableVisibleMaterialIds.length}
-                          onClick={replaceTutorQueueWithVisible}
-                        >
-                          REPLACE WITH VIEW
-                        </HudButton>
-                        <HudButton
-                          variant="outline"
-                          className={LIBRARY_COMPACT_BUTTON}
-                          disabled={!selectableVisibleMaterialIds.length}
-                          onClick={addVisibleToTutorQueue}
-                        >
-                          ADD VIEW
-                        </HudButton>
-                        <HudButton
-                          variant="outline"
-                          className={LIBRARY_COMPACT_BUTTON}
-                          disabled={!selectedForTutor.length}
-                          onClick={clearTutorQueue}
-                        >
-                          CLEAR QUEUE
-                        </HudButton>
-                        <HudButton
-                          variant="outline"
-                          className={LIBRARY_COMPACT_BUTTON}
-                          disabled={!selectedForTutor.length}
-                          onClick={handleOpenTutor}
-                        >
-                          OPEN TUTOR ({selectedForTutor.length})
-                        </HudButton>
-                      </div>
-                    </HudPanel>
-
-                    <HudPanel
-                      variant="b"
                       className="space-y-2 border-destructive/30 bg-destructive/5 p-2"
                     >
                       <div className="text-ui-xs uppercase tracking-wide text-red-200">
@@ -2508,7 +2746,7 @@ function useLibraryPageController() {
                       <div className="flex items-center flex-wrap gap-2">
                         <HudButton
                           variant="outline"
-                          className="w-auto min-h-[32px] rounded-none border-destructive/50 px-3 text-xs text-destructive hover:bg-destructive/10"
+                          className="w-auto min-h-[34px] rounded-none border-destructive/50 px-3 text-sm text-destructive hover:bg-destructive/10"
                           disabled={
                             selectedVisibleMaterialIds.length === 0 ||
                             clearMaterialsMutation.isPending
@@ -2537,7 +2775,7 @@ function useLibraryPageController() {
                         </HudButton>
                         <HudButton
                           variant="outline"
-                          className="w-auto min-h-[32px] rounded-none border-destructive/50 px-3 text-xs text-destructive hover:bg-destructive/10"
+                          className="w-auto min-h-[34px] rounded-none border-destructive/50 px-3 text-sm text-destructive hover:bg-destructive/10"
                           disabled={
                             materials.length === 0 ||
                             clearMaterialsMutation.isPending
@@ -2571,7 +2809,7 @@ function useLibraryPageController() {
                 </div>
 
                 {hiddenTutorSelectionCount > 0 ? (
-                  <div className="border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs font-terminal text-yellow-100">
+                  <div className="border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm font-terminal text-yellow-100">
                     The Tutor queue still includes {hiddenTutorSelectionCount}{" "}
                     file{hiddenTutorSelectionCount === 1 ? "" : "s"} from other
                     views. Use{" "}
@@ -2609,12 +2847,12 @@ function useLibraryPageController() {
                     </div>
                   ) : (
                     <div className="h-full min-h-0 overflow-auto">
-                      <div className="min-w-[900px]">
+                      <div className="min-w-[1040px]">
                         <div
-                          className="grid gap-2 px-2 py-1 border-b border-primary/20 bg-black/60 sticky top-0 z-10"
+                          className="grid gap-3 px-3 py-2 border-b border-primary/15 bg-black/80 sticky top-0 z-10"
                           style={{
                             gridTemplateColumns:
-                              "28px minmax(210px,1.6fr) minmax(140px,1fr) 64px 72px 84px 116px",
+                              "32px minmax(250px,1.55fr) minmax(180px,1fr) 78px 84px 92px 126px",
                           }}
                         >
                           <div
@@ -2703,7 +2941,7 @@ function useLibraryPageController() {
             data-testid="library-add-course-form"
           >
             <label className="block">
-              <span className="block text-xs font-terminal uppercase tracking-[0.18em] text-muted-foreground">
+              <span className="block text-sm font-terminal uppercase tracking-[0.16em] text-muted-foreground">
                 Name <span className="text-primary">*</span>
               </span>
               <input
@@ -2717,7 +2955,7 @@ function useLibraryPageController() {
               />
             </label>
             <label className="block">
-              <span className="block text-xs font-terminal uppercase tracking-[0.18em] text-muted-foreground">
+              <span className="block text-sm font-terminal uppercase tracking-[0.16em] text-muted-foreground">
                 Code
               </span>
               <input
@@ -2729,7 +2967,7 @@ function useLibraryPageController() {
               />
             </label>
             <label className="block">
-              <span className="block text-xs font-terminal uppercase tracking-[0.18em] text-muted-foreground">
+              <span className="block text-sm font-terminal uppercase tracking-[0.16em] text-muted-foreground">
                 Term
               </span>
               <input
@@ -2805,7 +3043,7 @@ function useLibraryPageController() {
                     <div className="font-arcade text-sm text-yellow-400">
                       EXTRACTION INCOMPLETE
                     </div>
-                    <div className={`${TEXT_MUTED} text-xs mt-1`}>
+                    <div className={`${TEXT_MUTED} text-sm mt-1`}>
                       {Math.round(materialContent.replacement_ratio * 100)}% of
                       this PDF could not be decoded — it may use scanned images
                       or an embedded font. The readable portions are shown

--- a/dashboard_rebuild/client/src/pages/tutor.tsx
+++ b/dashboard_rebuild/client/src/pages/tutor.tsx
@@ -61,6 +61,7 @@ function toJsonRecords<T extends object>(items: T[]): Record<string, unknown>[] 
 function useTutorPageController() {
   const queryClient = useQueryClient();
   const initialRouteQuery = useMemo(() => readTutorShellQuery(), []);
+  const pendingLaunchHandoff = useMemo(() => peekTutorLaunchHandoff(), []);
   const lastPersistedShellKeyRef = useRef("");
   const pendingPersistShellKeyRef = useRef<string | null>(null);
   const pendingPersistShellPayloadRef =
@@ -82,12 +83,11 @@ function useTutorPageController() {
     useState<number | null>(null);
   const [entrySessionName, setEntrySessionName] = useState("");
   const [entryMaterialSelectionTouched, setEntryMaterialSelectionTouched] =
-    useState(false);
+    useState(() => pendingLaunchHandoff.fromLibraryHandoff);
   const [entryCardFlashActive, setEntryCardFlashActive] = useState(false);
   const [entryCardStatusMessage, setEntryCardStatusMessage] = useState<string | null>(null);
 
   // ─── Shell state ───
-  const pendingLaunchHandoff = useMemo(() => peekTutorLaunchHandoff(), []);
   const storedActiveSessionId = useMemo(() => readTutorActiveSessionId(), []);
   const studioRun = useStudioRun({
     initialRouteQuery,
@@ -880,6 +880,9 @@ function useTutorPageController() {
     const canonicalMaterialSelection = readTutorSelectedMaterialIds();
     if (canonicalMaterialSelection.length > 0) {
       hub.setSelectedMaterials(canonicalMaterialSelection);
+      if (fromLibraryHandoff) {
+        setEntryMaterialSelectionTouched(true);
+      }
     }
     if (!fromLibraryHandoff && !fromBrainHandoff) {
       restoredCourseId = applyStoredStartState(

--- a/dashboard_rebuild/client/src/pages/tutor.tsx
+++ b/dashboard_rebuild/client/src/pages/tutor.tsx
@@ -1142,7 +1142,7 @@ function useTutorPageController() {
     session.advanceBlock,
   ]);
   const tutorHeroActionClassName =
-    "tutor-hero-action inline-flex min-h-[56px] min-w-[12rem] w-auto shrink-0 items-center justify-center gap-2.5 rounded-none px-6 py-3.5 font-arcade text-[0.92rem] leading-none tracking-[0.16em]";
+    "tutor-hero-action inline-flex min-h-[44px] min-w-[9.5rem] w-auto shrink-0 items-center justify-center gap-2 rounded-none px-3.5 py-2.5 font-arcade text-[0.72rem] leading-none tracking-[0.12em] sm:min-h-[50px] sm:min-w-[10.5rem] sm:px-5 sm:py-3 sm:text-[0.82rem] sm:tracking-[0.14em] xl:min-h-[56px] xl:min-w-[12rem] xl:px-6 xl:py-3.5 xl:text-[0.92rem] xl:tracking-[0.16em]";
 
   // ─── Render ───
   return (
@@ -1152,7 +1152,7 @@ function useTutorPageController() {
       subtitle="Run your study plan from Workspace Home through Priming, then move into Tutor and Final Sync without losing context."
       className="h-full min-h-0"
       contentClassName="gap-6"
-      heroClassName="min-h-[243px]"
+      heroClassName="tutor-page-hero"
       stats={tutorHeroStats}
       actions={
         <>

--- a/dashboard_rebuild/client/src/pages/tutor.tsx
+++ b/dashboard_rebuild/client/src/pages/tutor.tsx
@@ -37,6 +37,7 @@ import {
   writeTutorSelectedMaterialIds,
   writeTutorStoredStartState,
   writeTutorVaultFolder,
+  type TutorCourseSetupPrimingHandoff,
 } from "@/lib/tutorClientState";
 import { resolveResumableTutorHubCandidate } from "@/lib/tutorResumeCandidate";
 import { readTutorShellQuery, writeTutorShellQuery } from "@/lib/tutorUtils";
@@ -84,8 +85,11 @@ function useTutorPageController() {
   const [entrySessionName, setEntrySessionName] = useState("");
   const [entryMaterialSelectionTouched, setEntryMaterialSelectionTouched] =
     useState(() => pendingLaunchHandoff.fromLibraryHandoff);
+  const [courseSetupPrimingHandoff, setCourseSetupPrimingHandoff] =
+    useState<TutorCourseSetupPrimingHandoff | null>(null);
   const [entryCardFlashActive, setEntryCardFlashActive] = useState(false);
   const [entryCardStatusMessage, setEntryCardStatusMessage] = useState<string | null>(null);
+  const setupPrimingStartedRef = useRef<string | null>(null);
 
   // ─── Shell state ───
   const storedActiveSessionId = useMemo(() => readTutorActiveSessionId(), []);
@@ -841,11 +845,25 @@ function useTutorPageController() {
   // ─── Restore shell state on mount ───
   const restoreTutorShellState = useCallback(async () => {
     let restoredCourseId = false;
-    const { fromLibraryHandoff, brainLaunchContext: nextBrainLaunchContext } =
-      consumeTutorLaunchHandoff();
+    const {
+      fromLibraryHandoff,
+      brainLaunchContext: nextBrainLaunchContext,
+      courseSetupPrimingHandoff: nextCourseSetupPrimingHandoff,
+    } = consumeTutorLaunchHandoff();
     const fromBrainHandoff = Boolean(nextBrainLaunchContext);
     if (nextBrainLaunchContext) {
       setBrainLaunchContext(nextBrainLaunchContext);
+    }
+    if (nextCourseSetupPrimingHandoff) {
+      setCourseSetupPrimingHandoff(nextCourseSetupPrimingHandoff);
+      setEntryMaterialSelectionTouched(true);
+      setShowSetup(false);
+      suppressProjectShellRestoreRef.current = true;
+      hub.setSelectedMaterials([nextCourseSetupPrimingHandoff.materialId]);
+      hub.setTopic(`Course setup: ${nextCourseSetupPrimingHandoff.materialTitle}`);
+      if (typeof nextCourseSetupPrimingHandoff.courseId === "number") {
+        hub.setCourseId(nextCourseSetupPrimingHandoff.courseId);
+      }
     }
 
     const resumeCandidateSessionId =
@@ -903,6 +921,46 @@ function useTutorPageController() {
       }
     }
   }, [applyStoredStartState, hub, initialRouteQuery, session]);
+
+  useEffect(() => {
+    if (!courseSetupPrimingHandoff || !hasRestored) return;
+    const courseId = courseSetupPrimingHandoff.courseId ?? hub.courseId;
+    if (typeof courseId !== "number") return;
+    const key = `${courseId}:${courseSetupPrimingHandoff.materialId}`;
+    if (setupPrimingStartedRef.current === key) return;
+    setupPrimingStartedRef.current = key;
+    suppressProjectShellRestoreRef.current = true;
+    setShowSetup(false);
+    hub.setCourseId(courseId);
+    hub.setSelectedMaterials([courseSetupPrimingHandoff.materialId]);
+    hub.setTopic(`Course setup: ${courseSetupPrimingHandoff.materialTitle}`);
+
+    void (async () => {
+      const workflowId = await workflow.createWorkflowAndOpenPriming({
+        courseId,
+        topic: `Course setup: ${courseSetupPrimingHandoff.materialTitle}`,
+        selectedMaterials: [courseSetupPrimingHandoff.materialId],
+        selectedPaths: [],
+        selectedObjectiveGroup: "",
+        selectedObjectiveId: "",
+        objectiveScope: "module_all",
+      });
+      if (workflowId) {
+        setPanelLayout(buildStudioShellPresetLayout("priming"));
+        setStartPrimingViewportFocusRequestKey((current) =>
+          typeof current === "number" ? current + 1 : 1,
+        );
+      }
+      setCourseSetupPrimingHandoff(null);
+    })();
+  }, [
+    courseSetupPrimingHandoff,
+    hasRestored,
+    hub,
+    setPanelLayout,
+    setShowSetup,
+    workflow,
+  ]);
 
   // ─── Effects ───
   useEffect(() => {

--- a/docs/root/INSTALL.md
+++ b/docs/root/INSTALL.md
@@ -48,8 +48,8 @@ Before testing on a new computer, confirm these local roots are real on that mac
 | `OBSIDIAN_VAULT_FS_PATH` | Obsidian reads/writes | `/Users/fst/Desktop/Treys School/Treys School` |
 | `PT_OBSIDIAN_VAULT_PATH` | Obsidian helper alias | `/Users/fst/Desktop/Treys School/Treys School` |
 | `OBSIDIAN_VAULT_NAME` | `obsidian://` links | `Treys School` |
-| `PT_STUDY_RAG_DIR` | Library folder scan and material sync | `/Users/fst/Desktop/PT School` |
-| `TUTOR_MATERIALS_DIR` / `PT_SCHOOL_MATERIALS_DIR` | Optional material sync aliases | `/Users/fst/Desktop/PT School` |
+| `PT_STUDY_RAG_DIR` | Library folder scan and material sync | `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School` |
+| `TUTOR_MATERIALS_DIR` / `PT_SCHOOL_MATERIALS_DIR` | Optional material sync aliases | `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School` |
 | `PT_BRAIN_PORT` | Dashboard URL and OAuth callbacks | `5127` |
 | `GOOGLE_REDIRECT_URI` or `PT_GCAL_REDIRECT_URI` | Google Calendar OAuth | `http://localhost:5127/api/gcal/oauth/callback` |
 
@@ -189,7 +189,7 @@ On macOS, vault/material examples usually look like:
 
 ```dotenv
 OBSIDIAN_VAULT_FS_PATH=/Users/fst/Desktop/Treys School/Treys School
-PT_STUDY_RAG_DIR=/Users/fst/Desktop/PT School
+PT_STUDY_RAG_DIR=/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School
 PT_BRAIN_PORT=5127
 PT_GCAL_REDIRECT_URI=http://localhost:5127/api/gcal/oauth/callback
 ```
@@ -261,7 +261,7 @@ Recommended flow:
 1. Install the app from GitHub.
 2. Configure `brain/.env`.
 3. Confirm Obsidian Sync has pulled the current vault on the new machine.
-4. Create or copy the current semester material folder, for example `/Users/fst/Desktop/PT School`.
+4. Confirm the current semester material folder is available at `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`.
 5. Start the dashboard.
 6. Open `/library`.
 7. Add or import current semester materials.
@@ -329,5 +329,5 @@ The exact stats payload can vary by machine and database.
 - If the page loads but routes 404, rebuild the UI: `cd dashboard_rebuild && npm run build`.
 - If Obsidian writes fail, verify `OBSIDIAN_VAULT_FS_PATH`, `PT_OBSIDIAN_VAULT_PATH`, `OBSIDIAN_API_URL`, and the Obsidian Local REST API plugin.
 - If Library has no materials on a new semester install, that is expected. Import the current semester files fresh.
-- If Library folder scan fails on macOS, verify `/Users/fst/Desktop/PT School` exists or paste the actual local material folder path.
+- If Library folder scan fails on macOS, verify `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School` exists or paste the actual local material folder path.
 - If Google Calendar auth redirects to port `5000` on macOS, update `PT_GCAL_REDIRECT_URI` or `brain/data/api_config.json` to use port `5127`.

--- a/docs/root/MACHINE_PATHS.md
+++ b/docs/root/MACHINE_PATHS.md
@@ -13,7 +13,7 @@ This is the checklist for moving PT Study OS to a new computer. GitHub syncs cod
 | `OBSIDIAN_VAULT_FS_PATH` | Filesystem vault root for direct reads/writes | `C:\Users\treyt\Desktop\Treys School` | `/Users/fst/Desktop/Treys School/Treys School` |
 | `PT_OBSIDIAN_VAULT_PATH` | Alias for the same vault root | same as above | same as above |
 | `OBSIDIAN_VAULT_NAME` | Vault name for `obsidian://` links | `Treys School` | `Treys School` or the actual Mac vault name |
-| `PT_STUDY_RAG_DIR` | Source material folder scanned from Library | `C:\Users\treyt\OneDrive\Desktop\PT School` | `/Users/fst/Desktop/PT School` |
+| `PT_STUDY_RAG_DIR` | Source material folder scanned from Library | `C:\Users\treyt\OneDrive\Desktop\PT School` | `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School` |
 | `TUTOR_MATERIALS_DIR` / `PT_SCHOOL_MATERIALS_DIR` | Optional aliases for material sync flows | same PT School folder | same PT School folder |
 | `PT_BRAIN_PORT` | Local dashboard port | `5000` | `5127` |
 | Google OAuth redirect | Calendar callback URI must match the local port | `http://localhost:5000/api/gcal/oauth/callback` | `http://localhost:5127/api/gcal/oauth/callback` |
@@ -50,10 +50,10 @@ On macOS, those paths do not exist unless the source files were copied and the m
 
 For testing old materials on macOS:
 
-1. Copy the Windows `PT School` source folder to `/Users/fst/Desktop/PT School`.
-2. Set `PT_STUDY_RAG_DIR=/Users/fst/Desktop/PT School`.
-3. Set `TUTOR_MATERIALS_DIR=/Users/fst/Desktop/PT School`.
-4. Set `PT_SCHOOL_MATERIALS_DIR=/Users/fst/Desktop/PT School`.
+1. Use the OneDrive-backed `PT School` source folder at `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`.
+2. Set `PT_STUDY_RAG_DIR=/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`.
+3. Set `TUTOR_MATERIALS_DIR=/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`.
+4. Set `PT_SCHOOL_MATERIALS_DIR=/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`.
 5. Copy `brain/data/uploads/` only if old uploaded-file previews matter.
 6. Start the dashboard and re-scan or re-import selected current materials from `/library`.
 
@@ -84,7 +84,7 @@ Verified Mac Obsidian vault path:
 Required Mac material root for old/current PT School source files:
 
 ```text
-/Users/fst/Desktop/PT School
+/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School
 ```
 
 The Mac dashboard default is:

--- a/docs/root/STUDY_LOOP_FLOW_AND_GAP_REVIEW.md
+++ b/docs/root/STUDY_LOOP_FLOW_AND_GAP_REVIEW.md
@@ -1,0 +1,190 @@
+# PT Study OS Complete Study Loop Flow And Gap Review
+
+Last updated: 2026-05-13
+
+Authority note: `README.md` remains the product/source-of-truth document. This file is the operational map and gap ledger for proving the current app against Trey's real PT coursework folder.
+
+## Goal
+
+Map and test the complete loop from coursework input to live studying and system improvement:
+
+1. Bring current PT School coursework into Library.
+2. Verify courses, setup files, schedules, materials, sync jobs, and embedded `rag_docs`.
+3. Launch or resume Tutor from a selected real course/material.
+4. Move through Priming, Workspace cards/concept mapping, Tutor, Polish, and Final Sync where available.
+5. Confirm Brain telemetry and Scholar/SOP improvement paths remain connected.
+6. Classify and close only gaps that block real studying or distort the intended loop.
+
+## Full Loop Map
+
+```mermaid
+flowchart TD
+  A["Real PT School folder"] --> B{"Choose input path"}
+  B --> C["Semester Intake preview"]
+  B --> D["Direct material upload"]
+  B --> E["Folder sync preview/start"]
+
+  C --> F{"Classifications reasonable?"}
+  F -->|"No"| G["Fix folder/dependency/classification gap, then rescan"]
+  G --> C
+  F -->|"Yes"| H["Back up SQLite DB"]
+  H --> I["Semester Intake apply"]
+
+  D --> J["Library course/material state"]
+  E --> J
+  I --> J
+
+  I --> K["Courses, modules, syllabus objectives, course events"]
+  I --> L["Material sync jobs"]
+  L --> M["rag_docs + embed status"]
+  K --> N["Study wheel / planning context"]
+  M --> O{"At least one Tutor-ready course?"}
+  N --> O
+  J --> O
+
+  O -->|"No"| P["Fix P0 intake/sync/readiness blocker"]
+  P --> J
+  O -->|"Yes"| Q{"Study entry path"}
+
+  Q --> R["Library handoff to Tutor"]
+  Q --> S["Tutor direct course/material launch"]
+  Q --> T["Resume existing Tutor session"]
+
+  R --> U["Studio Workspace Home / Source Shelf"]
+  S --> U
+  T --> V["Live Tutor session"]
+  U --> W["Priming"]
+  W --> WC["Workspace cards auto-created from Priming results"]
+  WC --> CM["Workspace Canvas / Mind Map / Concept Map"]
+  WC --> TP["Tutor Context Packet from selected cards"]
+  WC --> OM["Obsidian markdown handoff packet"]
+  TP --> V
+  V --> X["Tutor artifacts, turns, notes, session state"]
+  X --> Y["Polish"]
+  Y --> Z["Final Sync"]
+
+  OM --> AA["External Obsidian agent / Obsidian notes"]
+  Z --> AA
+  Z --> AB["Anki/card drafts when enabled"]
+  Z --> AC["Brain telemetry/session evidence"]
+  AC --> AD["Brain home/status surfaces"]
+  AC --> AE["Scholar review and proposals"]
+  AE --> AF{"Human approves improvement?"}
+  AF -->|"No"| AD
+  AF -->|"Yes"| AG["SOP/method/library update"]
+  AG --> U
+```
+
+## Decision Paths To Verify
+
+- Semester Intake:
+  - New course folder creates or updates a course.
+  - Existing course folder maps to the existing course instead of duplicating it.
+  - Syllabus/setup files are parsed into modules/objectives where possible.
+  - Schedule files are parsed into course events where possible.
+  - Material files launch material sync jobs.
+  - Global schedule files are visible for review and not silently treated as a course.
+  - Ignored/admin files stay out of Tutor scope.
+  - Unassigned materials are visible so they can be handled manually.
+- Library alternatives:
+  - Direct upload remains available for one-off files.
+  - Folder sync remains available for selective import.
+  - Library material selection can hand off to Tutor.
+- Tutor readiness:
+  - A real course has at least one enabled material.
+  - Workspace Context can start Tutor directly from selected course/material/study unit.
+  - Preflight is no longer a required user-facing session gate.
+  - Priming results create editable Workspace cards automatically.
+  - Workspace cards can be edited, hidden, deleted, selected for Tutor, and selected for Obsidian.
+  - Workspace card buckets populate from Priming cards instead of showing empty counts.
+  - Tutor startup packet includes cards marked for Tutor context.
+  - Obsidian handoff generates a structured markdown packet from cards marked for Obsidian.
+  - A Tutor session can be created, restored, summarized, ended, or resumed.
+  - Scoped retrieval carries explicit selected `material_ids` and an `accuracy_profile`.
+- Loop completion:
+  - Tutor turns and artifacts persist.
+  - Polish and Final Sync surfaces are reachable from the workflow shell.
+  - Obsidian, Anki/card drafts, Brain telemetry, and Scholar proposal paths are represented truthfully.
+
+## Real Folder Result
+
+Tested folder: `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`
+
+Semester Intake preview found:
+
+- 3 course folders with supported files.
+- 6 syllabus files.
+- 6 schedule files, including 1 global schedule under `00_Class schedules`.
+- 27 material files.
+- 14 ignored/admin files under `90_Misc/EXXAT Uploads`.
+- 0 unassigned material files.
+
+Current course interpretation:
+
+| Course | Code | Preview result | Tutor readiness |
+| --- | --- | --- | --- |
+| Dx Mgmt Integumtary | PHYT 6262 | Existing course matched by code despite folder typo. Syllabus found. No current materials in that folder. | Not ready yet. Needs material files. |
+| Assistive Technology and Functional training | PHYT 6424 | Existing course matched. Syllabus, schedule, and 22 material files found. | Ready: existing embedded material is present. |
+| Professionalism | PHYT 6109 | Existing course matched. Syllabus, schedule, and 5 material files found. | Ready: 2 embedded materials and grouped study-unit objectives are present. |
+
+`11_Movement Science II` and `14_Cardiovascular Pulmonary` exist as folders but currently contain only `.DS_Store`, so they do not appear in Semester Intake yet. That is not an intake classifier failure; they need at least one supported syllabus, schedule, or material file.
+
+## Validation Matrix
+
+Status values:
+
+- `PASS`: tested this run and working.
+- `GAP`: tested this run and mismatched/broken.
+- `NOT TESTED`: not yet exercised in this run.
+- `DEFER`: known non-blocking follow-up.
+
+| Area | Check | Status | Evidence / Notes |
+| --- | --- | --- | --- |
+| Baseline | `git status --short` captured before new changes | PASS | Existing dirty files preserved: Tutor header CSS/TSX from prior fix. |
+| Baseline | `npm run check` | PASS | TypeScript check passed in `dashboard_rebuild`. |
+| Baseline | `npm run build` | PASS | Vite build passed and regenerated `brain/static/dist`. |
+| Baseline | `pytest brain/tests/test_semester_intake.py -q` | PASS | 6 passed, 5 warnings from third-party SWIG import deprecations. |
+| Baseline | Focused Tutor/session/intake smoke regressions | PASS | `.venv/bin/python -m pytest brain/tests/test_tutor_session_linking.py brain/tests/test_semester_intake.py brain/tests/test_live_tutor_smoke.py -q`: 51 passed, 5 third-party SWIG deprecation warnings. |
+| Workspace | Priming results auto-create Workspace cards | PASS | `TutorWorkflowPrimingPanel.test.tsx` proves non-visual result blocks auto-capture as `text_note` Workspace cards. |
+| Workspace | Sidebar buckets count Priming cards | PASS | `StudioWorkspaceMaterialSidebar.test.tsx` proves Priming Workspace cards appear in Learning Objectives and related buckets. |
+| Workspace | Card controls | PASS | `StudioTldrawWorkspace.test.tsx` proves edit, hide, delete, Tutor selection, and Obsidian selection on Workspace cards. |
+| Workspace | Obsidian markdown handoff | PASS | `obsidianHandoffPacket.test.ts` and `StudioTldrawWorkspace.test.tsx` prove selected cards serialize/copy as structured markdown. |
+| Tutor | Workspace Context direct start | PASS | `useTutorSession.test.tsx` proves frontend starts Tutor via `createSession` directly with course/material/objective context, not `/session/preflight`. |
+| Baseline | Focused Library frontend test | PASS | `npm run test -- client/src/pages/__tests__/library.test.tsx`: 3 passed. |
+| App health | `Start_Dashboard.command` / health endpoint | PASS | Dashboard restarted through the Mac launcher path and healthy on `http://127.0.0.1:5127/api/brain/status`: `ok: true`, 3 `rag_documents`, 1 active session. |
+| Real folder | Semester Intake preview of OneDrive PT School folder | PASS | Counts: 3 courses, 6 syllabus, 6 schedule, 27 material, 14 ignored, 0 unassigned. |
+| Intake apply | DB backup before real apply | PASS | Backup created at `brain/data/backups/pt_study_before_study_loop_apply_2026-05-13.db`. |
+| Intake apply | Apply reviewed classifications only | PASS | Applied structure only after review: 0 new courses, 3 updated, 6 setup files parsed, 14 objectives created, 0 setup parse errors, 0 material sync jobs. |
+| Library state | Courses/materials/sync jobs/rag_docs/embed status | PASS | 3 courses; 3 enabled `rag_docs`; embed status total 3, embedded 3, pending 0, stale 0. |
+| Tutor | Safe local Tutor path | PASS | `scripts/live_tutor_smoke.py --base-url http://127.0.0.1:5127 --skip-turn` passed. It created/restored/summarized/ended/deleted a material-scoped Professionalism session without calling the external model. |
+| Tutor | `scripts/live_tutor_smoke.py` full model-backed turn | DEFER | Not run by Codex because the turn step can send selected coursework to the configured external LLM provider; run only with explicit user approval. |
+| Browser | `/brain`, `/library`, and `/tutor` rendered checks | PASS | Built-in browser opened Brain, Library, and Tutor. Library showed `SEMESTER INTAKE` plus course names; Tutor opened `Professionalism` live session `tutor-20260513-101225-0c7ef7` with 2 materials, no visible Preflight, and no console errors. |
+
+## Gap Register
+
+| Priority | Gap | Current Evidence | Action |
+| --- | --- | --- | --- |
+| P0 | Semester Intake could duplicate typo-named folders instead of matching the existing course by course code. | `10_Dx Mgmt Integumtary` contains `PHYT 6262` but the existing course is named `Dx Mgmt Integumentary`. | Fixed: preview/apply infer `PHYT ####` from folder/files and match existing courses by code. |
+| P0 | Intake could create modules with no grouped objectives, leaving Tutor without a study-unit start handle. | Professionalism had modules/events but zero learning objectives, so `live_tutor_smoke` could not find a preflight-ready scope. | Fixed: apply now assigns objective `group_name` to the module/study unit and creates a conservative fallback `Study <module>` objective when setup parsing finds modules but no explicit objectives. |
+| P0 | Tutor preflight hard-failed when the course was not mapped into the Obsidian vault, even with selected embedded materials. | Professionalism preflight returned `Unmapped vault course 'Professionalism'...`. | Fixed: unmapped MoC context is now a warning for material-backed sessions, not a blocking 500. |
+| P0 | Preflight was still a required user-facing Tutor start gate. | Frontend called `/api/tutor/session/preflight` before `createSession`; backend rejected direct objective-scoped sessions with `PREFLIGHT_REQUIRED`. | Fixed: frontend sends Workspace Context directly to `createSession`; backend accepts objective/material context without a preflight id. |
+| P0 | Priming outputs did not become the active Workspace thinking table. | Text-only Priming blocks previously stayed in the Priming panel unless manually promoted; sidebar buckets stayed empty. | Fixed: Priming result blocks auto-create Workspace cards and sidebar buckets include them. |
+| P1 | Workspace cards lacked first-use controls for the study loop. | The workbench showed notes/excerpts but did not let the user edit, hide, delete, or mark cards for Tutor/Obsidian. | Fixed for Workspace cards: edit/hide/delete plus Tutor and Obsidian selection toggles are available. |
+| P1 | External Obsidian workflow required manual copy-chaining. | User had to copy Priming output to an external Obsidian agent by hand. | Fixed: Workspace can copy a structured Obsidian markdown handoff packet from selected cards. |
+| P1 | Semester Intake preview always reported embeddings as pending and `readyForTutor: false`. | Assistive Technology and Professionalism had embedded materials but preview showed not ready. | Fixed: preview now reads existing `rag_docs`/`rag_embeddings` and marks existing embedded courses ready. |
+| P1 | Full material apply would try to sync 27 files, including a 268 MB textbook, even though enough material is already embedded to study today. | Real preview includes `OSullivan Physical Rehabilitation 7th Ed.pdf` at 268 MB. | Deferred: structure-only apply was used today; selectively sync additional files from Library when needed. |
+| P1 | Assistive Technology is material-ready but has no parsed study-unit objectives yet. | AT has 1 embedded TXT and 22 previewed material files, but the setup parser did not extract modules/objectives from its files. | Deferred: usable for material review, but a better AT module/objective parser or manual objective approval is still needed. |
+| P2 | Old flowcharts do not represent the current in-app Semester Intake path. | Existing `docs/flowcharts/01-system-overview.mmd` starts from generic material ingestion, not the current Library intake workflow. | Keep this doc as the truthful loop map; add `docs/flowcharts/07-complete-study-loop.mmd` only if the embedded diagram becomes too large. |
+| P2 | Existing docs mix older M0-M6 language with current Studio workflow language. | README is current truth; historical flowcharts are older visual companions. | Do not refactor old docs today unless they confuse the study-now path. |
+
+## Study-Now Handoff
+
+- Ready course: Professionalism (`PHYT 6109`).
+- Ready study unit: `Week 1: The Future of Healthcare Systems and Why Leadership is Needed`.
+- Ready materials:
+  - `PHYT 6109 VS Class 1 - Course Orientation and Professionalism Training Lab 1.pdf`
+  - `Developing Habits of the Heart - Polly 2019.pdf`
+- Open path: `http://127.0.0.1:5127/tutor?course_id=3&session_id=tutor-20260513-101225-0c7ef7`.
+- Start/resume action: open Tutor and click `RESUME` on the live session. The session is already created, material-scoped, and restorable.
+- What was fixed: course-code matching, fallback grouped objectives, material-backed preflight without required Obsidian vault mapping, and truthful intake readiness.
+- What remains imperfect but non-blocking: no model-backed Tutor turn was run by Codex without explicit approval to send coursework to the configured provider; the active session carries a non-blocking Obsidian map-of-contents warning because Professionalism is not mapped in the vault yet; AT/CV/Movement need more setup/objective work; full 27-file sync was intentionally deferred.

--- a/docs/root/TUTOR_TODO.md
+++ b/docs/root/TUTOR_TODO.md
@@ -28,6 +28,26 @@ Purpose: keep implementation work ordered, visible, and tied to tests and verifi
 - Historical note: detailed implementation evidence still lives in the linked Conductor tracks plus `conductor/tracks/GENERAL/log.md`.
 - Ops note (2026-03-25): `dev-browser` is now a shared agent skill projected into every supported agent root; this does not change Tutor sprint priority.
 
+- [x] LIBRARY-FILE-EXPLORER-TABLE-2026-05-15. Add basic file-explorer controls to the Library file list before bigger visual redesign work.
+  - Scope:
+    - Let table columns resize by dragging header separators.
+    - Let double-clicking a separator auto-fit a column to visible file text.
+    - Let headers drag to reorder columns.
+    - Add simple header filter buttons for file selection basics.
+    - Keep the Library catalog-only boundary; no Tutor handoff or ingestion workflow changes.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-15
+  - Validation:
+    - Library file rows now render from a configurable column model instead of a fixed grid.
+    - Header separators resize columns by drag; double-clicking a separator auto-fits to visible file text.
+    - Header cells can be dragged to reorder columns, with order/widths persisted in local storage.
+    - Title, Folder, Type, and Status headers expose basic filter buttons; right-edge filters align inward so their controls remain visible.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, and `npm run build`.
+    - Built-in browser verification before the final alignment tweak confirmed the controls render and the Type filter can narrow 11 rows to 1 row; final post-build reload was blocked by Browser Use URL policy, so the next operator refresh should visually confirm the right-edge menu placement.
+  - Done when:
+    - Focused Library tests cover filter, resize/autofit, and reorder behavior.
+    - `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, `npm run build`, and browser verification pass.
+
 - [x] LIBRARY-SOURCE-FILE-PICKER-2026-05-15. Let live PT School source folders expose unuploaded files as explicit upload candidates.
   - Scope:
     - When a live source folder is selected, show source files that are not already uploaded into Library.

--- a/docs/root/TUTOR_TODO.md
+++ b/docs/root/TUTOR_TODO.md
@@ -28,6 +28,24 @@ Purpose: keep implementation work ordered, visible, and tied to tests and verifi
 - Historical note: detailed implementation evidence still lives in the linked Conductor tracks plus `conductor/tracks/GENERAL/log.md`.
 - Ops note (2026-03-25): `dev-browser` is now a shared agent skill projected into every supported agent root; this does not change Tutor sprint priority.
 
+- [x] LIBRARY-SOURCE-FILE-PICKER-2026-05-15. Let live PT School source folders expose unuploaded files as explicit upload candidates.
+  - Scope:
+    - When a live source folder is selected, show source files that are not already uploaded into Library.
+    - Keep uploads explicit with per-file checkboxes and a selected-file upload action.
+    - Reuse the existing selected-file sync backend instead of mass-loading folders.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-15
+  - Validation:
+    - Selecting a live source folder now switches to Upload and shows unchecked source-file candidates with per-file checkboxes.
+    - Selected candidates call the existing selected-file sync endpoint with relative source paths; no folder bulk load is triggered.
+    - Folder rail rows are real buttons so source folder selection works reliably in the browser.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `.venv/bin/python -m pytest brain/tests/test_tutor_material_pipeline_certification.py -q`, `npm run check`, and `npm run build`.
+    - Built-in browser verification passed on `/library`; selecting `10_Dx Mgmt Integumentary` opened Upload with 9 checkbox candidates and selecting one updated the upload button to `Upload Selected (1)`.
+  - Done when:
+    - Selecting a source folder opens the Upload tab with unchecked source-file candidates.
+    - Checked files can be uploaded into the Library catalog.
+    - Focused Library/backend checks, typecheck, build, and browser verification pass.
+
 - [x] LIBRARY-CATALOG-ONLY-2026-05-15. Simplify `/library` so it is a searchable uploaded-file catalog plus upload surface, not Tutor/intake workflow control.
   - Scope:
     - Keep course/folder browsing, uploaded-file rows, file search, file viewing, metadata edit/delete, and simple upload.

--- a/docs/root/TUTOR_TODO.md
+++ b/docs/root/TUTOR_TODO.md
@@ -28,6 +28,25 @@ Purpose: keep implementation work ordered, visible, and tied to tests and verifi
 - Historical note: detailed implementation evidence still lives in the linked Conductor tracks plus `conductor/tracks/GENERAL/log.md`.
 - Ops note (2026-03-25): `dev-browser` is now a shared agent skill projected into every supported agent root; this does not change Tutor sprint priority.
 
+- [x] LIBRARY-CURRENT-RUN-HANDOFF-2026-05-14. Keep Library one-file launches authoritative and make Library/Tutor wording Current Run-first.
+  - Scope:
+    - Preserve explicit Library-selected material IDs when Tutor opens from a Library handoff.
+    - Keep textbook/reference files visible as course references, but out of default bulk Current Run actions.
+    - Make Library actions favor one-file `Study this file` launches while keeping multi-file selection available.
+    - Clarify Tutor upload copy so uploads are understood as `Library + Current Run`.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-14
+  - Validation:
+    - Library row `Study this file` launches Tutor with only that selected file in Current Run.
+    - Tutor preserves Library handoff material IDs and no longer expands an untouched handoff to the whole course.
+    - Textbook/reference files are labeled `COURSE REF` and excluded from default bulk Current Run actions.
+    - Tutor upload copy now says uploads go to Library and Current Run.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/tutor.test.tsx client/src/pages/__tests__/library.test.tsx client/src/components/__tests__/TutorShell.test.tsx client/src/components/studio/__tests__/SourceShelf.test.tsx`, `npm run check`, `npm run build`.
+    - Built-in browser verification passed for `/library` and one-file Library -> Tutor handoff at `http://127.0.0.1:5127`.
+  - Done when:
+    - Focused Library/Tutor tests prove one-file handoff, reference exclusion, and Tutor upload wording.
+    - `npm run build` passes and `/library` plus Tutor handoff are browser-checked.
+
 - [x] LIBRARY-EXPLICIT-FILE-LOAD-2026-05-13. Make Library intake/sync load only files Trey explicitly selects.
   - Scope:
     - Semester Intake still scans a folder for classification, but material files are not auto-loaded.

--- a/docs/root/TUTOR_TODO.md
+++ b/docs/root/TUTOR_TODO.md
@@ -28,6 +28,81 @@ Purpose: keep implementation work ordered, visible, and tied to tests and verifi
 - Historical note: detailed implementation evidence still lives in the linked Conductor tracks plus `conductor/tracks/GENERAL/log.md`.
 - Ops note (2026-03-25): `dev-browser` is now a shared agent skill projected into every supported agent root; this does not change Tutor sprint priority.
 
+- [x] LIBRARY-CATALOG-ONLY-2026-05-15. Simplify `/library` so it is a searchable uploaded-file catalog plus upload surface, not Tutor/intake workflow control.
+  - Scope:
+    - Keep course/folder browsing, uploaded-file rows, file search, file viewing, metadata edit/delete, and simple upload.
+    - Remove Library-owned Semester Intake, Folder Sync, Tutor selection/handoff, Course Setup processing, Send to Priming, Obsidian strip, and source-folder refresh/import paths from Library.
+    - Keep Tutor responsible for Priming, study launch, syllabus/schedule processing, Workspace, and Obsidian/Final Sync.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-15
+  - Validation:
+    - `/library` primary tabs are now `All Files` and `Upload`.
+    - Library rows are catalog-only: no select-for-Tutor checkbox and no row Study action.
+    - Setup files render as ordinary catalog rows with a `SETUP` badge, without Send to Priming or Obsidian controls.
+    - Folder rail now reflects uploaded Library materials only; live PT School folder refresh/import is no longer part of Library.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, and `npm run build`.
+    - Built-in browser verification passed at `http://127.0.0.1:5127/library`; `All Files` showed search/catalog rows, `Upload` showed one upload surface, and removed intake/Tutor/Obsidian controls stayed absent.
+  - Done when:
+    - Catalog-only Library passes focused tests, typecheck, build, and built-in browser verification.
+
+- [x] LIBRARY-PRIMARY-TAB-SIMPLIFY-2026-05-14. Simplify `/library` primary navigation to match the intended material-viewing workflow.
+  - Scope:
+    - Keep `Study Materials` as the main Library surface.
+    - Keep `Add Files` available for upload/intake/sync.
+    - Remove Course Setup, Tutor Handoff, and Advanced from the primary tab row.
+    - Preserve setup upload, setup-to-Priming, row Study action, and safe cleanup behavior without making those their own top-level tabs.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-14
+  - Validation:
+    - `/library` now has only `Study Materials` and `Add Files` as primary tabs.
+    - Course Setup, Tutor Handoff, and Advanced are no longer primary workflow tabs.
+    - Setup files remain reachable as a collapsible syllabus/schedule section inside Study Materials, and setup upload remains available inside Add Files.
+    - Tutor selection actions remain available inside Study Materials without a separate Tutor Handoff tab, using `Selected for Tutor`, `Use Visible`, and `Add Visible` wording.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, and `npm run build`.
+    - Built-in browser verification passed at `http://127.0.0.1:5127/library`; Study Materials and Add Files tabs rendered/clicked, removed tabs stayed absent, and console logs showed no errors/warnings.
+  - Done when:
+    - `/library` shows only the needed primary tabs.
+    - Focused Library tests, `npm run check`, `npm run build`, and browser verification pass.
+
+- [x] LIBRARY-VISUAL-DESIGN-FIX-2026-05-14. Make `/library` visually calmer, more readable, and easier to navigate after the tab workflow split.
+  - Scope:
+    - Reduce hero/header height and red visual weight on `/library`.
+    - Increase readable UI type and spacing in the Library workspace.
+    - Make the tabbed workflow feel like the primary navigation, not another nested HUD layer.
+    - Preserve current Library behavior, setup/material separation, folder refresh, and Tutor handoff.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-14
+  - Validation:
+    - Compact Library hero/status strip reduces the page's vertical weight.
+    - Workflow controls are semantic tabs with selected state and calmer graphite/crimson styling.
+    - Library-specific panels, tabs, buttons, and helper text use a quieter graphite surface palette with larger readable type.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, and `npm run build`.
+    - Built-in browser verification passed at `http://127.0.0.1:5127/library`; all workflow tabs clicked successfully and console logs showed no errors/warnings.
+  - Done when:
+    - `/library` first viewport clearly shows the course rail, workflow tabs, and current tab content without feeling cramped.
+    - Source, Course Setup, Study Materials, Tutor Handoff, and Advanced tabs remain accessible and understandable.
+    - Focused Library tests, `npm run check`, `npm run build`, and built-in browser visual verification pass.
+
+- [x] LIBRARY-SETUP-PRIMING-BOUNDARY-2026-05-14. Split Library course setup files from study materials and send syllabus/schedule setup into Tutor Priming.
+  - Scope:
+    - Keep Library as a course/file staging surface instead of an Obsidian/Tutor/Brain replacement.
+    - Save syllabus/schedule files raw as Course Setup sources, separate from normal Study Materials.
+    - Show only Obsidian status and destination context in Library.
+    - Add a Library -> Tutor Priming handoff for setup files.
+    - Keep Study Material uploads embedded for Tutor retrieval.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-14
+  - Validation:
+    - `/library` explicitly requests setup rows while ordinary Tutor material lists continue to return study materials only.
+    - Course Setup uploads persist as `course_setup` and skip study embedding; Study Material uploads still embed for Tutor retrieval.
+    - Live browser check confirmed `Send to Priming` opens Tutor in the Priming stage with Dx Mgmt Integumentary setup context.
+    - Passed: `npm run check`, `npm run build`, focused Library/MaterialUploader/API tests, material pipeline tests, and semester intake tests.
+  - Done when:
+    - Course Setup files render separately from Study Materials in `/library`.
+    - Setup uploads are not embedded as normal study material by default.
+    - `Send to Priming` opens Tutor Studio/Priming with the setup file as context.
+    - Focused frontend/backend tests, `npm run check`, and `npm run build` pass.
+
 - [x] LIBRARY-CURRENT-RUN-HANDOFF-2026-05-14. Keep Library one-file launches authoritative and make Library/Tutor wording Current Run-first.
   - Scope:
     - Preserve explicit Library-selected material IDs when Tutor opens from a Library handoff.

--- a/docs/root/TUTOR_TODO.md
+++ b/docs/root/TUTOR_TODO.md
@@ -39,7 +39,7 @@ Purpose: keep implementation work ordered, visible, and tied to tests and verifi
     - `/library` primary tabs are now `All Files` and `Upload`.
     - Library rows are catalog-only: no select-for-Tutor checkbox and no row Study action.
     - Setup files render as ordinary catalog rows with a `SETUP` badge, without Send to Priming or Obsidian controls.
-    - Folder rail now reflects uploaded Library materials only; live PT School folder refresh/import is no longer part of Library.
+    - Folder rail now reflects the live configured PT School source tree for navigation/counts, while the material table remains catalog-only for uploaded Library files; no source-folder import workflow is exposed in Library.
     - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, and `npm run build`.
     - Built-in browser verification passed at `http://127.0.0.1:5127/library`; `All Files` showed search/catalog rows, `Upload` showed one upload surface, and removed intake/Tutor/Obsidian controls stayed absent.
   - Done when:

--- a/docs/root/TUTOR_TODO.md
+++ b/docs/root/TUTOR_TODO.md
@@ -28,6 +28,102 @@ Purpose: keep implementation work ordered, visible, and tied to tests and verifi
 - Historical note: detailed implementation evidence still lives in the linked Conductor tracks plus `conductor/tracks/GENERAL/log.md`.
 - Ops note (2026-03-25): `dev-browser` is now a shared agent skill projected into every supported agent root; this does not change Tutor sprint priority.
 
+- [x] LIBRARY-EXPLICIT-FILE-LOAD-2026-05-13. Make Library intake/sync load only files Trey explicitly selects.
+  - Scope:
+    - Semester Intake still scans a folder for classification, but material files are not auto-loaded.
+    - Folder Sync preview starts with zero selected files instead of selecting the whole folder tree.
+    - Add file-level controls so selected material files are the only files sent to sync/apply.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-13
+  - Validation:
+    - Semester Intake scan now leaves material files unselected until Trey chooses them.
+    - Folder Sync preview now starts with zero selected files after scan instead of selecting the full folder tree.
+    - Apply/sync payloads include only selected material file paths.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, and `npm run build`.
+  - Done when:
+    - Focused Library tests prove Semester Intake and Folder Sync send only selected files.
+    - Backend scoped embedding tests remain green.
+
+- [x] OPS-DASHBOARD-CPU-SYNC-SCOPE-2026-05-13. Stop dashboard material sync from turning one course intake into a whole-library CPU job.
+  - Scope:
+    - Review `scratch/bug_dashboard_high_cpu_2026-05-13.md` and the Mac dashboard startup/sync paths.
+    - Keep Flask startup/reloader behavior stable.
+    - Scope post-sync embedding to the documents touched by that sync job.
+    - Add focused regression coverage for the material sync embedding scope.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-13
+  - Validation:
+    - Reviewed `scratch/bug_dashboard_high_cpu_2026-05-13.md`, the Mac launcher, Flask startup, route registration, polling/background-thread paths, and material sync/embedding flow.
+    - Confirmed no live dashboard was listening on `127.0.0.1:5127` during the fix pass, so the hot process had already been killed.
+    - Fixed material sync embedding so a sync job embeds only the `rag_docs` IDs returned by that sync, instead of scanning the whole materials corpus.
+    - Added regression coverage proving the sync job passes its own synced document IDs into embedding.
+    - Checks passed: `.venv/bin/python -m pytest brain/tests/test_harness_startup.py brain/tests/test_tutor_material_pipeline_certification.py brain/tests/test_tutor_rag_embedding_provider.py brain/tests/test_semester_intake.py -q`.
+  - Done when:
+    - Focused backend tests prove material sync jobs embed only their synced document IDs.
+    - The high-CPU root cause/gap is summarized with any remaining non-blocking risks.
+
+- [x] LIBRARY-COURSE-OPS-REDESIGN-2026-05-13. Redesign `/library` into a calmer course-first operations workflow.
+  - Scope:
+    - Replace the current competing intake/upload/sync panel stack with a clear Source -> Review -> Study workflow.
+    - Make course names the primary navigation signal and PHYT codes secondary metadata.
+    - Consolidate Semester Intake, Folder Sync, and Upload into one Add Coursework control area.
+    - Preserve existing Semester Intake, folder sync, direct upload, material management, course linking, cleanup, and Tutor handoff behavior.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-13
+  - Validation:
+    - Library now defaults to a course-first rail with course names primary and PHYT codes secondary.
+    - Semester Intake, Folder Sync, and Direct Upload now live in one `ADD COURSEWORK` source switcher.
+    - Readiness and Tutor handoff controls now appear once in a dedicated `STUDY READINESS` panel instead of repeated workflow cards.
+    - Library hero is compacted so the operations workspace is reachable in a narrow in-app browser window.
+    - Checks passed: `npm run test -- client/src/pages/__tests__/library.test.tsx`, `npm run check`, `npm run build`, launcher health check at `http://127.0.0.1:5127/api/brain/status`, and built-in browser DOM verification for `/library`.
+  - Done when:
+    - Library renders as a course-first operations layout with calmer graphite/crimson/info/readiness colors.
+    - Movement Science II can be found by course name when present in course data or intake preview.
+    - Existing focused Library tests and new UI-flow tests pass.
+    - `npm run check`, `npm run build`, and browser verification for `/library` pass.
+
+- [x] STUDY-LOOP-WORKSPACE-CONTEXT-2026-05-13. Implement the real Library → Priming → Workspace cards/concept map → Tutor context packet → Obsidian markdown handoff loop.
+  - Scope:
+    - Make Priming outputs land as editable Workspace cards with hide/delete/edit controls.
+    - Use Workspace selection as Tutor context authority and remove the user-facing Preflight dependency.
+    - Generate a markdown Obsidian handoff packet for the external Obsidian agent.
+    - Keep syllabus/schedule intake as seed context while Priming creates actionable study objectives.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-13
+  - Validation:
+    - Priming results now auto-create editable Workspace cards; sidebar buckets include Priming cards.
+    - Workspace cards support edit, hide, delete, Tutor-context selection, and Obsidian-handoff selection.
+    - Tutor session creation uses selected material plus Workspace Context directly; the user-facing Preflight dependency is removed from the start path.
+    - Obsidian markdown handoff packet can be copied from selected Workspace cards.
+    - Checks passed: `npm run check`, `npm run build`, focused frontend tests for Priming/Workspace/Obsidian/Tutor session wiring, `.venv/bin/python -m pytest brain/tests/test_tutor_session_linking.py brain/tests/test_semester_intake.py brain/tests/test_live_tutor_smoke.py -q`, and `scripts/live_tutor_smoke.py --base-url http://127.0.0.1:5127 --skip-turn`.
+    - Built-in browser verification passed for `/brain`, `/library`, and `/tutor`; Library shows `SEMESTER INTAKE`, and Tutor opens a `Professionalism` live session without visible Preflight.
+  - Done when:
+    - Workspace buckets populate from Priming results.
+    - Selected Workspace context starts/resumes Tutor without Preflight.
+    - Obsidian handoff markdown is available from the selected Workspace context.
+    - Focused frontend/backend/browser verification passes.
+
+- [x] OPS-STUDY-LOOP-MAP-GAP-2026-05-13. Map, test, and close the full PT Study OS coursework-to-study loop against the real Mac semester folder.
+  - Scope:
+    - Document the full system loop from real coursework input through Library, Tutor, Studio workflow stages, Brain telemetry, Scholar review, and SOP/method improvement.
+    - Test the loop against `/Users/fst/Library/CloudStorage/OneDrive-Personal/Desktop/PT School`.
+    - Classify gaps as P0/P1/P2 and fix only P0/P1 gaps that block real coursework intake, material sync, Tutor readiness, or the intended loop.
+  - Assignee: @codex-cli
+  - Completed: 2026-05-13
+  - Validation:
+    - `docs/root/STUDY_LOOP_FLOW_AND_GAP_REVIEW.md` now maps the full coursework-to-study loop with a Mermaid flowchart, validation matrix, gap register, and study-now handoff.
+    - Real PT School preview: 3 courses, 6 syllabus files, 6 schedule files, 27 material files, 14 ignored/admin files, 0 unassigned files.
+    - Real apply after DB backup: 0 courses created, 3 courses updated, 6 setup files parsed, 14 objectives created, 0 setup parse errors, 0 material sync jobs.
+    - Tutor readiness: Professionalism Week 1 preflight passed, session `tutor-20260513-101225-0c7ef7` created/restored, Library/Tutor rendered in browser screenshots.
+    - Checks: `npm run check`, `npm run build`, `npm run test -- client/src/pages/__tests__/library.test.tsx`, `pytest brain/tests/test_semester_intake.py -q`, and focused Tutor preflight regression tests passed.
+  - Notes:
+    - Full `scripts/live_tutor_smoke.py` model-backed turn was not run by Codex because it can send selected coursework to the configured external LLM provider; run only with explicit user approval.
+    - Movement Science II and Cardiovascular Pulmonary folders currently contain no supported study files, so they are not intake-visible yet.
+  - Done when:
+    - `docs/root/STUDY_LOOP_FLOW_AND_GAP_REVIEW.md` reflects the current app truth with Mermaid flowcharts and validation results.
+    - Semester Intake preview/apply, Library state, material ingestion, and Tutor readiness are validated against at least one real current course.
+    - Trey receives a short study-now handoff identifying a ready course/material and any non-blocking imperfections.
+
 - [x] OPS-CROSS-PLATFORM-AUDIT-P0-2026-05-11. Review Codex Cloud repo audit, restore frontend typecheck, and keep Mac/Windows launch behavior aligned.
   - Scope:
     - Reproduce and fix P0 frontend `npm run check` failures.

--- a/scripts/live_tutor_smoke.py
+++ b/scripts/live_tutor_smoke.py
@@ -2,7 +2,7 @@
 Live Tutor Smoke Test
 
 Exercises the modern Tutor lifecycle:
-  course discovery -> material/objective discovery -> preflight ->
+  course discovery -> material/objective discovery -> Workspace Context ->
   create -> turn (SSE) -> restore -> summary -> end -> delete
 
 Prerequisites:
@@ -13,6 +13,7 @@ Prerequisites:
 
 Usage:
   python scripts/live_tutor_smoke.py [--base-url http://127.0.0.1:5000]
+  python scripts/live_tutor_smoke.py --skip-turn [--base-url http://127.0.0.1:5000]
 """
 
 from __future__ import annotations
@@ -107,7 +108,7 @@ def _group_objectives_by_study_unit(
     return list(grouped.items())
 
 
-def _build_preflight_payload(
+def _build_workspace_context_payload(
     *,
     course_id: int,
     study_unit: str,
@@ -118,6 +119,7 @@ def _build_preflight_payload(
         "course_id": course_id,
         "study_unit": study_unit,
         "topic": study_unit,
+        "module_name": study_unit,
         "objective_scope": "module_all",
         "learning_objectives": [
             {
@@ -135,14 +137,12 @@ def _build_preflight_payload(
     }
 
 
-def select_preflight_ready_scope(
+def select_workspace_context_ready_scope(
     *,
     session: requests.Session,
     base_url: str,
     course_candidates: list[dict],
 ) -> dict:
-    last_failure: str | None = None
-
     for course in course_candidates:
         course_id = course.get("id")
         if not course_id:
@@ -175,61 +175,34 @@ def select_preflight_ready_scope(
             continue
 
         for study_unit, unit_objectives in grouped_units:
-            payload = _build_preflight_payload(
+            payload = _build_workspace_context_payload(
                 course_id=int(course_id),
                 study_unit=study_unit,
                 objectives=unit_objectives,
                 selected_material_ids=selected_material_ids,
             )
-            resp = session.post(
-                f"{base_url}/api/tutor/session/preflight",
-                json=payload,
-                timeout=30,
-            )
-            if resp.status_code >= 400:
-                try:
-                    error_payload = resp.json()
-                except Exception:
-                    error_payload = resp.text
-                last_failure = (
-                    f"course={course.get('name') or course_id}, "
-                    f"study_unit={study_unit}, "
-                    f"error={error_payload}"
-                )
-                continue
-
-            preflight = resp.json()
-            if preflight.get("ok"):
-                grouped_objectives = [
-                    objective
-                    for _, grouped_objectives in grouped_units
-                    for objective in grouped_objectives
-                ]
-                return {
-                    "course": course,
-                    "materials": materials,
-                    "learning_objectives": learning_objectives,
-                    "grouped_objectives": grouped_objectives,
-                    "study_unit": study_unit,
-                    "unit_objectives": unit_objectives,
-                    "selected_material_ids": selected_material_ids,
-                    "preflight_payload": payload,
-                    "preflight": preflight,
-                }
-
-            last_failure = (
-                f"course={course.get('name') or course_id}, "
-                f"study_unit={study_unit}, "
-                f"preflight={preflight}"
-            )
+            grouped_objectives = [
+                objective
+                for _, grouped_objectives in grouped_units
+                for objective in grouped_objectives
+            ]
+            return {
+                "course": course,
+                "materials": materials,
+                "learning_objectives": learning_objectives,
+                "grouped_objectives": grouped_objectives,
+                "study_unit": study_unit,
+                "unit_objectives": unit_objectives,
+                "selected_material_ids": selected_material_ids,
+                "workspace_context_payload": payload,
+            }
 
     raise RuntimeError(
-        "No course has a preflight-ready study unit."
-        + (f" Last failure: {last_failure}" if last_failure else "")
+        "No course has a material-backed study unit ready for Workspace Context."
     )
 
 
-def smoke(base_url: str) -> None:
+def smoke(base_url: str, *, skip_turn: bool = False) -> None:
     session = requests.Session()
     failures: list[str] = []
     created_session_id: str | None = None
@@ -269,7 +242,7 @@ def smoke(base_url: str) -> None:
 
     course_candidates = courses.get("courses", []) if isinstance(courses, dict) else courses
     try:
-        selected_scope = select_preflight_ready_scope(
+        selected_scope = select_workspace_context_ready_scope(
             session=session,
             base_url=base_url,
             course_candidates=course_candidates,
@@ -285,7 +258,7 @@ def smoke(base_url: str) -> None:
     study_unit = selected_scope["study_unit"]
     unit_objectives = selected_scope["unit_objectives"]
     selected_material_ids = selected_scope["selected_material_ids"]
-    preflight_payload = selected_scope["preflight_payload"]
+    workspace_context_payload = selected_scope["workspace_context_payload"]
     course_id = selected_course.get("id")
     course_name = selected_course.get("name") or "Unknown Course"
     print(
@@ -295,22 +268,24 @@ def smoke(base_url: str) -> None:
     print("  [Tutor: list materials] OK")
     print("  [Tutor: list objectives] OK")
 
-    preflight = step(
-        "Tutor: preflight",
-        lambda: selected_scope["preflight"],
-    )
-    if not preflight or not preflight.get("ok"):
-        print("FATAL: Tutor preflight did not return ok=true.")
-        if preflight:
-            print(json.dumps(preflight, indent=2))
-        sys.exit(1)
+    print("  [Tutor: Workspace Context] OK")
 
     created = step(
         "Tutor: create session",
         lambda: (
             resp := session.post(
                 f"{base_url}/api/tutor/session",
-                json={"preflight_id": preflight["preflight_id"], "mode": "Core"},
+                json={
+                    **workspace_context_payload,
+                    "mode": "Core",
+                    "phase": "first_pass",
+                    "packet_context": (
+                        "Workspace Context smoke packet\n"
+                        f"- Course: {course_name}\n"
+                        f"- Study unit: {study_unit}\n"
+                        f"- Materials: {selected_material_ids}"
+                    ),
+                },
                 timeout=30,
             ),
             resp.raise_for_status(),
@@ -322,24 +297,27 @@ def smoke(base_url: str) -> None:
         sys.exit(1)
     created_session_id = created["session_id"]
 
-    turn_body = step(
-        "Tutor: send turn",
-        lambda: _run_turn(session, base_url, created_session_id),
-    )
-    if not turn_body:
-        print("FATAL: Tutor turn failed before response body was returned.")
-        sys.exit(1)
+    if skip_turn:
+        print("  [Tutor: send turn] SKIP - --skip-turn avoids external LLM calls")
+    else:
+        turn_body = step(
+            "Tutor: send turn",
+            lambda: _run_turn(session, base_url, created_session_id),
+        )
+        if not turn_body:
+            print("FATAL: Tutor turn failed before response body was returned.")
+            sys.exit(1)
 
-    turn_error = _extract_error_payload(turn_body)
-    if turn_error:
-        print("FATAL: Tutor turn returned an SSE error payload.")
-        print(json.dumps(turn_error, indent=2))
-        sys.exit(1)
+        turn_error = _extract_error_payload(turn_body)
+        if turn_error:
+            print("FATAL: Tutor turn returned an SSE error payload.")
+            print(json.dumps(turn_error, indent=2))
+            sys.exit(1)
 
-    turn_done = _extract_done_payload(turn_body)
-    if not turn_done:
-        print("FATAL: Tutor turn did not emit a done payload.")
-        sys.exit(1)
+        turn_done = _extract_done_payload(turn_body)
+        if not turn_done:
+            print("FATAL: Tutor turn did not emit a done payload.")
+            sys.exit(1)
 
     restored = step(
         "Tutor: restore session",
@@ -413,8 +391,13 @@ def main() -> None:
         default=os.environ.get("SMOKE_BASE_URL", DEFAULT_BASE),
         help=f"Dashboard base URL (default: {DEFAULT_BASE})",
     )
+    parser.add_argument(
+        "--skip-turn",
+        action="store_true",
+        help="Create/restore/end/delete a Tutor session without sending an LLM-backed turn.",
+    )
     args = parser.parse_args()
-    smoke(args.base_url)
+    smoke(args.base_url, skip_turn=args.skip_turn)
 
 
 if __name__ == "__main__":

--- a/scripts/start_dashboard_macos.sh
+++ b/scripts/start_dashboard_macos.sh
@@ -28,7 +28,10 @@ if [ -n "${OBSIDIAN_VAULT_FS_PATH:-}" ] && [ -z "${PT_OBSIDIAN_VAULT_PATH:-}" ];
 fi
 
 if [ -z "${PT_STUDY_RAG_DIR:-}" ]; then
-  if [ -d "$HOME/Desktop/PT School" ]; then
+  ONEDRIVE_PT_SCHOOL="$HOME/Library/CloudStorage/OneDrive-Personal/Desktop/PT School"
+  if [ -d "$ONEDRIVE_PT_SCHOOL" ]; then
+    export PT_STUDY_RAG_DIR="$ONEDRIVE_PT_SCHOOL"
+  elif [ -d "$HOME/Desktop/PT School" ]; then
     export PT_STUDY_RAG_DIR="$HOME/Desktop/PT School"
   elif [ -d "$ROOT_DIR/PT School" ]; then
     export PT_STUDY_RAG_DIR="$ROOT_DIR/PT School"


### PR DESCRIPTION
## Summary
- Connects Tutor workspace context through material scope, Priming, Tutor, and Obsidian handoff paths.
- Redesigns /library around course-first PT material loading and readability.
- Adds responsive containment for the Library/app shell so mid-size desktop widths stay stacked/readable instead of forcing the wide intake split too early.
- Adds study-loop gap review plus focused frontend/backend coverage.

## Fresh validation from this thread
- npm run build
- npm run test -- client/src/pages/__tests__/library.test.tsx client/src/components/__tests__/layout.test.tsx
- Dashboard health: http://127.0.0.1:5127/api/brain/status returned ok=true
- Browser QA on /library: page loaded with real content, console errors/warnings were clean, Professionalism course filter changed the visible file count, and mobile viewport rendered the Library flow.

## Note
- The in-app Browser desktop screenshot still shows a right-edge mirrored strip even though the DOM exposes only one course rail and the interaction target count is one. Mobile is clean. Treat as a visual follow-up if it reproduces in the user-facing browser.